### PR TITLE
Set namespace on service accounts and clusterrole

### DIFF
--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -9,7 +9,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: argo-events-sa
-    namespace: argo-events
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/argo-events/templates/argo-events-sa.yaml
+++ b/charts/argo-events/templates/argo-events-sa.yaml
@@ -4,4 +4,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-events-sa
-  namespace: argo-events
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
I found argo-events chart doesn't set namespace on service account and clusterrole correctly.