### PR TITLE
Issue #147, k8s label part-of expected to be argocd

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -2,7 +2,7 @@ Argo CD Chart
 ======
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
-Current chart version is `1.0.0`
+Current chart version is `1.0.2`
 
 Source code can be found [here](https://argoproj.github.io/argo-cd/)
 

--- a/charts/argo-cd/templates/argocd-application-controller/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 rules:
 - apiGroups:

--- a/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 spec:
   selector:
@@ -29,7 +29,7 @@ spec:
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/part-of: argocd
         app.kubernetes.io/component: {{ .Values.controller.name }}
         {{- if .Values.controller.podLabels }}
 {{- toYaml .Values.controller.podLabels | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-application-controller/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/metrics-service.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 {{- if .Values.controller.metrics.service.labels }}
 {{- toYaml .Values.controller.metrics.service.labels | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 rules:
 - apiGroups:

--- a/charts/argo-cd/templates/argocd-application-controller/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/argo-cd/templates/argocd-application-controller/service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/service.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 spec:
   ports:

--- a/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
 {{- toYaml .Values.controller.metrics.serviceMonitor.selector | nindent 4 }}
     {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 data:
 {{- toYaml .Values.server.config | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 data:
 {{- toYaml .Values.server.rbacConfig | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 type: Opaque
 {{- if or .Values.configs.secret.githubSecret (or .Values.configs.secret.gitlabSecret .Values.configs.secret.bitbucketSecret) }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
@@ -7,6 +7,6 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
   name: argocd-ssh-known-hosts-cm

--- a/charts/argo-cd/templates/argocd-configs/argocd-tls-certs-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-tls-certs-cm.yaml
@@ -9,6 +9,6 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
   name: argocd-tls-certs-cm

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.repoServer.name }}
 spec:
   selector:
@@ -29,7 +29,7 @@ spec:
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/part-of: argocd
         app.kubernetes.io/component: {{ .Values.repoServer.name }}
         {{- if .Values.controller.podLabels }}
 {{- toYaml .Values.controller.podLabels | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-repo-server/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/metrics-service.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.repoServer.name }}
 {{- if .Values.repoServer.metrics.service.labels }}
 {{- toYaml .Values.repoServer.metrics.service.labels | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-repo-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/service.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.repoServer.name }}
   name: {{ template "argo-cd.repoServer.fullname" . }}
 spec:

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.repoServer.name }}
 {{- toYaml .Values.repoServer.metrics.serviceMonitor.selector | nindent 4 }}
     {{- if .Values.repoServer.metrics.serviceMonitor.additionalLabels }}

--- a/charts/argo-cd/templates/argocd-server/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-server/certificate.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 spec:
   commonName: {{ .Values.server.certificate.domain | quote }}

--- a/charts/argo-cd/templates/argocd-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 rules:
   - apiGroups:

--- a/charts/argo-cd/templates/argocd-server/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 spec:
   selector:
@@ -29,7 +29,7 @@ spec:
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/part-of: argocd
         app.kubernetes.io/component: {{ .Values.server.name }}
         {{- if .Values.controller.podLabels }}
 {{- toYaml .Values.controller.podLabels | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 {{- if .Values.server.ingress.labels }}
 {{- toYaml .Values.server.ingress.labels | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-server/metrics-service.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 {{- if .Values.server.metrics.service.labels }}
 {{- toYaml .Values.server.metrics.service.labels | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/role.yaml
+++ b/charts/argo-cd/templates/argocd-server/role.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 rules:
 - apiGroups:

--- a/charts/argo-cd/templates/argocd-server/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/service.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 spec:
   type: {{ .Values.server.service.type }}

--- a/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 {{- toYaml .Values.server.metrics.serviceMonitor.selector | nindent 4 }}
     {{- if .Values.server.metrics.serviceMonitor.additionalLabels }}

--- a/charts/argo-cd/templates/crds/application-crd.yaml
+++ b/charts/argo-cd/templates/crds/application-crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
   name: applications.argoproj.io
   annotations:
     "helm.sh/hook": crd-install

--- a/charts/argo-cd/templates/crds/appproject-crd.yaml
+++ b/charts/argo-cd/templates/crds/appproject-crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
   name: appprojects.argoproj.io
   annotations:
     "helm.sh/hook": crd-install

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.dex.name }}
 spec:
   selector:
@@ -22,7 +22,7 @@ spec:
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/part-of: argocd
         app.kubernetes.io/component: {{ .Values.dex.name }}
     spec:
       initContainers:

--- a/charts/argo-cd/templates/dex/role.yaml
+++ b/charts/argo-cd/templates/dex/role.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.dex.name }}
 rules:
 - apiGroups:

--- a/charts/argo-cd/templates/dex/rolebinding.yaml
+++ b/charts/argo-cd/templates/dex/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.dex.name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.dex.name }}
 spec:
   ports:

--- a/charts/argo-cd/templates/dex/serviceaccount.yaml
+++ b/charts/argo-cd/templates/dex/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.dex.name }}
 {{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.redis.name }}
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
         helm.sh/chart: {{ include "argo-cd.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+        app.kubernetes.io/part-of: argocd
         app.kubernetes.io/component: {{ .Values.redis.name }}
     spec:
       automountServiceAccountToken: false

--- a/charts/argo-cd/templates/redis/service.yaml
+++ b/charts/argo-cd/templates/redis/service.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ include "argo-cd.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/part-of: {{ include "argo-cd.name" . }}
+    app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.redis.name }}
 spec:
   ports:


### PR DESCRIPTION
The argocd application expects that the label 'app.kubernetes.io/part-of' is set to 'argocd' otherwise the configmap or secret is rejected, and the argocd-dex-server, argocd-server, and argocd-application-controller fail to start.

[Issue 147](https://github.com/argoproj/argo-helm/issues/147)
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.