### PR TITLE
Helm chart for ArgoCD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 output
 .vscode
+.DS_Store

--- a/charts/argo-cd/.helmignore
+++ b/charts/argo-cd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.11"
+description: A Helm chart for Argo-CD
+name: argo-cd
+version: 0.1.0

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -1,0 +1,13 @@
+In order to access the server UI you have the following options:
+
+1. kubectl port-forward svc/argocd-server -n argocd 8080:443
+
+    and then open the browser on http://localhost:8080 and accept the certificate
+
+2. enable ingress and check the first option ssl passthrough:
+    https://github.com/argoproj/argo-cd/blob/master/docs/ingress.md#option-1-ssl-passthrough
+
+After reaching the UI the first time you can login with username: admin and the password will be the
+name of the server pod. You can get the pod name by running:
+
+kubectl get pods -n argocd -l app.kubernetes.io/name={{ include "argo-cd.name" . }}-server -o name | cut -d'/' -f 2

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argo-cd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "argo-cd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argo-cd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller-clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-application-controller-clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.clusterAdminAccess.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+{{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.clusterAdminAccess.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  namespace: {{ .Release.Namespace }}
+{{- end -}} }}

--- a/charts/argo-cd/templates/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-clusterrolebinding.yaml
@@ -18,4 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: argocd-application-controller
   namespace: {{ .Release.Namespace }}
-{{- end -}} }}
+{{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}
@@ -13,9 +13,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   namespace: {{ .Release.Namespace }}
 {{- end -}} }}

--- a/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: {{ include "argo-cd.fullname" . }}-application-controller
   labels:
-    app: {{ include "argo-cd.name" . }}-application-controller
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -13,12 +12,10 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ include "argo-cd.name" . }}-application-controller
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
   template:
     metadata:
       labels:
-        app: {{ include "argo-cd.name" . }}-application-controller
         app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "argo-cd.name" . }}-application-controller
