### PR TITLE
Enable image pull policy in argo & argo-ci

### DIFF
--- a/charts/argo-ci/templates/ci-deployment.yaml
+++ b/charts/argo-ci/templates/ci-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: ci
           image: "{{ .Values.imageNamespace }}/{{ .Values.ciImage }}:{{ .Values.imageTag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
           - name: IN_CLUSTER
             value: "true"

--- a/charts/argo-ci/values.yaml
+++ b/charts/argo-ci/values.yaml
@@ -1,6 +1,7 @@
 imageNamespace: argoproj
 ciImage: argoci
 imageTag: v1.0.0-alpha2
+imagePullPolicy: Always
 workflowNamespace: default
 
 argo:

--- a/charts/argo/templates/ui-deployment.yaml
+++ b/charts/argo/templates/ui-deployment.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
         - name: ui
           image: "{{ .Values.images.namespace }}/{{ .Values.images.ui }}:{{ .Values.images.tag }}"
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
           env:
           {{- if .Values.ui.forceNamespaceIsolation }}
           - name: FORCE_NAMESPACE_ISOLATION

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
         - name: controller
           image: "{{ .Values.images.namespace }}/{{ .Values.images.controller }}:{{ .Values.images.tag }}"
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: [ "workflow-controller" ]
           args:
           - "--configmap"

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -3,6 +3,7 @@ images:
   controller: workflow-controller
   ui: argoui
   executor: argoexec
+  pullPolicy: Always
   tag: v2.2.1
 
 crdVersion: v1alpha1


### PR DESCRIPTION
This pull request will enable configuration of image pull policy in the following charts: 

- argo 
- argo-ci 

When using the argo helm chart in an environment that is closed off from the internet, it is important to allow images to be pre-loaded and leveraged. 