### PR TITLE
Multi-namespace RBAC support

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.4.0
+version: 0.4.1
 keywords:
 - argo-events
 - sensor-controller

--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -10,6 +10,13 @@ subjects:
   - kind: ServiceAccount
     name: argo-events-sa
     namespace: {{ .Release.Namespace }}
+  {{- if .Values.additionalSaNamespaces }}
+  {{- range $namespace := .Values.additionalSaNamespaces }}
+  - kind: ServiceAccount
+    name: argo-events-sa
+    namespace: {{ $namespace }}
+  {{- end }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/argo-events/templates/argo-events-sa.yaml
+++ b/charts/argo-events/templates/argo-events-sa.yaml
@@ -5,3 +5,13 @@ kind: ServiceAccount
 metadata:
   name: argo-events-sa
   namespace: {{ .Release.Namespace }}
+{{- if .Values.additionalSaNamespaces }}
+{{- range $namespace := .Values.additionalSaNamespaces }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-events-sa
+  namespace: {{ $namespace }}
+{{- end }}
+{{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -6,10 +6,12 @@ imagePullPolicy: Always
 
 # ServiceAccount to use for running controller.
 serviceAccount: argo-events-sa
+# Create service accounts in additional namespaces specified
+# The SA will always be created in the release namespaces
+additionalSaNamespaces: []
+  # - argo-prod
 
 instanceID: argo-events
-
-
 
 # set `singleNamespace` to false to have the controllers 
 # listen on all namespaces.  Otherwise the controllers will listen


### PR DESCRIPTION
When using the charts accross namespaces we need the SA and bindings to be created in all of them.  Otherwise the sensor and gateway controllers just crash or complain about RBAC errors. 