+  template:
+    metadata:
+      labels:
+        app: {{ include "argo-cd.name" . }}-application-controller
+        app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+        helm.sh/chart: {{ include "argo-cd.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/component: application-controller
+    spec:
+      containers:
+      - command:
+        - argocd-application-controller
+        - --status-processors
+        - "20"
+        - --operation-processors
+        - "10"
+        image: {{ .Values.applicationController.image.repository }}:{{ .Values.applicationController.image.tag }}
+        imagePullPolicy: {{ .Values.applicationController.image.pullPolicy }}
+        name: {{ include "argo-cd.name" . }}-application-controller
+        ports:
+        - containerPort: {{ .Values.applicationController.containerPort }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.applicationController.containerPort }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      serviceAccountName: {{ include "argo-cd.name" . }}-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
@@ -2,10 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app: {{ include "argo-cd.name" . }}-application-controller
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller
 spec:
   selector:
     matchLabels:
       app: {{ include "argo-cd.name" . }}-application-controller
+      app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
   template:
     metadata:
       labels:

--- a/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}
@@ -32,7 +32,7 @@ spec:
         - "10"
         image: {{ .Values.applicationController.image.repository }}:{{ .Values.applicationController.image.tag }}
         imagePullPolicy: {{ .Values.applicationController.image.pullPolicy }}
-        name: {{ include "argo-cd.name" . }}-application-controller
+        name: argocd-application-controller
         ports:
         - containerPort: {{ .Values.applicationController.containerPort }}
         readinessProbe:
@@ -40,4 +40,4 @@ spec:
             port: {{ .Values.applicationController.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 10
-      serviceAccountName: {{ include "argo-cd.name" . }}-application-controller
+      serviceAccountName: argocd-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-application-controller-role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - list
+  

--- a/charts/argo-cd/templates/argocd-application-controller-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argo-cd.fullname" . }}-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-sa.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-sa.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-application-controller-service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-service.yaml
@@ -14,5 +14,4 @@ spec:
   - port: {{ .Values.applicationController.servicePort }}
     targetPort: {{ .Values.applicationController.containerPort }}
   selector:
-    app: {{ include "argo-cd.name" . }}-application-controller
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-application-controller
+  name: argocd-application-controller
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-application-controller-service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: {{ .Values.applicationController.containerPort }}
   selector:
     app: {{ include "argo-cd.name" . }}-application-controller
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller-service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-application-controller
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-application-controller
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: application-controller
+spec:
+  ports:
+  - port: {{ .Values.applicationController.servicePort }}
+    targetPort: {{ .Values.applicationController.containerPort }}
+  selector:
+    app: {{ include "argo-cd.name" . }}-application-controller

--- a/charts/argo-cd/templates/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-cm.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-cm
+  labels: 
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+data:
+{{- if .Values.config.helmRepositories }}
+  helm.repositories: |
+{{ toYaml .Values.config.helmRepositories | indent 4 }}
+{{- end }}
+{{- if .Values.config.repositories }}
+  repositories: |
+{{ toYaml .Values.config.repositories | indent 4 }}
+{{- end }}
+{{- if .Values.config.dexConfig }}
+  dex.config: |
+{{ toYaml .Values.config.dexConfig | indent 4 }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-cm
+  name: argocd-cm
   labels: 
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-cm.yaml
@@ -3,13 +3,11 @@ kind: ConfigMap
 metadata:
   name: {{ include "argo-cd.fullname" . }}-cm
   labels: 
-    app: {{ include "argo-cd.name" . }}-server
-    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
-    app.kubernetes.io/component: server
 data:
 {{- if .Values.config.helmRepositories }}
   helm.repositories: |

--- a/charts/argo-cd/templates/argocd-dex-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-dex-server-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: dex-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+        helm.sh/chart: {{ include "argo-cd.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/component: dex-server
+    spec:
+      serviceAccountName: argocd-dex-server
+      initContainers:
+      - name: copyutil
+        image: {{ .Values.dexServer.initImage.repository }}:{{ .Values.dexServer.initImage.tag }}
+        imagePullPolicy: {{ .Values.dexServer.initImage.pullPolicy }}
+        command: [cp, /usr/local/bin/argocd-util, /shared]
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      containers:
+      - name: dex
+        image: {{ .Values.dexServer.image.repository }}:{{ .Values.dexServer.image.tag }}
+        imagePullPolicy: {{ .Values.dexServer.image.pullPolicy }}
+        command: [/shared/argocd-util, rundex]
+        ports:
+        - containerPort: {{ .Values.dexServer.containerPortHttp }}
+        - containerPort: {{ .Values.dexServer.containerPortGrpc }}
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      volumes:
+      - emptyDir: {}
+        name: static-files

--- a/charts/argo-cd/templates/argocd-dex-server-role.yaml
+++ b/charts/argo-cd/templates/argocd-dex-server-role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: dex-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/argo-cd/templates/argocd-dex-server-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-dex-server-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: dex-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-dex-server
+subjects:
+- kind: ServiceAccount
+  name: argocd-dex-server

--- a/charts/argo-cd/templates/argocd-dex-server-sa.yaml
+++ b/charts/argo-cd/templates/argocd-dex-server-sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: dex-server

--- a/charts/argo-cd/templates/argocd-dex-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-dex-server-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-dex-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: dex-server  
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.dexServer.servicePortHttp }}
+    targetPort: {{ .Values.dexServer.containerPortHttp }}
+  - name: grpc
+    protocol: TCP
+    port: {{ .Values.dexServer.servicePortGrpc }}
+    targetPort: {{ .Values.dexServer.containerPortGrpc }}
+  selector:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-dex-server

--- a/charts/argo-cd/templates/argocd-metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-metrics-service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
     app.kubernetes.io/component: server
-  name: {{ include "argo-cd.fullname" . }}-metrics
+  name: argocd-metrics
 spec:
   ports:
   - name: http

--- a/charts/argo-cd/templates/argocd-metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-metrics-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ include "argo-cd.name" . }}-metrics
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-metrics
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+  name: {{ include "argo-cd.fullname" . }}-metrics
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.server.serviceMetricsPort }}
+    targetPort: {{ .Values.server.containerMetricsPort }}
+  selector:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server

