### PR TITLE
fix(argocd): Adds argocd-server ClusterRole and ClusterRoleBinding

### DIFF
--- a/charts/argo-cd/templates/argocd-server-clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server-clusterrole.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.clusterAdminAccess.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - delete
+      - get
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server-clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.clusterAdminAccess.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-server
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-server
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/component: server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-server
+subjects:
+  - kind: ServiceAccount
+    name: argocd-server
+    namespace: {{ .Release.Namespace }}
+{{- end -}}


### PR DESCRIPTION
Adding the ClusterRole and ClusterRoleBinding allows argocd-server
to
read the necessary resources to deploy applications
to the default
cluster.

Closes #61