### PR TITLE
add admin password and tls values to argocd admin-secret.yaml

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1.2"
 description: A Helm chart for Argo-CD
 name: argo-cd
-version: 0.3.0
+version: 0.3.1

--- a/charts/argo-cd/templates/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-secret.yaml
@@ -2,14 +2,29 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-secret
-  labels: 
+  labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
 type: Opaque
-data:  
+data:
+{{- if .Values.config.admin.password }}
+  admin.password: {{ .Values.config.admin.password }}
+{{- end }}
+{{- if .Values.config.admin.passwordMtime }}
+  admin.passwordMtime: {{ .Values.config.admin.passwordMtime }}
+{{- end }}
+{{- if .Values.config.server.secretkey }}
+  server.secretkey: {{ .Values.config.server.secretkey }}
+{{- end }}
+{{- if .Values.config.tls.crt }}
+  tls.crt: {{ .Values.config.tls.crt }}
+{{- end }}
+{{- if .Values.config.tls.key }}
+  tls.key: {{ .Values.config.tls.key }}
+{{- end }}
 {{- if .Values.config.webhook.githubSecret }}
   github.webhook.secret: {{ .Values.config.webhook.githubSecret }}
 {{- end }}


### PR DESCRIPTION
This PR proposes to add the following values to argo-secret.yaml for ArgoCD:
* `.Values.config.admin.password`
* `.Values.config.admin.passwordMtime`
* `.Values.config.server.secretkey`
* `.Values.config.tls.crt`
* `.Values.config.tls.key`