### PR TITLE
feat: Add securityContext. Fixes #96

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.4.5
+version: 1.5.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -32,6 +32,7 @@ $ helm install --name my-release argo/argo-cd
 | global.image.imagePullPolicy | If defined, a imagePullPolicy applied to all ArgoCD deployments. | `"IfNotPresent"` |
 | global.image.repository | If defined, a repository applied to all ArgoCD deployments. | `"argoproj/argocd"` |
 | global.image.tag | If defined, a tag applied to all ArgoCD deployments. | `"v1.2.3"` |
+| global.securityContext | Toggle and define securityContext | See [values.yaml](values.yaml) | 
 | nameOverride | Provide a name in place of `argocd` | `"argocd"` |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
 | configs.secret.bitbucketSecret | BitBucket incoming webhook secret | `""` |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -35,7 +35,9 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - command:
         - argocd-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       containers:
       - command:
         - argocd-application-controller

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.global.securityContext.enabled }}
+      {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.securityContext.enabled }}
+      {{- if .Values.global.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -35,7 +35,9 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.repoServer.name }}
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default .Values.global.image.tag .Values.repoServer.image.tag }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       containers:
       - name: {{ .Values.repoServer.name }}
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default .Values.global.image.tag .Values.repoServer.image.tag }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.global.securityContext.enabled }}
+      {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.securityContext.enabled }}
+      {{- if .Values.global.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       containers:
       - name: {{ .Values.server.name }}
         image: {{ default .Values.global.image.repository .Values.server.image.repository }}:{{ default .Values.global.image.tag .Values.server.image.tag }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -35,7 +35,9 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.server.name }}
         image: {{ default .Values.global.image.repository .Values.server.image.repository }}:{{ default .Values.global.image.tag .Values.server.image.tag }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.global.securityContext.enabled }}
+      {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.securityContext.enabled }}
+      {{- if .Values.global.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: {{ .Values.redis.name }}
     spec:
       automountServiceAccountToken: false
-      {{- if .Values.global.securityContext.enabled }}
+      {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         app.kubernetes.io/component: {{ .Values.redis.name }}
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "argo-cd.redis.fullname" . }}
         args:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: {{ .Values.redis.name }}
     spec:
       automountServiceAccountToken: false
+      securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       containers:
       - name: {{ template "argo-cd.redis.fullname" . }}
         args:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: {{ .Values.redis.name }}
     spec:
       automountServiceAccountToken: false
-      {{- if .Values.securityContext.enabled }}
+      {{- if .Values.global.securityContext.enabled }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -12,6 +12,10 @@ global:
     repository: argoproj/argocd
     tag: v1.3.4
     imagePullPolicy: IfNotPresent
+  securityContext:
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
 
 ## Controller
 controller:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -13,6 +13,7 @@ global:
     tag: v1.3.4
     imagePullPolicy: IfNotPresent
   securityContext:
+    enabled: true
     runAsUser: 999
     runAsGroup: 999
     fsGroup: 999

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -12,11 +12,10 @@ global:
     repository: argoproj/argocd
     tag: v1.3.4
     imagePullPolicy: IfNotPresent
-  securityContext:
-    enabled: true
-    runAsUser: 999
-    runAsGroup: 999
-    fsGroup: 999
+  securityContext: {}
+  #  runAsUser: 999
+  #  runAsGroup: 999
+  #  fsGroup: 999
 
 ## Controller
 controller:


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

Adds security-context.
I wonder if it makes sense to reuse some other charts for dex / redis to avoid reinventing the wheel for these?

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/argoproj/argo-helm/185)
<!-- Reviewable:end -->