--- a/charts/argo-cd/templates/argocd-metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-metrics-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ include "argo-cd.name" . }}-metrics
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-metrics
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-rbac-cm.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-rbac-cm
+data:
+{{- if .Values.rbac.policy-default }}
+  policy.default: {{ .Values.rbac.policy-default }}
+{{- end }}
+{{- if .Values.rbac.policy-csv }}
+  policy.csv: |
+{{ toYaml .Values.rbac.policy-csv | indent 4 }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-rbac-cm.yaml
@@ -9,10 +9,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
 data:
-{{- if .Values.rbac.policy-default }}
-  policy.default: {{ .Values.rbac.policy-default }}
+{{- if .Values.rbac.policyDefault }}
+  policy.default: {{ .Values.rbac.policyDefault }}
 {{- end }}
-{{- if .Values.rbac.policy-csv }}
+{{- if .Values.rbac.policyCsv }}
   policy.csv: |
-{{ toYaml .Values.rbac.policy-csv | indent 4 }}
+{{ toYaml .Values.rbac.policyCsv | indent 4 }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-rbac-cm.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "argo-cd.fullname" . }}-rbac-cm
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
 data:
 {{- if .Values.rbac.policy-default }}
   policy.default: {{ .Values.rbac.policy-default }}

--- a/charts/argo-cd/templates/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-rbac-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-rbac-cm
+  name: argocd-rbac-cm
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
@@ -13,6 +13,6 @@ data:
   policy.default: {{ .Values.rbac.policyDefault }}
 {{- end }}
 {{- if .Values.rbac.policyCsv }}
-  policy.csv: |
-{{ toYaml .Values.rbac.policyCsv | indent 4 }}
+  policy.csv:
+{{- toYaml .Values.rbac.policyCsv | indent 4 }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-repo-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-repo-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: repo-server
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "argo-cd.name" . }}-repo-server
+      app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
+  template:
+    metadata:
+      labels:
+        app: {{ include "argo-cd.name" . }}-repo-server
+        app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
+        helm.sh/chart: {{ include "argo-cd.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/component: repo-server
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: argocd-repo-server
+        image: {{ .Values.repoServer.image.repository }}:{{ .Values.repoServer.image.tag }}
+        imagePullPolicy: {{ .Values.repoServer.image.pullPolicy}}
+        command: [argocd-repo-server]
+        ports:
+        - containerPort: {{ .Values.repoServer.containerPort }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.repoServer.containerPort }}
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-repo-server
+  name: argocd-repo-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: {{ include "argo-cd.fullname" . }}-repo-server
   labels:
-    app: {{ include "argo-cd.name" . }}-repo-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -13,12 +12,10 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ include "argo-cd.name" . }}-repo-server
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
   template:
     metadata:
       labels:
-        app: {{ include "argo-cd.name" . }}-repo-server
         app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-repo-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-repo-server
+  name: argocd-repo-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-repo-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-repo-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-repo-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: repo-server
+spec:
+  ports:
+  - port: {{ .Values.repoServer.servicePort }}
+    targetPort: {{ .Values.repoServer.servicePort }}
+  selector:
+    app: {{ include "argo-cd.name" . }}-repo-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server

--- a/charts/argo-cd/templates/argocd-repo-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   name: {{ include "argo-cd.fullname" . }}-repo-server
   labels:
-    app: {{ include "argo-cd.name" . }}-repo-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -15,5 +14,4 @@ spec:
   - port: {{ .Values.repoServer.servicePort }}
     targetPort: {{ .Values.repoServer.servicePort }}
   selector:
-    app: {{ include "argo-cd.name" . }}-repo-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-repo-server

