### PR TITLE
[argo-events] v0.11 update

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.5.2
+version: 0.6.0
 keywords:
   - argo-events
   - sensor-controller
@@ -11,6 +11,6 @@ sources:
 maintainers:
   - name: VaibhavPage
   - name: magaldima
-appVersion: 0.10
+appVersion: 0.11
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -14,3 +14,10 @@ This is a **community maintained** chart. It installs the [argo-events](https://
 ## Notes on CRD Installation
 
 Some users would prefer to install the CRDs _outside_ of the chart. You can disable the CRD installation of this chart by using `--set installCRD=false` when installing the chart.
+
+You can install the CRDs manually like so:
+
+```
+kubectl apply -f https://github.com/argoproj/argo-events/raw/v0.11/hack/k8s/manifests/sensor-crd.yaml
+kubectl apply -f https://github.com/argoproj/argo-events/raw/v0.11/hack/k8s/manifests/gateway-crd.yaml
+```

--- a/charts/argo-events/ci/test-values.yaml
+++ b/charts/argo-events/ci/test-values.yaml
@@ -1,0 +1,6 @@
+serviceAccount: argo-events-sa-test
+additionalSaNamespaces:
+  - nsone
+  - nstwo
+instanceID: test-argo-events
+singleNamespace: false

--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -51,6 +51,8 @@ rules:
     resources:
       - workflows
       - workflows/finalizers
+      - workflowtemplates
+      - workflowtemplates/finalizers
       - gateways
       - gateways/finalizers
       - sensors

--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -11,9 +11,10 @@ subjects:
     name: {{ .Values.serviceAccount }}
     namespace: {{ .Release.Namespace }}
   {{- if .Values.additionalSaNamespaces }}
+  {{ $sa := .Values.serviceAccount }}
   {{- range $namespace := .Values.additionalSaNamespaces }}
   - kind: ServiceAccount
-    name: {{ .Values.serviceAccount }}
+    name: {{ $sa }}
     namespace: {{ $namespace }}
   {{- end }}
   {{- end }}

--- a/charts/argo-events/templates/argo-events-sa.yaml
+++ b/charts/argo-events/templates/argo-events-sa.yaml
@@ -1,4 +1,4 @@
-# All argo-events services are bound to the "argo-events" service account. 
+# All argo-events services are bound to the "argo-events" service account.
 # In RBAC enabled setups, this SA is bound to specific roles.
 apiVersion: v1
 kind: ServiceAccount
@@ -6,12 +6,13 @@ metadata:
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.additionalSaNamespaces }}
+{{ $sa := .Values.serviceAccount }}
 {{- range $namespace := .Values.additionalSaNamespaces }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount }}
+  name: {{ $sa }}
   namespace: {{ $namespace }}
 {{- end }}
 {{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -26,11 +26,11 @@ singleNamespace: true
 sensorController:
   name: sensor-controller
   image: sensor-controller
-  tag: v0.10
+  tag: v0.11
   replicaCount: 1
 
 gatewayController:
   name: gateway-controller
   image: gateway-controller
-  tag: v0.10
+  tag: v0.11
   replicaCount: 1


### PR DESCRIPTION
Bumped the version of argo-events to v0.11 and updated the clusterrole to be able to view workflowTemplates just like the clusterroles in the argo installation.

I also had to update the way that serviceAccount was handled when additionaSaNamespaces was set in order to work.  I also added a test-values.yaml in order to include this in testing if the chart-test install tests are running.

Chart has been installed using the additional namespaces value in a test cluster.

Checklist:

* [ x ] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [ x ] Any new values are backwards compatible and/or have sensible default.
* [ x ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ x ] I have signed the CLA and the build is green.
* [ x ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.