### PR TITLE
Add force namespace isolation for UI

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v2.2.1"
 description: A Helm chart for Kubernetes
 name: argo
-version: 0.3.1
+version: 0.3.2

--- a/charts/argo/templates/ui-deployment.yaml
+++ b/charts/argo/templates/ui-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         - name: ui
           image: "{{ .Values.images.namespace }}/{{ .Values.images.ui }}:{{ .Values.images.tag }}"
           env:
+          {{- if .Values.ui.forceNamespaceIsolation }}
+          - name: FORCE_NAMESPACE_ISOLATION
+            value: "true"
+          {{- end }}
           - name: IN_CLUSTER
             value: "true"
           - name: ARGO_NAMESPACE

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -37,6 +37,8 @@ controller:
 
 ui:
   enabled: true
+  # only show workflows where UI installed
+  forceNamespaceIsolation: false
   # optional map of annotations to be applied to the ui Pods
   podAnnotations: {}
   name: ui


### PR DESCRIPTION
Allow UI to watch for workflow in the namespace it is installed.
Existing release will have no change. 