--- a/charts/argo-cd/templates/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-secret
+  name: argocd-secret
   labels: 
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-secret
+  labels: 
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+type: Opaque
+data:  
+{{- if .Values.config.webhook.githubSecret }}
+  github.webhook.secret: {{ .Values.config.webhook.githubSecret }}
+{{- end }}
+{{- if .Values.config.webhook.gitlabSecret }}
+  gitlab.webhook.secret: {{ .Values.config.webhook.gitlabSecret }}
+{{- end }}
+{{- if .Values.config.webhook.bitbucketSecret }}
+  bitbucket.webhook.uuid: {{ .Values.config.webhook.bitbucketSecret }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-secret.yaml
@@ -3,13 +3,11 @@ kind: Secret
 metadata:
   name: {{ include "argo-cd.fullname" . }}-secret
   labels: 
-    app: {{ include "argo-cd.name" . }}-server
-    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
-    app.kubernetes.io/component: server
 type: Opaque
 data:  
 {{- if .Values.config.webhook.githubSecret }}

--- a/charts/argo-cd/templates/argocd-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "argo-cd.name" . }}-server
+      app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+  template:
+    metadata:
+      labels:
+        app: {{ include "argo-cd.name" . }}-server
+        app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+        helm.sh/chart: {{ include "argo-cd.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/component: server
+    spec:
+      serviceAccountName: {{ include "argo-cd.fullname" . }}-server
+      initContainers:
+      - name: ui
+        image: {{ .Values.server.uiInitImage.repository }}:{{ .Values.server.uiInitImage.tag }}
+        imagePullPolicy: {{ .Values.server.uiInitImage.pullPolicy }}
+        command: [cp, -r, /app, /shared]
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+      containers:
+      - name: argocd-server
+        image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}
+        imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+        command: [argocd-server, --staticassets, /shared/app]
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+        ports:
+        - containerPort: {{ .Values.server.containerPort }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.server.containerPort }}
+          initialDelaySeconds: 3
+          periodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: static-files

--- a/charts/argo-cd/templates/argocd-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server-deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: {{ include "argo-cd.fullname" . }}-server
   labels:
-    app: {{ include "argo-cd.name" . }}-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -13,12 +12,10 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ include "argo-cd.name" . }}-server
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
   template:
     metadata:
       labels:
-        app: {{ include "argo-cd.name" . }}-server
         app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
         app.kubernetes.io/component: server
     spec:
-      serviceAccountName: {{ include "argo-cd.fullname" . }}-server
+      serviceAccountName: argocd-server
       initContainers:
       - name: ui
         image: {{ .Values.server.uiInitImage.repository }}:{{ .Values.server.uiInitImage.tag }}

--- a/charts/argo-cd/templates/argocd-server-ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server-ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $servicePortHttps := .Values.server.servicePortHttps -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: argocd-server
+  labels: 
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: argocd-server
+              servicePort: {{ $servicePortHttps }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server-role.yaml
+++ b/charts/argo-cd/templates/argocd-server-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-server-role.yaml
+++ b/charts/argo-cd/templates/argocd-server-role.yaml
@@ -3,7 +3,6 @@ kind: Role
 metadata:
   name: {{ include "argo-cd.fullname" . }}-server
   labels:
-    app: {{ include "argo-cd.name" . }}-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-server-role.yaml
+++ b/charts/argo-cd/templates/argocd-server-role.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - list

--- a/charts/argo-cd/templates/argocd-server-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server-rolebinding.yaml
@@ -3,7 +3,6 @@ kind: RoleBinding
 metadata:
   name: {{ include "argo-cd.fullname" . }}-server
   labels:
-    app: {{ include "argo-cd.name" . }}-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-server-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "argo-cd.fullname" . }}-server
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argo-cd.fullname" . }}-server

--- a/charts/argo-cd/templates/argocd-server-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server-rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
@@ -13,7 +13,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server

--- a/charts/argo-cd/templates/argocd-server-sa.yaml
+++ b/charts/argo-cd/templates/argocd-server-sa.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   name: {{ include "argo-cd.fullname" . }}-server
   labels:
-    app: {{ include "argo-cd.name" . }}-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/argocd-server-sa.yaml
+++ b/charts/argo-cd/templates/argocd-server-sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-server-sa.yaml
+++ b/charts/argo-cd/templates/argocd-server-sa.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server

