### PR TITLE
Allow custom tools for argo-cd in helm chart

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.2
+version: 1.2.5
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.5
+version: 1.2.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.3
+version: 1.4.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- if .Values.repoServer.volumeMounts }}
-{{- toYaml .Values.repoServer.volumeMounts | nindent 10}}
+{{- toYaml .Values.repoServer.volumeMounts | nindent 8}}
         {{- end }}
         {{- if .Values.configs.knownHosts }}
         - mountPath: /app/config/ssh
@@ -108,7 +108,7 @@ spec:
       serviceAccountName: {{ template "argo-cd.repoServerServiceAccountName" . }}
       volumes:
       {{- if .Values.repoServer.volumes }}
-{{- toYaml .Values.repoServer.volumes | nindent 8}}
+{{- toYaml .Values.repoServer.volumes | nindent 6}}
       {{- end }}
       {{- if .Values.configs.knownHosts }}
       - configMap:
@@ -119,4 +119,8 @@ spec:
       - configMap:
           name: argocd-tls-certs-cm
         name: tls-certs
+      {{- end }}
+      {{- if .Values.repoServer.initContainers }}
+      initContainers:
+{{- toYaml .Values.repoServer.initContainers | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -536,6 +536,7 @@ repoServer:
 
   ## Use init containers to configure custom tooling
   ## https://argoproj.github.io/argo-cd/operator-manual/custom_tools/
+  ## When using the volumes & volumeMounts section bellow, please comment out those above.
  #  volumes:
  #  - name: custom-tools
  #    emptyDir: {}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -534,6 +534,10 @@ repoServer:
  #     - list
  #     - watch
 
+  ## Use init containers to configure custom tooling
+  ## https://argoproj.github.io/argo-cd/operator-manual/custom_tools/
+ #  initContainers:
+
 ## Argo Configs
 configs:
   knownHosts:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -536,7 +536,24 @@ repoServer:
 
   ## Use init containers to configure custom tooling
   ## https://argoproj.github.io/argo-cd/operator-manual/custom_tools/
+ #  volumes:
+ #  - name: custom-tools
+ #    emptyDir: {}
+ #
  #  initContainers:
+ #  - name: download-tools
+ #    image: alpine:3.8
+ #    command: [sh, -c]
+ #    args:
+ #      - wget -qO- https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz | tar -xvzf - &&
+ #        mv linux-amd64/helm /custom-tools/
+ #    volumeMounts:
+ #      - mountPath: /custom-tools
+ #        name: custom-tools
+ #  volumeMounts:
+ #  - mountPath: /usr/local/bin/helm
+ #    name: custom-tools
+ #    subPath: helm
 
 ## Argo Configs
 configs:


### PR DESCRIPTION
This pull request allows the configuration of custom tooling as described in https://argoproj.github.io/argo-cd/operator-manual/custom_tools/ .

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.