### PR TITLE
argo-cd: allow anonymous access

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for Argo-CD
 name: argo-cd
-version: 0.5.1
+version: 0.5.2

--- a/charts/argo-cd/templates/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-cm.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
 data:
+{{- if .Values.config.enableAnonymousAccess }}
+  users.anonymous.enabled: {{ .Values.config.enableAnonymousAccess }}
+{{- end }}
 {{- if .Values.config.helmRepositories }}
   helm.repositories: |
 {{ toYaml .Values.config.helmRepositories | indent 4 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -77,6 +77,7 @@ clusterAdminAccess:
 
 config:
   createSecret: true
+  enableAnonymousAccess: false
   helmRepositories:
     # - name: privateRepo
     #   url: http://chartmuseum.privatecloud.com


### PR DESCRIPTION
This PR allows the user to configure anonymous access to ArgoCD using a new `enableAnonymousAccess` field in `values.yaml`. The new field defaults to `false`.

This is convenient for local or highly trusted deployments of ArgoCD.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