--- a/charts/argo-cd/templates/argocd-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-server-service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   name: {{ include "argo-cd.fullname" . }}-server
   labels:
-    app: {{ include "argo-cd.name" . }}-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -21,6 +20,5 @@ spec:
     port: {{ .Values.repoServer.servicePortHttps }}
     targetPort: {{ .Values.repoServer.containerPort }}
   selector:
-    app: {{ include "argo-cd.name" . }}-server
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
 

--- a/charts/argo-cd/templates/argocd-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-server-service.yaml
@@ -13,12 +13,12 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: {{ .Values.repoServer.servicePortHttp }}
-    targetPort: {{ .Values.repoServer.containerPort }}
+    port: {{ .Values.server.servicePortHttp }}
+    targetPort: {{ .Values.server.containerPort }}
   - name: https
     protocol: TCP
-    port: {{ .Values.repoServer.servicePortHttps }}
-    targetPort: {{ .Values.repoServer.containerPort }}
+    port: {{ .Values.server.servicePortHttps }}
+    targetPort: {{ .Values.server.containerPort }}
   selector:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
 

--- a/charts/argo-cd/templates/argocd-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-server-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.fullname" . }}-server
+  name: argocd-server
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-server-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argo-cd.fullname" . }}-server
+  labels:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.repoServer.servicePortHttp }}
+    targetPort: {{ .Values.repoServer.containerPort }}
+  - name: https
+    protocol: TCP
+    port: {{ .Values.repoServer.servicePortHttps }}
+    targetPort: {{ .Values.repoServer.containerPort }}
+  selector:
+    app: {{ include "argo-cd.name" . }}-server
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+

--- a/charts/argo-cd/templates/crds/application-crd.yaml
+++ b/charts/argo-cd/templates/crds/application-crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+  name: applications.argoproj.io
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: argoproj.io
+  names:
+    kind: Application
+    plural: applications
+    shortNames:
+    - app
+    - apps
+  scope: Namespaced
+  version: v1alpha1

--- a/charts/argo-cd/templates/crds/appproject-crd.yaml
+++ b/charts/argo-cd/templates/crds/appproject-crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+  name: appprojects.argoproj.io
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: argoproj.io
+  names:
+    kind: AppProject
+    plural: appprojects
+    shortNames:
+    - appproj
+    - appprojs
+  scope: Namespaced
+  version: v1alpha1

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -21,7 +21,8 @@ server:
     pullPolicy: Always
     
 repoServer:
-  port: 8081
+  containerPort: 8081
+  servicePort: 8081
   image:
     repository: argoproj/argocd
     tag: v0.11.0

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -8,7 +8,8 @@ applicationController:
 
 server:
   containerPort: 8080
-  servicePort: 8080
+  servicePortHttp: 80
+  servicePortHttps: 443
   containerMetricsPort: 8082
   metricsPort: 8082
   image:
@@ -66,7 +67,25 @@ config:
             orgs:
             - name: your-github-org
               teams:
