### PR TITLE
[argo-cd] Added simple PrometheusRule

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.2
+version: 1.4.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.rules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "argo-cd.controller.fullname" . }}
+  {{- if .Values.controller.metrics.rules.namespace }}
+  namespace: {{ .Values.controller.metrics.rules.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.controller.name }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: {{ .Values.controller.name }}
+{{- toYaml .Values.controller.metrics.rules.selector | nindent 4 }}
+    {{- if .Values.controller.metrics.rules.additionalLabels }}
+{{- toYaml .Values.controller.metrics.rules.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: argocd
+    rules:
+{{- toYaml .Values.controller.metrics.rules.spec | nindent 4 }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
@@ -13,7 +13,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
+    {{- if .Values.controller.metrics.rules.selector }}
 {{- toYaml .Values.controller.metrics.rules.selector | nindent 4 }}
+    {{- end }}
     {{- if .Values.controller.metrics.rules.additionalLabels }}
 {{- toYaml .Values.controller.metrics.rules.additionalLabels | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -107,6 +107,37 @@ controller:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
     #   additionalLabels: {}
+    rules:
+      enabled: false
+      spec:
+      - alert: ArgoAppMissing
+        expr: |
+          absent(argocd_app_info)
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "[ArgoCD] No reported applications"
+          description: >
+            ArgoCD has not reported any applications data for the past 15 minutes which
+            means that it must be down or not functioning properly.  This needs to be
+            resolved for this cloud to continue to maintain state.
+      - alert: ArgoAppNotSynced
+        expr: |
+          argocd_app_sync_status{sync_status!="Synced"} == 1
+        for: 12h
+        labels:
+          severity: warning
+        annotations:
+          summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
+          description: >
+            The application [{{`{{$labels.name}}`}} has not been synchronized for over
+            12 hours which means that the state of this cloud has drifted away from the
+            state inside Git.
+    #   selector:
+    #     prometheus: kube-prometheus
+    #   namespace: monitoring
+    #   additionalLabels: {}
 
   ## Enable Admin ClusterRole resources.
   ## Enable if you would like to grant rights to ArgoCD to deploy to the local kuberentes cluster.

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -113,31 +113,31 @@ controller:
     #   additionalLabels: {}
     rules:
       enabled: false
-      spec:
-      - alert: ArgoAppMissing
-        expr: |
-          absent(argocd_app_info)
-        for: 15m
-        labels:
-          severity: critical
-        annotations:
-          summary: "[ArgoCD] No reported applications"
-          description: >
-            ArgoCD has not reported any applications data for the past 15 minutes which
-            means that it must be down or not functioning properly.  This needs to be
-            resolved for this cloud to continue to maintain state.
-      - alert: ArgoAppNotSynced
-        expr: |
-          argocd_app_sync_status{sync_status!="Synced"} == 1
-        for: 12h
-        labels:
-          severity: warning
-        annotations:
-          summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
-          description: >
-            The application [{{`{{$labels.name}}`}} has not been synchronized for over
-            12 hours which means that the state of this cloud has drifted away from the
-            state inside Git.
+      spec: []
+      # - alert: ArgoAppMissing
+      #   expr: |
+      #     absent(argocd_app_info)
+      #   for: 15m
+      #   labels:
+      #     severity: critical
+      #   annotations:
+      #     summary: "[ArgoCD] No reported applications"
+      #     description: >
+      #       ArgoCD has not reported any applications data for the past 15 minutes which
+      #       means that it must be down or not functioning properly.  This needs to be
+      #       resolved for this cloud to continue to maintain state.
+      # - alert: ArgoAppNotSynced
+      #   expr: |
+      #     argocd_app_sync_status{sync_status!="Synced"} == 1
+      #   for: 12h
+      #   labels:
+      #     severity: warning
+      #   annotations:
+      #     summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
+      #     description: >
+      #       The application [{{`{{$labels.name}}`}} has not been synchronized for over
+      #       12 hours which means that the state of this cloud has drifted away from the
+      #       state inside Git.
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring


### PR DESCRIPTION
This patch adds a few simple rules which you can leverage to make
sure that your infrastructure is up to date.  They are optional
and opt-in only.

There is not a lot of customization initially but this is a start
of a simple framework to deliver this.


Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.