### PR TITLE
fix: Update Argo icon URL for the Helm charts

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 appVersion: "1.3.6"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.5.0
+version: 1.5.1
 home: https://github.com/argoproj/argo-helm
-icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:
   - argoproj
   - argocd

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.6"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.5.1
+version: 1.5.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Argo-CI
 name: argo-ci
-version: 0.1.5
-icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+version: 0.1.6
+icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 appVersion: v1.0.0-alpha2
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.6.0
+version: 0.6.1
 keywords:
   - argo-events
   - sensor-controller
@@ -12,5 +12,5 @@ maintainers:
   - name: VaibhavPage
   - name: magaldima
 appVersion: 0.11
-icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 appVersion: "v2.4.3"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.6.4
-icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+version: 0.6.5
+icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
   - name: alexec


### PR DESCRIPTION
The path to the argo.png image has changed in
the Argo repository.

The helm charts icon URL still points to the
old URL which is invalid. The image has moved
from /argo.png to /docs/assets/argo.png.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.