### PR TITLE
argo-cd: Add volume parameters to Deployments

### DIFF
--- a/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller-deployment.yaml
@@ -40,4 +40,12 @@ spec:
             port: {{ .Values.applicationController.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        {{- if .Values.applicationController.volumeMounts }}
+        {{ toYaml .Values.applicationController.volumeMounts | nindent 8 | trim }}
+        {{- end }}
       serviceAccountName: argocd-application-controller
+      volumes:
+      {{- if .Values.applicationController.volumes }}
+      {{ toYaml .Values.applicationController.volumes | nindent 6 | trim }}
+      {{- end }}

--- a/charts/argo-cd/templates/argocd-dex-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-dex-server-deployment.yaml
@@ -43,6 +43,12 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: static-files
+        {{- if .Values.dexServer.volumeMounts }}
+        {{ toYaml .Values.dexServer.volumeMounts | nindent 8 | trim }}
+        {{- end }}
       volumes:
       - emptyDir: {}
         name: static-files
+      {{- if .Values.dexServer.volumes }}
+      {{ toYaml .Values.dexServer.volumes | nindent 6 | trim }}
+      {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server-deployment.yaml
@@ -36,3 +36,11 @@ spec:
             port: {{ .Values.repoServer.containerPort }}
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        {{- if .Values.repoServer.volumeMounts }}
+        {{ toYaml .Values.repoServer.volumeMounts | nindent 8 | trim }}
+        {{- end }}
+      volumes:
+      {{- if .Values.repoServer.volumes }}
+      {{ toYaml .Values.repoServer.volumes | nindent 6 | trim }}
+      {{- end }}

--- a/charts/argo-cd/templates/argocd-server-deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server-deployment.yaml
@@ -46,6 +46,9 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: static-files
+        {{- if .Values.server.volumeMounts }}
+        {{ toYaml .Values.server.volumeMounts | nindent 8 | trim }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.server.containerPort }}
         readinessProbe:
@@ -57,3 +60,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: static-files
+      {{- if .Values.server.volumes }}
+      {{ toYaml .Values.server.volumes | nindent 6 | trim }}
+      {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -5,6 +5,8 @@ applicationController:
     repository: argoproj/argocd
     tag: v0.12.1
     pullPolicy: Always
+  volumeMounts: []
+  volumes: []
 
 server:
   containerPort: 8080
@@ -20,7 +22,9 @@ server:
     tag: v0.12.1
     pullPolicy: Always
   extraArgs: []
-    
+  volumeMounts: []
+  volumes: []
+
 repoServer:
   containerPort: 8081
   servicePort: 8081
@@ -28,6 +32,8 @@ repoServer:
     repository: argoproj/argocd
     tag: v0.12.1
     pullPolicy: Always
+  volumeMounts: []
+  volumes: []
 
 dexServer:
   containerPortHttp: 5556
@@ -42,6 +48,8 @@ dexServer:
     repository: argoproj/argocd
     tag: v0.12.1
     pullPolicy: Always
+  volumeMounts: []
+  volumes: []
 
 # terminate tls at ArgoCD level
 ingress:


### PR DESCRIPTION
This adds new parameters to each Deployment in the argo-cd chart, allowing users to specify custom volumes to mount.  This makes it possible to use a Git repository self-signed certificates by manually adding a "known_hosts" file, as recommended in the documentation: https://argoproj.github.io/argo-cd/user-guide/private-repositories/

`volumes` and `volumeMounts` parameters are added to each Deployment, with defaults set to empty.

This change was tested by templating the chart with default parameters, and by templating it with volume mounts specified for each service.