### PR TITLE
Allow extraargs for argocd server

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.11"
 description: A Helm chart for Argo-CD
 name: argo-cd
-version: 0.1.0
+version: 0.1.1

--- a/charts/argo-cd/templates/argocd-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server-deployment.yaml
@@ -36,8 +36,14 @@ spec:
       - name: argocd-server
         image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-        command: [argocd-server, --staticassets, /shared/app]
-        volumeMounts:
+        command:
+        - argocd-server
+        - --staticassets
+        - /shared/app
+        {{- range .Values.server.extraArgs }}
+        - {{. | quote }}
+        {{- end}}
+            volumeMounts:
         - mountPath: /shared
           name: static-files
         ports:

--- a/charts/argo-cd/templates/argocd-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server-deployment.yaml
@@ -42,8 +42,8 @@ spec:
         - /shared/app
         {{- range .Values.server.extraArgs }}
         - {{. | quote }}
-        {{- end}}
-            volumeMounts:
+        {{- end }}
+        volumeMounts:
         - mountPath: /shared
           name: static-files
         ports:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -20,6 +20,7 @@ server:
     repository: argoproj/argocd-ui
     tag: v0.11.0
     pullPolicy: Always
+  extraArgs: []
     
 repoServer:
   containerPort: 8081


### PR DESCRIPTION
Allowing extra arguments to be specified for argocd-server.

This is useful, for instance, if you need to change the basehref or use insecure when using ingress
https://github.com/argoproj/argo-cd/blob/master/docs/ingress.md