### PR TITLE
loadBalancerIP support in argo-ui

### DIFF
--- a/charts/argo/templates/ui-service.yaml
+++ b/charts/argo/templates/ui-service.yaml
@@ -19,6 +19,9 @@ spec:
     app: {{ .Release.Name }}-{{ .Values.ui.name }}
   sessionAffinity: None
   type: {{ .Values.ui.serviceType }}
+  {{- if and (eq .Values.ui.serviceType "LoadBalancer") .Values.ui.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.ui.loadBalancerIP | quote }}
+  {{- end }}
   {{- if and (eq .Values.ui.serviceType "LoadBalancer") .Values.ui.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.ui.loadBalancerSourceRanges | indent 4 }}{{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -51,6 +51,9 @@ ui:
   serviceAccount: argo-ui
   # Annotations to be applied to the UI Service
   serviceAnnotations: {}
+  # Static IP address to assign to loadBalancer
+  # service type `LoadBalancer`
+  loadBalancerIP: "123"
   # Source ranges to allow access to service from. Only applies to
   # service type `LoadBalancer`
   loadBalancerSourceRanges: []

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -53,7 +53,7 @@ ui:
   serviceAnnotations: {}
   # Static IP address to assign to loadBalancer
   # service type `LoadBalancer`
-  loadBalancerIP: "123"
+  loadBalancerIP: ""
   # Source ranges to allow access to service from. Only applies to
   # service type `LoadBalancer`
   loadBalancerSourceRanges: []


### PR DESCRIPTION
Guys I think that Argo-ui is used a lot internally in companies through VPN, therefore it would make sense to allow for setting static IP address for internal loadBalancer. WDYT ?