+rbac:
+#   # An RBAC policy .csv file containing additional policy and role definitions.
+#   # See https://github.com/argoproj/argo-cd/blob/master/docs/rbac.md on how to write RBAC policies.
+#   policy.csv: |
+#     # Give all members of "my-org:team-alpha" the ability to sync apps in "my-project"
+#     p, my-org:team-alpha, applications, sync, my-project/*, allow
+#     # Make all members of "my-org:team-beta" admins
+#     g, my-org:team-beta, role:admin
+  policy-csv: |
+    p, role:org-admin, applications, *, */*, allow
+    p, role:org-admin, clusters, get, *, allow
+    p, role:org-admin, repositories, get, *, allow
+    p, role:org-admin, repositories, create, *, allow
+    p, role:org-admin, repositories, update, *, allow
+    p, role:org-admin, repositories, delete, *, allow
 
+    g, your-github-org:your-team, role:org-admin
+  # The default role Argo CD will fall back to, when authorizing API requests
+  policy-default: role:readonly
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -67,6 +67,14 @@ config:
             orgs:
             - name: your-github-org
               teams:
+  # The following keys hold the shared secret for authenticating GitHub/GitLab/BitBucket webhook
+  # events. To enable webhooks, configure one or more of the following keys with the shared git
+  # provider webhook secret. The payload URL configured in the git provider should use the
+  # /api/webhook endpoint of your Argo CD instance (e.g. https://argocd.example.com/api/webhook)
+    # webhook:
+    #   githubSecret: 
+    #   gitlabSecret:
+    #   bitbucketSecret:
 rbac:
 #   # An RBAC policy .csv file containing additional policy and role definitions.
 #   # See https://github.com/argoproj/argo-cd/blob/master/docs/rbac.md on how to write RBAC policies.

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1,0 +1,40 @@
+applicationController:
+  containerPort: 8083
+  servicePort: 8083
+  image:
+    repository: argoproj/argocd
+    tag: v0.11.0
+    pullPolicy: Always
+
+server:
+  containerPort: 8080
+  servicePort: 8080
+  containerMetricsPort: 8082
+  metricsPort: 8082
+  image:
+    repository: argoproj/argocd
+    tag: v0.11.0
+    pullPolicy: Always
+  uiInitImage:
+    repository: argoproj/argocd-ui
+    tag: v0.11.0
+    pullPolicy: Always
+    
+repoServer:
+  port: 8081
+  image:
+    repository: argoproj/argocd
+    tag: v0.11.0
+    pullPolicy: Always
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -11,7 +11,7 @@ server:
   servicePortHttp: 80
   servicePortHttps: 443
   containerMetricsPort: 8082
-  metricsPort: 8082
+  serviceMetricsPort: 8082
   image:
     repository: argoproj/argocd
     tag: v0.11.0
@@ -50,31 +50,31 @@ config:
       sshPrivateKeySecret:
         key: privateKey
         name: argocd-dev-key
-    dexConfig:
+  dexConfig:
     #   # Argo CD's externally facing base URL. Required for configuring SSO
     #   # url: https://argo-cd-demo.argoproj.io
     #
     #   # A dex connector configuration. See documentation on how to configure SSO:
     #   # https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso
-      connectors:
-        # GitHub example
-        - type: github
-          id: github
-          name: GitHub
-          config:
-            clientID: aabbccddeeff00112233
-            clientSecret: $dex.github.clientSecret
-            orgs:
-            - name: your-github-org
-              teams:
+    connectors:
+      # GitHub example
+      - type: github
+        id: github
+        name: GitHub
+        config:
+          clientID: aabbccddeeff00112233
+          clientSecret: $dex.github.clientSecret
+          orgs:
+          - name: your-github-org
+            teams:
   # The following keys hold the shared secret for authenticating GitHub/GitLab/BitBucket webhook
   # events. To enable webhooks, configure one or more of the following keys with the shared git
   # provider webhook secret. The payload URL configured in the git provider should use the
   # /api/webhook endpoint of your Argo CD instance (e.g. https://argocd.example.com/api/webhook)
-    # webhook:
-    #   githubSecret: 
-    #   gitlabSecret:
-    #   bitbucketSecret:
+  webhook:
+    githubSecret: 
+    gitlabSecret:
+    bitbucketSecret:
 rbac:
 #   # An RBAC policy .csv file containing additional policy and role definitions.
 #   # See https://github.com/argoproj/argo-cd/blob/master/docs/rbac.md on how to write RBAC policies.
@@ -83,17 +83,16 @@ rbac:
 #     p, my-org:team-alpha, applications, sync, my-project/*, allow
 #     # Make all members of "my-org:team-beta" admins
 #     g, my-org:team-beta, role:admin
-  policy-csv: |
+  policyCsv: |
     p, role:org-admin, applications, *, */*, allow
     p, role:org-admin, clusters, get, *, allow
     p, role:org-admin, repositories, get, *, allow
     p, role:org-admin, repositories, create, *, allow
     p, role:org-admin, repositories, update, *, allow
     p, role:org-admin, repositories, delete, *, allow
