### PR TITLE
[charts/argo-cd] Fix servicemonitors

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.2.2
+version: 1.2.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -32,3 +32,4 @@ spec:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-metrics
       app.kubernetes.io/component: {{ .Values.controller.name }}
 {{- end }}
+

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -13,7 +13,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.controller.name }}
+    {{- if .Values.controller.metrics.serviceMonitor.selector }}
 {{- toYaml .Values.controller.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- end }}
     {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
 {{- toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -13,7 +13,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.repoServer.name }}
+    {{- if .Values.repoServer.metrics.serviceMonitor.selector }}
 {{- toYaml .Values.repoServer.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- end }}
     {{- if .Values.repoServer.metrics.serviceMonitor.additionalLabels }}
 {{- toYaml .Values.repoServer.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -33,3 +33,4 @@ spec:
       app.kubernetes.io/name: {{ template "argo-cd.repoServer.fullname" . }}-metrics
       app.kubernetes.io/component: {{ .Values.repoServer.name }}
 {{- end }}
+

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -13,7 +13,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
+    {{- if .Values.server.metrics.serviceMonitor.selector }}
 {{- toYaml .Values.server.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- end }}
     {{- if .Values.server.metrics.serviceMonitor.additionalLabels }}
 {{- toYaml .Values.server.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -33,3 +33,4 @@ spec:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}-metrics
       app.kubernetes.io/component: {{ .Values.server.name }}
 {{- end }}
+


### PR DESCRIPTION
Why do we need it:

When I enable Metrics and run `helm template ./` i receive next template 

```
---
# Source: argo-cd/templates/argocd-server/servicemonitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-argocd-server
  labels:
    app.kubernetes.io/name: argocd-server
    helm.sh/chart: argo-cd-1.2.2
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Tiller
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/component: server
    null

spec:
  endpoints:
    - port: metrics
      interval: 30s
      path: /metrics
  namespaceSelector:
    matchNames:
      - default
  selector:
    matchLabels:
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/name: argocd-server-metrics
      app.kubernetes.io/component: server
---
```

`null` is incorrect 

Also when I try to install or upgrade my release I receive error. 

```
UPGRADE FAILED
Error: YAML parse error on argo-cd/templates/argocd-server/servicemonitor.yaml: error converting YAML to JSON: yaml: line 14: could not find expected ':'
Error: UPGRADE FAILED: YAML parse error on argo-cd/templates/argocd-server/servicemonitor.yaml: error converting YAML to JSON: yaml: line 14: could not find expected ':'
```

I have found reason of this issue and made current PR. 

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.