### PR TITLE
add a toggle to allow the controllers to listen on all namespaces

### DIFF
--- a/charts/argo-events/templates/gateway-controller-configmap.yaml
+++ b/charts/argo-events/templates/gateway-controller-configmap.yaml
@@ -9,4 +9,6 @@ metadata:
 data:
   config: |
     instanceID: {{ .Values.instanceID }}
+{{- if .Values.singleNamespace }}
     namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/argo-events/templates/sensor-controller-configmap.yaml
+++ b/charts/argo-events/templates/sensor-controller-configmap.yaml
@@ -9,4 +9,6 @@ metadata:
 data:
   config: |
     instanceID: {{ .Values.instanceID }}
+{{- if .Values.singleNamespace }}
     namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -9,7 +9,13 @@ serviceAccount: argo-events-sa
 
 instanceID: argo-events
 
+
+
+# set `singleNamespace` to false to have the controllers 
+# listen on all namespaces.  Otherwise the controllers will listen
+# on the namespace provided
 namespace: argo-events
+singleNamespace: true
 
 # sensor controller
 sensorController:


### PR DESCRIPTION
it's helpful to be able to control whether or not the controllers listen on all namespaces when we install them.
this adds a configurable option `singleNamespace` which is a boolean, and controls that behaviour
