### PR TITLE
Update argo chart for 2.4.2

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v2.4.1"
+appVersion: "v2.4.2"
 description: A Helm chart for Argo Workflows
 name: argo
 version: 0.6.0

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "v2.3.0"
+appVersion: "v2.4.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.5.4
+version: 0.6.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png

--- a/charts/argo/README.md
+++ b/charts/argo/README.md
@@ -8,7 +8,7 @@ If you want your deployment of this helm chart to most closely match the [argo C
 This chart uses an install hook to configure the CRD definition.  Installation of CRDs is a somewhat privileged process in itself and in RBAC enabled clusters the `default` service account for namespaces does not typically have the ability to do create these.
 
 A few options are:
-- Setup the CRD yourself manually and use the `--no-hooks` options of `helm install`
+- Setup the CRD yourself manually and use `--set installCRD=false` when installing the helm chart. Find the CRDs in the [argo codebase](https://raw.githubusercontent.com/argoproj/argo/master/manifests/base/crds/workflow-crd.yaml)
 - Manually create a ServiceAccount in the Namespace which your release will be deployed w/ appropriate bindings to perform this action and set the `init.serviceAccount` attribute
 - Augment the `default` ServiceAccount permissions in the Namespace in which your Release is deployed to have the appropriate permissions
 

--- a/charts/argo/templates/ui-cluster-role.yaml
+++ b/charts/argo/templates/ui-cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.enabled -}}
+{{- if .Values.ui.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,8 +24,9 @@ rules:
   - argoproj.io
   resources:
   - workflows
+  - workflowtemplates
   verbs:
   - get
   - list
   - watch
-  {{- end -}}
+{{- end }}

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -14,11 +14,12 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
   verbs:
   - get
   - list
   - watch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -35,6 +36,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
   verbs:
   - create
   - delete
@@ -44,7 +47,6 @@ rules:
   - patch
   - update
   - watch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -61,6 +63,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
   verbs:
   - create
   - delete

--- a/charts/argo/templates/workflow-controller-clusterrole.yaml
+++ b/charts/argo/templates/workflow-controller-clusterrole.yaml
@@ -43,3 +43,20 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+

--- a/charts/argo/templates/workflow-template-crd.yaml
+++ b/charts/argo/templates/workflow-template-crd.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: workflows.argoproj.io
+  name: workflowtemplates.argoproj.io
   annotations:
     helm.sh/hook: crd-install
     helm.sh/hook-delete-policy: before-hook-creation
@@ -11,8 +11,8 @@ spec:
   version: v1alpha1
   scope: Namespaced
   names:
-    kind: Workflow
-    plural: workflows
+    kind: WorkflowTemplate
+    plural: workflowtemplates
     shortNames:
-    - wf
+    - wftmpl
 {{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,7 +4,7 @@ images:
   ui: argoui
   executor: argoexec
   pullPolicy: Always
-  tag: v2.4.1
+  tag: v2.4.2
 
 crdVersion: v1alpha1
 installCRD: true

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,9 +4,10 @@ images:
   ui: argoui
   executor: argoexec
   pullPolicy: Always
-  tag: v2.3.0
+  tag: v2.4.1
 
 crdVersion: v1alpha1
+installCRD: true
 
 init:
   # By default the installation will not set an explicit one, which will mean it uses `default` for the namespace the chart is


### PR DESCRIPTION
Notable changes:

* Default argo image is 2.4.2
* WorkflowTemplate CRD is created
* RBAC is updated to include workflowtemplate permissions
* CRD install is disabled with a Helm flag in order to be more compatible with tools such as [Reckoner](https://github.com/fairwindsops/reckoner)
* README suggests where to find CRDs for manual install

I have installed this chart using the values that I had for my previous install of Argo on 2.3.0 and it installs cleanly. I tested running both standard workflows and submitting templates and workflows that use templates.


Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
