### PR TITLE
Fix delete crd command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Clean-up:
 
 ```
 helm delete argo-cd --purge
-kubectl delete crd -l app.kubernetes.io/part-of=argo-cd
+kubectl delete crd -l app.kubernetes.io/part-of=argocd
 ```
 
 Minimally:


### PR DESCRIPTION
The part-of is incorrect compared to the argo-cd helm chart, which
installs this crd as a part of argocd (without the dash).

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.