### PR TITLE
argo-cd/crds: add 'hook-delete-policy: before-hook-creation'

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for Argo-CD
 name: argo-cd
-version: 0.5.3
+version: 0.5.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png

--- a/charts/argo-cd/templates/crds/application-crd.yaml
+++ b/charts/argo-cd/templates/crds/application-crd.yaml
@@ -8,6 +8,7 @@ metadata:
   name: applications.argoproj.io
   annotations:
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   group: argoproj.io
   names:

--- a/charts/argo-cd/templates/crds/appproject-crd.yaml
+++ b/charts/argo-cd/templates/crds/appproject-crd.yaml
@@ -8,6 +8,7 @@ metadata:
   name: appprojects.argoproj.io
   annotations:
     "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   group: argoproj.io
   names:


### PR DESCRIPTION
The pattern is standard to support 'helm upgrade' for charts that define CRDs.