### PR TITLE
Make containerRuntimeExecutor configurable

### DIFF
--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -15,6 +15,7 @@ data:
     instanceID: {{ .Values.controller.instanceID.explicitID }}
     {{- end }}
     {{- end }}
+    containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
     artifactRepository:
       {{- if or .Values.minio.install .Values.useDefaultArtifactRepo }}
       s3:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -19,6 +19,7 @@ controller:
   name: workflow-controller
   workflowNamespaces:
     - default
+  containerRuntimeExecutor: docker
   instanceID:
     # `instanceID.enabled` configures the controller to filter workflow submissions
     # to only those which have a matching instanceID attribute.


### PR DESCRIPTION
I'd like to configure `containerRuntimeExecutor`. Would you consider merging this change?