### PR TITLE
[argo-events] Rename argo-events-sa to argo-events

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.5.0
+version: 0.5.1
 keywords:
 - argo-events
 - sensor-controller

--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -8,12 +8,12 @@ roleRef:
   name: argo-events-role
 subjects:
   - kind: ServiceAccount
-    name: argo-events-sa
+    name: {{ .Values.serviceAccount }}
     namespace: {{ .Release.Namespace }}
   {{- if .Values.additionalSaNamespaces }}
   {{- range $namespace := .Values.additionalSaNamespaces }}
   - kind: ServiceAccount
-    name: argo-events-sa
+    name: {{ .Values.serviceAccount }}
     namespace: {{ $namespace }}
   {{- end }}
   {{- end }}

--- a/charts/argo-events/templates/argo-events-sa.yaml
+++ b/charts/argo-events/templates/argo-events-sa.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: argo-events-sa
+  name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.additionalSaNamespaces }}
 {{- range $namespace := .Values.additionalSaNamespaces }}
@@ -11,7 +11,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: argo-events-sa
+  name: {{ .Values.serviceAccount }}
   namespace: {{ $namespace }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The suffix -sa is redundant, remove it to be consistent with
ServiceAccount naming in argo, and argo-cd charts.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
