### PR TITLE
Add archiveLogs option to Argo workflow controller config map

### DIFF
--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -17,6 +17,9 @@ data:
     {{- end }}
     artifactRepository:
       {{- if or .Values.minio.install .Values.useDefaultArtifactRepo }}
+      {{- if .Values.artifactRepository.archiveLogs }}
+      archiveLogs: {{ .Values.artifactRepository.archiveLogs }}
+      {{- end }}
       s3:
         {{- if .Values.useStaticCredentials }}
         accessKeySecret:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -72,7 +72,7 @@ useDefaultArtifactRepo: false
 useStaticCredentials: true
 artifactRepository:
   # archiveLogs will archive the main container logs as an artifact
-  archiveLogs: true
+  archiveLogs: false
   s3:
     # Note the `key` attribute is not the actual secret, it's the PATH to
     # the contents in the associated secret, as defined by the `name` attribute.

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -71,6 +71,8 @@ ui:
 useDefaultArtifactRepo: false
 useStaticCredentials: true
 artifactRepository:
+  # archiveLogs will archive the main container logs as an artifact
+  archiveLogs: true
   s3:
     # Note the `key` attribute is not the actual secret, it's the PATH to
     # the contents in the associated secret, as defined by the `name` attribute.


### PR DESCRIPTION
Adds the option to persist workflow logs to default `artifactRepository`