### PR TITLE
charts/argo-cd: fix typo in users.anonymous.enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for Argo-CD
 name: argo-cd
-version: 0.5.2
+version: 0.5.3

--- a/charts/argo-cd/templates/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-cm.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/part-of: argocd
 data:
 {{- if .Values.config.enableAnonymousAccess }}
-  users.anonymous.enabled: {{ .Values.config.enableAnonymousAccess }}
+  users.anonymous.enabled: "{{ .Values.config.enableAnonymousAccess }}"
 {{- end }}
 {{- if .Values.config.helmRepositories }}
   helm.repositories: |


### PR DESCRIPTION
Copy paste error: missed the quotes. Apologies.

Error introduced in https://github.com/argoproj/argo-helm/pull/117

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
