### PR TITLE
workflow-crd.yaml: delete before hook creation

### DIFF
--- a/charts/argo/templates/workflow-crd.yaml
+++ b/charts/argo/templates/workflow-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: workflows.argoproj.io
   annotations:
     helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   group: argoproj.io
   version: v1alpha1


### PR DESCRIPTION
Without this change, you end up with the following error on rolling upgrades:
```
Error: customresourcedefinitions.apiextensions.k8s.io "workflows.argoproj.io" already exists
ERROR: Job failed: exit code 1
```