### PR TITLE
fix: remove spec.subdomain field from OpenShift route

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.6"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.6.2
+version: 1.6.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/route.yaml
+++ b/charts/argo-cd/templates/argocd-server/route.yaml
@@ -16,7 +16,6 @@ metadata:
 {{- end }}
 spec:
   host: {{ .Values.server.route.hostname | quote }}
-  subdomain: ''
   to:
     kind: Service
     name: {{ template "argo-cd.server.fullname" . }}


### PR DESCRIPTION
This spec.subdomain field is not part of OpenShift 3.11 route OpenAPI
specification and since it's empty it can safely be removed without impacting
OpenShift 4.

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.