### PR TITLE
Set specific version to argo-events images

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.3.0
+version: 0.4.0
 keywords:
 - argo-events
 - sensor-controller
@@ -11,4 +11,4 @@ sources:
 maintainers:
 - name: Vaibhav Page
 - name: Matt Magaldi
-appVersion: 0.7.0
+appVersion: 0.8.1

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -21,11 +21,11 @@ singleNamespace: true
 sensorController:
   name: sensor-controller
   image: sensor-controller
-  tag: latest
+  tag: v0.8.1
   replicaCount: 1
 
 gatewayController:
   name: gateway-controller
   image: gateway-controller
-  tag: latest
+  tag: v0.8.1
   replicaCount: 1


### PR DESCRIPTION
I think a container image should use a fixed tag instead of latest tag.
https://helm.sh/docs/chart_best_practices/#images