### PR TITLE
feat: Make server component replicas configurable

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.7.1
+version: 1.7.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.repoServer.name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   revisionHistoryLimit: 5
-  replicas: 1
+  replicas: {{ .Values.repoServer.replicas }}
   template:
     metadata:
       {{- if .Values.repoServer.podAnnotations }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   revisionHistoryLimit: 5
-  replicas: 1
+  replicas: {{ .Values.server.replicas }}
   template:
     metadata:
       {{- if .Values.server.podAnnotations }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -268,6 +268,8 @@ redis:
 server:
   name: server
 
+  replicas: 1
+
   image:
     repository: # argoproj/argocd
     tag: # v1.4.2
@@ -508,6 +510,8 @@ server:
 ## Repo Server
 repoServer:
   name: repo-server
+
+  replicas: 1
 
   image:
     repository: # argoproj/argocd


### PR DESCRIPTION
The official Argo-CD HA manifests do not scale the dex server
or the application controller past 1 because they still have
local caches and cannot support more than one pod at a time

Signed-off-by: Carson Anderson <ca@carsonoid.net>

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.