-
     g, your-github-org:your-team, role:org-admin
   # The default role Argo CD will fall back to, when authorizing API requests
-  policy-default: role:readonly
+  policyDefault: role:readonly
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -28,6 +28,45 @@ repoServer:
     tag: v0.11.0
     pullPolicy: Always
 
+config:
+  helmRepositories:
+    - name: privateRepo
+      url: http://chartmuseum.privatecloud.com
+      usernameSecret:
+        name: private-chartmuseum
+        key: username
+      passwordSecret:
+        name: private-chartmuseum
+        key: password
+    - name: incubator
+      url: https://kubernetes-charts-incubator.storage.googleapis.com/
+  repositories:
+    - url: git@gitlab.com:usersprivategroup/users-gitops-config.git
+      sshPrivateKeySecret:
+        key: privateKey
+        name: argocd-dev-key
+    - url: git@gitlab.com:accountingprivategroup/accounting-gitops-config.git
+      sshPrivateKeySecret:
+        key: privateKey
+        name: argocd-dev-key
+    dexConfig:
+    #   # Argo CD's externally facing base URL. Required for configuring SSO
+    #   # url: https://argo-cd-demo.argoproj.io
+    #
+    #   # A dex connector configuration. See documentation on how to configure SSO:
+    #   # https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso
+      connectors:
+        # GitHub example
+        - type: github
+          id: github
+          name: GitHub
+          config:
+            clientID: aabbccddeeff00112233
+            clientSecret: $dex.github.clientSecret
+            orgs:
+            - name: your-github-org
+              teams:
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -29,6 +29,20 @@ repoServer:
     tag: v0.11.0
     pullPolicy: Always
 
+dexServer:
+  containerPortHttp: 5556
+  containerPortGrpc: 5557
+  servicePortHttp: 5556
+  servicePortGrpc: 5557
+  image:
+    repository: quay.io/dexidp/dex
+    tag: v2.12.0
+    pullPolicy: Always
+  initImage:
+    repository: argoproj/argocd
+    tag: v0.11.0
+    pullPolicy: Always
+
 # Standard Argo CD installation with cluster-admin access. 
 # Set this true if you plan to use Argo CD to deploy applications in the same cluster that 
 #     Argo CD runs in (i.e. kubernetes.svc.default). 
@@ -39,42 +53,42 @@ clusterAdminAccess:
 
 config:
   helmRepositories:
-    - name: privateRepo
-      url: http://chartmuseum.privatecloud.com
-      usernameSecret:
-        name: private-chartmuseum
-        key: username
-      passwordSecret:
-        name: private-chartmuseum
-        key: password
-    - name: incubator
-      url: https://kubernetes-charts-incubator.storage.googleapis.com/
+    # - name: privateRepo
+    #   url: http://chartmuseum.privatecloud.com
+    #   usernameSecret:
+    #     name: private-chartmuseum
+    #     key: username
+    #   passwordSecret:
+    #     name: private-chartmuseum
+    #     key: password
+    # - name: incubator
+    #   url: https://kubernetes-charts-incubator.storage.googleapis.com/
   repositories:
-    - url: git@gitlab.com:usersprivategroup/users-gitops-config.git
-      sshPrivateKeySecret:
-        key: privateKey
-        name: argocd-dev-key
-    - url: git@gitlab.com:accountingprivategroup/accounting-gitops-config.git
-      sshPrivateKeySecret:
-        key: privateKey
-        name: argocd-dev-key
+    # - url: git@gitlab.com:usersprivategroup/users-gitops-config.git
+    #   sshPrivateKeySecret:
+    #     key: privateKey
+    #     name: argocd-dev-key
+    # - url: git@gitlab.com:accountingprivategroup/accounting-gitops-config.git
+    #   sshPrivateKeySecret:
+    #     key: privateKey
+    #     name: argocd-dev-key
   dexConfig:
     #   # Argo CD's externally facing base URL. Required for configuring SSO
     #   # url: https://argo-cd-demo.argoproj.io
     #
     #   # A dex connector configuration. See documentation on how to configure SSO:
     #   # https://github.com/argoproj/argo-cd/blob/master/docs/sso.md#2-configure-argocd-for-sso
