### PR TITLE
Allow manually setting password modification time

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.0"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.6.4
+version: 1.7.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -41,6 +41,8 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | nameOverride | Provide a name in place of `argocd` | `"argocd"` |
 | installCRDs | bool | `true` | Install CRDs if you are using Helm2. |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
+| configs.secret.argocdServerAdminPassword | Admin password | `null` |
+| configs.secret.argocdServerAdminPasswordMtime | Admin password modification time | `date "2006-01-02T15:04:05Z" now` if configs.secret.argocdServerAdminPassword is set |
 | configs.secret.bitbucketSecret | BitBucket incoming webhook secret | `""` |
 | configs.secret.createSecret | Create the argocd-secret. | `true` |
 | configs.secret.githubSecret | GitHub incoming webhook secret | `""` |

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -35,7 +35,7 @@ data:
   {{- end }}
   {{- if .Values.configs.secret.argocdServerAdminPassword }}
   admin.password: {{ .Values.configs.secret.argocdServerAdminPassword | b64enc }}
-  admin.passwordMtime: {{ date "2006-01-02T15:04:05Z" now | b64enc }}
+  admin.passwordMtime: {{ default (date "2006-01-02T15:04:05Z" now) .Values.configs.secret.argocdServerAdminPasswordMtime | b64enc }}
   {{- end }}
   {{- range $key, $value := .Values.configs.secret.extra }}
   {{ $key }}: {{ $value | b64enc }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -742,3 +742,5 @@ configs:
     # Argo expects the password in the secret to be bcrypt hashed. You can create this hash with
     # `htpasswd -nbBC 10 "" $ARGO_PWD | tr -d ':\n' | sed 's/$2y/$2a/'`
     # argocdServerAdminPassword:
+    # Password modification time defaults to current time if not set
+    # argocdServerAdminPasswordMtime: "2006-01-02T15:04:05Z"


### PR DESCRIPTION
Automatically setting password modification time to the current time leads to
it changing every time the chart is rendered. Ironically, this is a problem
when Argo CD manages itself using this chart ;-)

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.