### PR TITLE
[charts/argo-cd] Update to 1.3, some chart cleanup

### DIFF
--- a/charts/argo-cd/.helmignore
+++ b/charts/argo-cd/.helmignore
@@ -1,0 +1,2 @@
+*.tgz
+output

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.2.4"
+appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.0.8
+version: 1.1.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -2,8 +2,6 @@ Argo CD Chart
 ======
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
-Current chart version is `1.0.4`
-
 Source code can be found [here](https://argoproj.github.io/argo-cd/)
 
 ## Additional Information

--- a/charts/argo-cd/templates/crds/application-crd.yaml
+++ b/charts/argo-cd/templates/crds/application-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -416,7 +417,7 @@ spec:
                     type: object
                   type: array
                 revision:
-                  description: Revision is the git revision in which to sync the application
+                  description: Revision is the revision in which to sync the application
                     to. If omitted, will use the revision specified in app spec.
                   type: string
                 source:
@@ -424,6 +425,9 @@ spec:
                     This is typically set in a Rollback operation and nil during a
                     Sync operation
                   properties:
+                    chart:
+                      description: Chart is a Helm chart name
+                      type: string
                     directory:
                       description: Directory holds path/directory specific options
                       properties:
@@ -492,6 +496,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        values:
+                          description: Values is Helm values, typically defined as
+                            a block
+                          type: string
                       type: object
                     ksonnet:
                       description: Ksonnet holds ksonnet specific options
@@ -536,8 +544,7 @@ spec:
                           type: string
                       type: object
                     path:
-                      description: Path is a directory path within the repository
-                        containing a
+                      description: Path is a directory path within the Git repository
                       type: string
                     plugin:
                       description: ConfigManagementPlugin holds config management
@@ -561,7 +568,7 @@ spec:
                           type: string
                       type: object
                     repoURL:
-                      description: RepoURL is the git repository URL of the application
+                      description: RepoURL is the repository URL of the application
                         manifests
                       type: string
                     targetRevision:
@@ -571,7 +578,6 @@ spec:
                       type: string
                   required:
                   - repoURL
-                  - path
                   type: object
                 syncStrategy:
                   description: SyncStrategy describes how to perform the sync
@@ -634,7 +640,6 @@ spec:
                   namespace:
                     type: string
                 required:
-                - group
                 - kind
                 - jsonPointers
                 type: object
@@ -661,6 +666,9 @@ spec:
               description: Source is a reference to the location ksonnet application
                 definition
               properties:
+                chart:
+                  description: Chart is a Helm chart name
+                  type: string
                 directory:
                   description: Directory holds path/directory specific options
                   properties:
@@ -729,6 +737,9 @@ spec:
                       items:
                         type: string
                       type: array
+                    values:
+                      description: Values is Helm values, typically defined as a block
+                      type: string
                   type: object
                 ksonnet:
                   description: Ksonnet holds ksonnet specific options
@@ -773,8 +784,7 @@ spec:
                       type: string
                   type: object
                 path:
-                  description: Path is a directory path within the repository containing
-                    a
+                  description: Path is a directory path within the Git repository
                   type: string
                 plugin:
                   description: ConfigManagementPlugin holds config management plugin
@@ -798,8 +808,7 @@ spec:
                       type: string
                   type: object
                 repoURL:
-                  description: RepoURL is the git repository URL of the application
-                    manifests
+                  description: RepoURL is the repository URL of the application manifests
                   type: string
                 targetRevision:
                   description: TargetRevision defines the commit, tag, or branch in
@@ -807,7 +816,6 @@ spec:
                   type: string
               required:
               - repoURL
-              - path
               type: object
             syncPolicy:
               description: SyncPolicy controls when a sync will be performed
@@ -867,6 +875,9 @@ spec:
                     type: string
                   source:
                     properties:
+                      chart:
+                        description: Chart is a Helm chart name
+                        type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
@@ -936,6 +947,10 @@ spec:
                             items:
                               type: string
                             type: array
+                          values:
+                            description: Values is Helm values, typically defined
+                              as a block
+                            type: string
                         type: object
                       ksonnet:
                         description: Ksonnet holds ksonnet specific options
@@ -980,8 +995,7 @@ spec:
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the repository
-                          containing a
+                        description: Path is a directory path within the Git repository
                         type: string
                       plugin:
                         description: ConfigManagementPlugin holds config management
@@ -1005,7 +1019,7 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the git repository URL of the application
+                        description: RepoURL is the repository URL of the application
                           manifests
                         type: string
                       targetRevision:
@@ -1015,7 +1029,6 @@ spec:
                         type: string
                     required:
                     - repoURL
-                    - path
                     type: object
                 required:
                 - revision
@@ -1024,6 +1037,8 @@ spec:
                 type: object
               type: array
             observedAt:
+              description: ObservedAt indicates when the application state was updated
+                without querying latest git state
               format: date-time
               type: string
             operationState:
@@ -1071,15 +1086,18 @@ spec:
                             type: object
                           type: array
                         revision:
-                          description: Revision is the git revision in which to sync
-                            the application to. If omitted, will use the revision
-                            specified in app spec.
+                          description: Revision is the revision in which to sync the
+                            application to. If omitted, will use the revision specified
+                            in app spec.
                           type: string
                         source:
                           description: Source overrides the source definition set
                             in the application. This is typically set in a Rollback
                             operation and nil during a Sync operation
                           properties:
+                            chart:
+                              description: Chart is a Helm chart name
+                              type: string
                             directory:
                               description: Directory holds path/directory specific
                                 options
@@ -1155,6 +1173,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                values:
+                                  description: Values is Helm values, typically defined
+                                    as a block
+                                  type: string
                               type: object
                             ksonnet:
                               description: Ksonnet holds ksonnet specific options
@@ -1200,8 +1222,8 @@ spec:
                                   type: string
                               type: object
                             path:
-                              description: Path is a directory path within the repository
-                                containing a
+                              description: Path is a directory path within the Git
+                                repository
                               type: string
                             plugin:
                               description: ConfigManagementPlugin holds config management
@@ -1225,8 +1247,8 @@ spec:
                                   type: string
                               type: object
                             repoURL:
-                              description: RepoURL is the git repository URL of the
-                                application manifests
+                              description: RepoURL is the repository URL of the application
+                                manifests
                               type: string
                             targetRevision:
                               description: TargetRevision defines the commit, tag,
@@ -1235,7 +1257,6 @@ spec:
                               type: string
                           required:
                           - repoURL
-                          - path
                           type: object
                         syncStrategy:
                           description: SyncStrategy describes how to perform the sync
@@ -1322,12 +1343,15 @@ spec:
                         type: object
                       type: array
                     revision:
-                      description: Revision holds the git commit SHA of the sync
+                      description: Revision holds the revision of the sync
                       type: string
                     source:
                       description: Source records the application source information
                         of the sync, used for comparing auto-sync
                       properties:
+                        chart:
+                          description: Chart is a Helm chart name
+                          type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
@@ -1399,6 +1423,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            values:
+                              description: Values is Helm values, typically defined
+                                as a block
+                              type: string
                           type: object
                         ksonnet:
                           description: Ksonnet holds ksonnet specific options
@@ -1444,8 +1472,7 @@ spec:
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the repository
-                            containing a
+                          description: Path is a directory path within the Git repository
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management
@@ -1469,7 +1496,7 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the git repository URL of the application
+                          description: RepoURL is the repository URL of the application
                             manifests
                           type: string
                         targetRevision:
@@ -1479,7 +1506,6 @@ spec:
                           type: string
                       required:
                       - repoURL
-                      - path
                       type: object
                   required:
                   - revision
@@ -1490,6 +1516,8 @@ spec:
               - startedAt
               type: object
             reconciledAt:
+              description: ReconciledAt indicates when the application state was reconciled
+                using the latest git version
               format: date-time
               type: string
             resources:
@@ -1553,6 +1581,9 @@ spec:
                       type: object
                     source:
                       properties:
+                        chart:
+                          description: Chart is a Helm chart name
+                          type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
@@ -1624,6 +1655,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            values:
+                              description: Values is Helm values, typically defined
+                                as a block
+                              type: string
                           type: object
                         ksonnet:
                           description: Ksonnet holds ksonnet specific options
@@ -1669,8 +1704,7 @@ spec:
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the repository
-                            containing a
+                          description: Path is a directory path within the Git repository
                           type: string
                         plugin:
                           description: ConfigManagementPlugin holds config management
@@ -1694,7 +1728,7 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the git repository URL of the application
+                          description: RepoURL is the repository URL of the application
                             manifests
                           type: string
                         targetRevision:
@@ -1704,7 +1738,6 @@ spec:
                           type: string
                       required:
                       - repoURL
-                      - path
                       type: object
                   required:
                   - source
@@ -1726,3 +1759,4 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+{{- end }}

--- a/charts/argo-cd/templates/crds/appproject-crd.yaml
+++ b/charts/argo-cd/templates/crds/appproject-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -434,6 +435,15 @@ spec:
                 - kind
                 type: object
               type: array
+            orphanedResources:
+              description: OrphanedResources specifies if controller should monitor
+                orphaned resources of apps in this project
+              properties:
+                warn:
+                  description: Warn indicates if warning condition should be created
+                    for apps which have orphaned resources
+                  type: boolean
+              type: object
             roles:
               description: Roles are user defined RBAC roles associated with this
                 project
@@ -477,10 +487,50 @@ spec:
                 type: object
               type: array
             sourceRepos:
-              description: SourceRepos contains list of git repository URLs which
-                can be used for deployment
+              description: SourceRepos contains list of repository URLs which can
+                be used for deployment
               items:
                 type: string
+              type: array
+            syncWindows:
+              description: SyncWindows controls when syncs can be run for apps in
+                this project
+              items:
+                properties:
+                  applications:
+                    description: Applications contains a list of applications that
+                      the window will apply to
+                    items:
+                      type: string
+                    type: array
+                  clusters:
+                    description: Clusters contains a list of clusters that the window
+                      will apply to
+                    items:
+                      type: string
+                    type: array
+                  duration:
+                    description: Duration is the amount of time the sync window will
+                      be open
+                    type: string
+                  kind:
+                    description: Kind defines if the window allows or blocks syncs
+                    type: string
+                  manualSync:
+                    description: ManualSync enables manual syncs when they would otherwise
+                      be blocked
+                    type: boolean
+                  namespaces:
+                    description: Namespaces contains a list of namespaces that the
+                      window will apply to
+                    items:
+                      type: string
+                    type: array
+                  schedule:
+                    description: Schedule is the time the window will begin, specified
+                      in cron format
+                    type: string
+                type: object
               type: array
           type: object
       required:
@@ -491,3 +541,4 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+{{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       initContainers:
       - name: copyutil
         image: {{ default .Values.global.image.repository .Values.dex.initImage.repository }}:{{ default .Values.global.image.tag .Values.dex.initImage.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.initImage.pullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.initImage.imagePullPolicy }}
         command:
         - cp
         - /usr/local/bin/argocd-util

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -338,6 +338,12 @@ server:
     #     sshPrivateKeySecret:
     #       name: secret-name
     #       key: sshPrivateKey
+    #   - type: helm
+    #     url: https://kubernetes-charts.storage.googleapis.com
+    #     name: stable
+    #   - type: helm
+    #     url: https://argoproj.github.io/argo-helm
+    #     name: argo
     # oidc.config: |
     #   name: AzureAD
     #   issuer: https://login.microsoftonline.com/TENANT_ID/v2.0

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2,21 +2,25 @@
 ## Ref: https://github.com/argoproj/argo-cd
 ##
 nameOverride: argocd
+fullnameOverride: ""
+
+# Optional CRD installation for those without Helm hooks
+installCRDs: true
 
 global:
   image:
     repository: argoproj/argocd
-    tag: v1.2.4
+    tag: v1.3.0
     imagePullPolicy: IfNotPresent
 
 ## Controller
 controller:
   name: application-controller
 
-  image: {}
-  #  repository: argoproj/argocd
-  #  tag: v1.2.1
-  #  imagePullPolicy: IfNotPresent
+  image:
+    repository: # argoproj/argocd
+    tag: # v1.3.0
+    imagePullPolicy: # IfNotPresent
 
   ## Argo controller commandline flags
   args:
@@ -118,7 +122,10 @@ dex:
     repository: quay.io/dexidp/dex
     tag: v2.14.0
     imagePullPolicy: IfNotPresent
-  initImage: {}
+  initImage:
+    repository:
+    tag:
+    imagePullPolicy:
 
   serviceAccount:
     create: true
@@ -187,14 +194,17 @@ redis:
   #    cpu: 100m
   #    memory: 64Mi
 
+  volumeMounts: []
+  volumes: []
+
 ## Server
 server:
   name: server
 
-  image: {}
-  #  repository: argoproj/argocd
-  #  tag: v1.2.1
-  #  imagePullPolicy: IfNotPresent
+  image:
+    repository: # argoproj/argocd
+    tag: # v1.3.0
+    imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-server
   ## - key: value
@@ -297,11 +307,13 @@ server:
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace
     ##
-    hosts: []
+    hosts:
+      []
       # - argocd.example.com
     paths:
-    - /
-    tls: []
+      - /
+    tls:
+      []
       # - secretName: argocd-example-tls
       #   hosts:
       #     - argocd.example.com
@@ -321,10 +333,28 @@ server:
     url: https://argocd.example.com
     # Argo CD instance label key
     application.instanceLabelKey: argocd.argoproj.io/instance
+    # repositories: |
+    #   - url: git@github.com:group/repo.git
+    #     sshPrivateKeySecret:
+    #       name: secret-name
+    #       key: sshPrivateKey
+    # oidc.config: |
+    #   name: AzureAD
+    #   issuer: https://login.microsoftonline.com/TENANT_ID/v2.0
+    #   clientID: CLIENT_ID
+    #   clientSecret: $oidc.azuread.clientSecret
+    #   requestedIDTokenClaims:
+    #     groups:
+    #       essential: true
+    #   requestedScopes:
+    #     - openid
+    #     - profile
+    #     - email
 
   ## ArgoCD rbac config
   ## reference https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/rbac.md
-  rbacConfig: {}
+  rbacConfig:
+    {}
     # policy.csv is an file containing user-defined RBAC policies and role definitions (optional).
     # Policy rules are in the form:
     #   p, subject, resource, action, object, effect
@@ -340,7 +370,6 @@ server:
     # authorizing API requests (optional). If omitted or empty, users may be still be able to login,
     # but will see no apps, projects, etc...
     # policy.default: role:readonly
-
     # scopes controls which OIDC scopes to examine during rbac enforcement (in addition to `sub` scope).
     # If omitted, defaults to: '[groups]'. The scope value can be a string, or a list of strings.
     # scopes: '[cognito:groups, email]'
@@ -398,10 +427,10 @@ server:
 repoServer:
   name: repo-server
 
-  image: {}
-  #  repository: argoproj/argocd
-  #  tag: v1.2.1
-  #  imagePullPolicy: IfNotPresent
+  image:
+    repository: # argoproj/argocd
+    tag: # v1.3.0
+    imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-repo-server
   ## - key: value
@@ -492,7 +521,8 @@ configs:
         gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
         ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
         vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
-  tlsCerts: {}
+  tlsCerts:
+    {}
     # data:
     #   argocd.example.com: |
     #     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
This bumps the version of ArgoCD to 1.3 and the chart version to 1.1 due
to a CRD change. Restored conditional CRDs to correct #27. Additionally,
 some value defaults were added so Helm strict linting could pass.

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.