### PR TITLE
Update Argo to v2.3.0 and add support for Prometheus operator

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v2.2.1"
 description: A Helm chart for Kubernetes
 name: argo
-version: 0.4.0
+version: 0.5.0

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -36,3 +36,6 @@ data:
     {{- if .Values.controller.metricsConfig.enabled }}
     metricsConfig:
 {{ toYaml .Values.controller.metricsConfig | indent 6}}{{- end }}
+    {{- if .Values.controller.telemetryConfig.enabled }}
+    telemetryConfig:
+{{ toYaml .Values.controller.telemetryConfig | indent 6}}{{- end }}

--- a/charts/argo/templates/workflow-controller-service.yaml
+++ b/charts/argo/templates/workflow-controller-service.yaml
@@ -1,0 +1,35 @@
+{{- if or .Values.controller.metricsConfig.enabled .Values.controller.telemetryConfig.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.controller.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.controller.serviceAnnotations | indent 4}}{{- end }}
+spec:
+  ports:
+  {{- if .Values.controller.metricsConfig.enabled }}
+  - name: metrics
+    port: {{ .Values.controller.metricsServicePort }}
+    protocol: TCP
+    targetPort: {{ .Values.controller.metricsConfig.port }}
+  {{- end }}
+  {{- if .Values.controller.telemetryConfig.enabled }}
+  - name: telemetry
+    port: {{ .Values.controller.telemetryServicePort }}
+    protocol: TCP
+    targetPort: {{ .Values.controller.telemetryConfig.port }}
+  {{- end }}
+  selector:
+    app: {{ .Release.Name }}-{{ .Values.controller.name }}
+  sessionAffinity: None
+  type: {{ .Values.controller.serviceType }}
+  {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.loadBalancerSourceRanges | indent 4 }}{{- end }}
+{{- end -}}

--- a/charts/argo/templates/workflow-controller-servicemonitor.yaml
+++ b/charts/argo/templates/workflow-controller-servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and (or .Values.controller.metricsConfig.enabled .Values.controller.telemetryConfig.enabled) .Values.controller.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.controller.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.controller.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  {{- if .Values.controller.metricsConfig.enabled }}
+    - port: metrics
+      path: {{ .Values.controller.metricsConfig.path }}
+      interval: 30s
+  {{- end }}
+  {{- if .Values.controller.telemetryConfig.enabled }}
+    - port: telemetry
+      path: {{ .Values.controller.telemetryConfig.path }}
+      interval: 30s
+  {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -3,7 +3,7 @@ images:
   controller: workflow-controller
   ui: argoui
   executor: argoexec
-  tag: v2.2.1
+  tag: v2.3.0
 
 crdVersion: v1alpha1
 
@@ -21,6 +21,13 @@ controller:
     enabled: false
     path: /metrics
     port: 8080
+  telemetryConfig:
+    enabled: false
+    path: /telemetry
+    port: 8081
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
   serviceAccount: argo
   name: workflow-controller
   workflowNamespaces:
@@ -36,6 +43,14 @@ controller:
   logging:
     level: info
     globallevel: "0"
+  serviceType: ClusterIP
+  metricsServicePort: 8080
+  telemetryServicePort: 8081
+  # Annotations to be applied to the controller Service
+  serviceAnnotations: {}
+  # Source ranges to allow access to service from. Only applies to
+  # service type `LoadBalancer`
+  loadBalancerSourceRanges: []
 
 ui:
   enabled: true


### PR DESCRIPTION
This PR does several things:

- update to the latest version of Argo (v2.3.0)

- allow to enable telemetry endpoint, the same way the metrics endpoint is enabled (personal comment: i suggest to merge this two endpoints in the Argo product to simplify things)

- allow to activate Prometheus ServiceMonitor for both metrics and telemetry endpoints

- add a Service resource for both metrics and telemetry endpoints (needed for Prometheus ServiceMonitor)

I've tried to match the current way of declaring resources in the Argo chart.