### PR TITLE
Adding Service Annotation to argo-cd helm chart

### DIFF
--- a/charts/argo-cd/templates/argocd-server-service.yaml
+++ b/charts/argo-cd/templates/argocd-server-service.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
     app.kubernetes.io/component: server
+  annotations:
+{{ toYaml .Values.server.serviceAnnotations | indent 4}}{{- end }}
 spec:
   ports:
   - name: http

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -12,6 +12,7 @@ server:
   servicePortHttps: 443
   containerMetricsPort: 8082
   serviceMetricsPort: 8082
+  serviceAnnotations: {}
   image:
     repository: argoproj/argocd
     tag: v0.12.1


### PR DESCRIPTION
Added annotations to `argo-cd-server-service.yaml`.
it's useful for backend configuration.

```
apiVersion: v1
kind: Service
metadata:
  name: argocd-server
  labels:
    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
    helm.sh/chart: {{ include "argo-cd.chart" . }}
    app.kubernetes.io/instance: {{ .Release.Name }}
    app.kubernetes.io/managed-by: {{ .Release.Service }}
    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
    app.kubernetes.io/component: server
  annotations:
{{ toYaml .Values.server.serviceAnnotations | indent 4}}{{- end }}
```