### PR TITLE
Correct the values.yaml comment for extra arg

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.1
+version: 1.2.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.0
+version: 1.2.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -31,7 +31,7 @@ controller:
   logLevel: info
 
   ## Additional command line arguments to pass to argocd-controller
-  ## - key: value
+  ## key: value
   extraArgs: []
 
   ## Annotations to be added to controller pods
@@ -207,9 +207,9 @@ server:
     imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-server
-  ## - key: value
+  ## key: value
   # extraArgs: []
-  #   - insecure: true
+  #   insecure: true
   extraArgs: []
 
   ## Argo server log level
@@ -439,7 +439,7 @@ repoServer:
     imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-repo-server
-  ## - key: value
+  ## key: value
   extraArgs: []
 
   ## Argo repoServer log level


### PR DESCRIPTION
Extra arg handling changed in v1 release #129 , and expects map rather than list.
Just updating the comment to align with that expectation.

With the previous doc, I got the following in deployment:

```
      containers:
      - command:
        - argocd-server
        ...
        - --0=map[insecure:true]
        image: argoproj/argocd:v1.3.0
```

And got a straight error when a pod started:

```
time="2019-11-25T11:24:29Z" level=fatal msg="unknown flag: --0"
```

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.