### PR TITLE
Add configManagementPlugins option to argo-cd

### DIFF
--- a/charts/argo-cd/templates/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-cm.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: argocd-cm
-  labels: 
+  labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -27,4 +27,8 @@ data:
 {{- if .Values.config.oidcConfig }}
   oidc.config: |
 {{ toYaml .Values.config.oidcConfig | indent 4 }}
+{{- end }}
+{{- if .Values.config.configManagementPlugins }}
+  configManagementPlugins: |
+{{ toYaml .Values.config.configManagementPlugins | indent 4 }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -62,9 +62,9 @@ ingress:
   hosts:
     - argocd.example.com
 
-# Standard Argo CD installation with cluster-admin access. 
-# Set this true if you plan to use Argo CD to deploy applications in the same cluster that 
-#     Argo CD runs in (i.e. kubernetes.svc.default). 
+# Standard Argo CD installation with cluster-admin access.
+# Set this true if you plan to use Argo CD to deploy applications in the same cluster that
+#     Argo CD runs in (i.e. kubernetes.svc.default).
 # Will still be able to deploy to external clusters with inputted credentials.
 
 clusterAdminAccess:
@@ -119,9 +119,18 @@ config:
   # provider webhook secret. The payload URL configured in the git provider should use the
   # /api/webhook endpoint of your Argo CD instance (e.g. https://argocd.example.com/api/webhook)
   webhook:
-    githubSecret: 
+    githubSecret:
     gitlabSecret:
     bitbucketSecret:
+  configManagementPlugins:
+    # - name: pluginName
+    #   init:                          # Optional command to initialize application source directory
+    #     command: ["sample command"]
+    #     args: ["sample args"]
+    #   generate:                      # Command to generate manifests YAML
+    #     command: ["sample command"]
+    #     args: ["sample args"]
+
 rbac:
 #   # An RBAC policy .csv file containing additional policy and role definitions.
 #   # See https://github.com/argoproj/argo-cd/blob/master/docs/rbac.md on how to write RBAC policies.


### PR DESCRIPTION
https://argoproj.github.io/argo-cd/user-guide/application_sources/#config-management-plugins

Added `configManagementPlugins` option because it was not supported.
