### PR TITLE
Fix typo in ui-crb.yaml

### DIFF
--- a/charts/argo/templates/ui-crb.yaml
+++ b/charts/argo/templates/ui-crb.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.ui.serviceAccount }}
-  namespace: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This was binding roles to the service account in the `.Release.Name` instead of `.Release.Namespace` namespace