### PR TITLE
Support argocd 0.12.0

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.11"
+appVersion: "0.12"
 description: A Helm chart for Argo-CD
 name: argo-cd
-version: 0.1.0
+version: 0.2.0

--- a/charts/argo-cd/templates/argocd-redis-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-redis-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-redis
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-redis
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "argo-cd.name" . }}-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "argo-cd.name" . }}-redis
+        helm.sh/chart: {{ include "argo-cd.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/component: redis
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: redis
+        args:
+        - --save
+        - ""
+        - --appendonly
+        - "no"
+        image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+        imagePullPolicy: {{ .Values.redis.image.pullPolicy}}
+        ports:
+        - containerPort: {{ .Values.redis.containerPort }}
+

--- a/charts/argo-cd/templates/argocd-redis-service.yaml
+++ b/charts/argo-cd/templates/argocd-redis-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-redis
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-redis
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: redis
+spec:
+  ports:
+  - port: {{ .Values.redis.servicePort }}
+    targetPort: {{ .Values.redis.servicePort }}
+  selector:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-redis

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -3,7 +3,7 @@ applicationController:
   servicePort: 8083
   image:
     repository: argoproj/argocd
-    tag: v0.11.0
+    tag: v0.12.0
     pullPolicy: Always
 
 server:
@@ -14,11 +14,11 @@ server:
   serviceMetricsPort: 8082
   image:
     repository: argoproj/argocd
-    tag: v0.11.0
+    tag: v0.12.0
     pullPolicy: Always
   uiInitImage:
     repository: argoproj/argocd-ui
-    tag: v0.11.0
+    tag: v0.12.0
     pullPolicy: Always
     
 repoServer:
@@ -26,7 +26,7 @@ repoServer:
   servicePort: 8081
   image:
     repository: argoproj/argocd
-    tag: v0.11.0
+    tag: v0.12.0
     pullPolicy: Always
 
 dexServer:
@@ -40,7 +40,7 @@ dexServer:
     pullPolicy: Always
   initImage:
     repository: argoproj/argocd
-    tag: v0.11.0
+    tag: v0.12.0
     pullPolicy: Always
 
 # terminate tls at ArgoCD level
@@ -126,3 +126,11 @@ rbac:
   #   g, your-github-org:your-team, role:org-admin
   # The default role Argo CD will fall back to, when authorizing API requests
   policyDefault: #role:readonly
+
+redis:
+  image:
+    repository: redis
+    tag: 5.0.3
+    pullPolicy: Always
+  containerPort: 6379
+  servicePort: 6379


### PR DESCRIPTION
This is to fix https://github.com/argoproj/argo-helm/issues/45

Added a deployment for redis based on https://raw.githubusercontent.com/argoproj/argo-cd/v0.12.0/manifests/install.yaml

Updated all container image tags to 0.12.0.

Bumped appVersion and chart version.

I've tested this on my cluster and it works fine.