-    connectors:
-      # GitHub example
-      - type: github
-        id: github
-        name: GitHub
-        config:
-          clientID: aabbccddeeff00112233
-          clientSecret: $dex.github.clientSecret
-          orgs:
-          - name: your-github-org
-            teams:
+    # connectors:
+    #   # GitHub example
+    #   - type: github
+    #     id: github
+    #     name: GitHub
+    #     config:
+    #       clientID: aabbccddeeff00112233
+    #       clientSecret: $dex.github.clientSecret
+    #       orgs:
+    #       - name: your-github-org
+    #         teams:
   # The following keys hold the shared secret for authenticating GitHub/GitLab/BitBucket webhook
   # events. To enable webhooks, configure one or more of the following keys with the shared git
   # provider webhook secret. The payload URL configured in the git provider should use the
@@ -91,24 +105,13 @@ rbac:
 #     p, my-org:team-alpha, applications, sync, my-project/*, allow
 #     # Make all members of "my-org:team-beta" admins
 #     g, my-org:team-beta, role:admin
-  policyCsv: |
-    p, role:org-admin, applications, *, */*, allow
-    p, role:org-admin, clusters, get, *, allow
-    p, role:org-admin, repositories, get, *, allow
-    p, role:org-admin, repositories, create, *, allow
-    p, role:org-admin, repositories, update, *, allow
-    p, role:org-admin, repositories, delete, *, allow
-    g, your-github-org:your-team, role:org-admin
+  policyCsv: #|
+  #   p, role:org-admin, applications, *, */*, allow
+  #   p, role:org-admin, clusters, get, *, allow
+  #   p, role:org-admin, repositories, get, *, allow
+  #   p, role:org-admin, repositories, create, *, allow
+  #   p, role:org-admin, repositories, update, *, allow
+  #   p, role:org-admin, repositories, delete, *, allow
+  #   g, your-github-org:your-team, role:org-admin
   # The default role Argo CD will fall back to, when authorizing API requests
-  policyDefault: role:readonly
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  policyDefault: #role:readonly

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -29,6 +29,14 @@ repoServer:
     tag: v0.11.0
     pullPolicy: Always
 
+# Standard Argo CD installation with cluster-admin access. 
+# Set this true if you plan to use Argo CD to deploy applications in the same cluster that 
+#     Argo CD runs in (i.e. kubernetes.svc.default). 
+# Will still be able to deploy to external clusters with inputted credentials.
+
+clusterAdminAccess:
+  enabled: true
+
 config:
   helmRepositories:
     - name: privateRepo

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -43,6 +43,17 @@ dexServer:
     tag: v0.11.0
     pullPolicy: Always
 
+# terminate tls at ArgoCD level
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+  path: /
+  hosts:
+    - argocd.example.com
+
 # Standard Argo CD installation with cluster-admin access. 
 # Set this true if you plan to use Argo CD to deploy applications in the same cluster that 
 #     Argo CD runs in (i.e. kubernetes.svc.default). 


### PR DESCRIPTION
This will create a Helm chart for ArgoCD.
Compared to the existing manifests it adds:

- support for ingress with ssl passthrough (default is disabled)
- parameter to install on cluster level(default) or namespace level
- crds are created with helm crd-install hooks
- new labels recommended by https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
- parameterised the most important values: image repo, tags, pullPolicy and container and service ports

After installation with helm on minikube I made some tests the apps defined here: https://github.com/lcostea/argocd-helm-deployment

I didn't try to setup argocd with argocd (to update itself), it seems there will be some additional work here, at least on how the crd are installed (can't use the crd-install hook probably), but I think that should be a separate issue/PR. So this version is probably good enough to start playing with argocd on a cluster, but for production the kustomize version is still recommended, at least it can update itself.

