### PR TITLE
Fixed typo at argocd-ui

### DIFF
--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -19,7 +19,7 @@ server:
     pullPolicy: Always
   uiInitImage:
     repository: argoproj/argocd-ui
-    tag: v.1.1.2
+    tag: v1.1.2
     pullPolicy: Always
   extraArgs: []
   volumeMounts: []


### PR DESCRIPTION
Hey,

there is an incorrect image tag at argocd-ui.

Recognized after **helm install argo/argo-cd**