### PR TITLE
expose workflow metrics port

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "v2.3.0"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.5.3
+version: 0.5.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -48,3 +48,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
+          {{- if .Values.controller.metricsConfig.enabled }}
+          ports:
+          - containerPort: 8080
+          {{- end }}


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).

This change just exposes the metrics port of the workflow controller pod if the metrics are enabled.