### PR TITLE
add metricsConfig to the argo-workflow configmap

### DIFF
--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -30,3 +30,6 @@ data:
         endpoint: {{ .Values.artifactRepository.s3.endpoint | default (printf "%s-%s" .Release.Name "minio:9000") }}
         insecure: {{ .Values.artifactRepository.s3.insecure }}
       {{- end}}
+    {{- if .Values.controller.metricsConfig.enabled }}
+    metricsConfig:
+{{ toYaml .Values.controller.metricsConfig | indent 6}}{{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -15,6 +15,10 @@ init:
 controller:
   # podAnnotations is an optional map of annotations to be applied to the controller Pods
   podAnnotations: {}
+  metricsConfig:
+    enabled: false
+    path: /metrics
+    port: 8080
   serviceAccount: argo
   name: workflow-controller
   workflowNamespaces:


### PR DESCRIPTION
adds a configurable stanza for the workflow-controller-configmap.yaml

```
controller:
  metricsConfig:
    enabled: false
    path: /metrics
    port: 8080
```