### PR TITLE
set minio to not be installed by default

### DIFF
--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -29,7 +29,7 @@ useStaticCredentials: true
 # If set to true then chart installs minio and generate according artifactRepository section in workflow controller config map
 minio:
   # This is not used by the subchart, but makes sense to group here.
-  install: true
+  install: false
   defaultBucket:
     enabled: true
     name: argo-artifacts


### PR DESCRIPTION
I've found that helm has issues with conditional sub charts of a sub chart so I think it'd be better to have minio not be installed as part of the chart by default so if you want to leverage this chart as part of another chart you don't have to worry about unintended resources getting created on cluster.