### PR TITLE
Deployment extensions/v1beta1 is deprecated in Kubernetes 1.16

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v2.3.0"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.5.1
+version: 0.5.2

--- a/charts/argo/templates/ui-deployment.yaml
+++ b/charts/argo/templates/ui-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ui.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-{{ .Values.ui.name}}
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.ui.name}}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-{{ .Values.controller.name}}
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
The argo helm chart does not deploy on Kubernetes 1.16 because it is still trying to deploy using the deprecated extensions/v1betax of the Deployment object.

This PR simply change it to apps/v1 and add the selector field;

```bash
helm install --name argo --namespace argo .
```

```bash
kubectl get all -n argo
NAME                                            READY   STATUS    RESTARTS   AGE
pod/argo-ui-54d674fdfd-254sl                    1/1     Running   0          3m41s
pod/argo-workflow-controller-6c5544f94d-5vl5s   1/1     Running   0          3m41s

NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/argo-ui   ClusterIP   10.99.128.160   <none>        80/TCP    3m41s

NAME                                       READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/argo-ui                    1/1     1            1           3m41s
deployment.apps/argo-workflow-controller   1/1     1            1           3m41s

NAME                                                  DESIRED   CURRENT   READY   AGE
replicaset.apps/argo-ui-54d674fdfd                    1         1         1       3m41s
replicaset.apps/argo-workflow-controller-6c5544f94d   1         1         1       3m41s
```
