### PR TITLE
feat: Add chart for argo-rollouts

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "0.7"
+description: A Helm chart for Argo Rollouts
+name: argo-rollouts
+version: 0.1.0
+icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+home: https://github.com/argoproj/argo-helm
+maintainers:
+  - name: alexmt
+  - name: dthomson25
+  - name: jessesuen

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argo-rollouts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "argo-rollouts.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argo-rollouts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
@@ -1,0 +1,77 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-aggregate-to-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-view
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - experiments
+  - analysistemplates
+  - analysisruns
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-aggregate-to-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-edit
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - experiments
+  - analysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-aggregate-to-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-admin
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  - experiments
+  - analysistemplates
+  - analysisruns
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.clusterInstall }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-clusterrole
+  labels:
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/name: {{ .Release.Name }}-clusterrole
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns
+  - experiments
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysistemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - watch
+  - get
+  - update
+{{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrolebinding.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.clusterInstall }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-clusterrolebinding
+  labels:
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/name: {{ .Release.Name }}-clusterrolebinding
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+      - command:
+        - "/bin/rollouts-controller"
+        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        name: {{ .Values.controller.name }}
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+  strategy:
+    type: Recreate

--- a/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metrics
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: {{ .Release.Name }}-metrics
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+spec:
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 8090
+    targetPort: 8090
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}

--- a/charts/argo-rollouts/templates/argo-rollouts-role.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-role.yaml
@@ -1,0 +1,87 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-role
+  labels:
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/name: {{ .Release.Name }}-role
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns
+  - experiments
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysistemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get

--- a/charts/argo-rollouts/templates/argo-rollouts-rolebinding.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-role-binding
+  labels:
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/name: {{ .Release.Name }}-role-binding
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}

--- a/charts/argo-rollouts/templates/argo-rollouts-sa.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -1,0 +1,2726 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: analysisruns.argoproj.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: AnalysisRun status
+    name: Status
+    type: string
+  group: argoproj.io
+  names:
+    kind: AnalysisRun
+    listKind: AnalysisRunList
+    plural: analysisruns
+    singular: analysisrun
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            args:
+              items:
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            metrics:
+              items:
+                properties:
+                  consecutiveErrorLimit:
+                    format: int32
+                    type: integer
+                  count:
+                    format: int32
+                    type: integer
+                  failureCondition:
+                    type: string
+                  failureLimit:
+                    format: int32
+                    type: integer
+                  inconclusiveLimit:
+                    format: int32
+                    type: integer
+                  initialDelay:
+                    type: string
+                  interval:
+                    type: string
+                  name:
+                    type: string
+                  provider:
+                    properties:
+                      job:
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              backoffLimit:
+                                format: int32
+                                type: integer
+                              completions:
+                                format: int32
+                                type: integer
+                              manualSelector:
+                                type: boolean
+                              parallelism:
+                                format: int32
+                                type: integer
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              template:
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    properties:
+                                      activeDeadlineSeconds:
+                                        format: int64
+                                        type: integer
+                                      affinity:
+                                        properties:
+                                          nodeAffinity:
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    preference:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    items:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      automountServiceAccountToken:
+                                        type: boolean
+                                      containers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      dnsConfig:
+                                        properties:
+                                          nameservers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          options:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          searches:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      dnsPolicy:
+                                        type: string
+                                      enableServiceLinks:
+                                        type: boolean
+                                      ephemeralContainers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            targetContainerName:
+                                              type: string
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      hostAliases:
+                                        items:
+                                          properties:
+                                            hostnames:
+                                              items:
+                                                type: string
+                                              type: array
+                                            ip:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      hostIPC:
+                                        type: boolean
+                                      hostNetwork:
+                                        type: boolean
+                                      hostPID:
+                                        type: boolean
+                                      hostname:
+                                        type: string
+                                      imagePullSecrets:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      initContainers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      nodeName:
+                                        type: string
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      overhead:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      preemptionPolicy:
+                                        type: string
+                                      priority:
+                                        format: int32
+                                        type: integer
+                                      priorityClassName:
+                                        type: string
+                                      readinessGates:
+                                        items:
+                                          properties:
+                                            conditionType:
+                                              type: string
+                                          required:
+                                          - conditionType
+                                          type: object
+                                        type: array
+                                      restartPolicy:
+                                        type: string
+                                      runtimeClassName:
+                                        type: string
+                                      schedulerName:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          fsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          supplementalGroups:
+                                            items:
+                                              format: int64
+                                              type: integer
+                                            type: array
+                                          sysctls:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      serviceAccount:
+                                        type: string
+                                      serviceAccountName:
+                                        type: string
+                                      shareProcessNamespace:
+                                        type: boolean
+                                      subdomain:
+                                        type: string
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      tolerations:
+                                        items:
+                                          properties:
+                                            effect:
+                                              type: string
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            tolerationSeconds:
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      topologySpreadConstraints:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            maxSkew:
+                                              format: int32
+                                              type: integer
+                                            topologyKey:
+                                              type: string
+                                            whenUnsatisfiable:
+                                              type: string
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          type: object
+                                        type: array
+                                      volumes:
+                                        items:
+                                          properties:
+                                            awsElasticBlockStore:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  format: int32
+                                                  type: integer
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                              required:
+                                              - volumeID
+                                              type: object
+                                            azureDisk:
+                                              properties:
+                                                cachingMode:
+                                                  type: string
+                                                diskName:
+                                                  type: string
+                                                diskURI:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - diskName
+                                              - diskURI
+                                              type: object
+                                            azureFile:
+                                              properties:
+                                                readOnly:
+                                                  type: boolean
+                                                secretName:
+                                                  type: string
+                                                shareName:
+                                                  type: string
+                                              required:
+                                              - secretName
+                                              - shareName
+                                              type: object
+                                            cephfs:
+                                              properties:
+                                                monitors:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretFile:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                user:
+                                                  type: string
+                                              required:
+                                              - monitors
+                                              type: object
+                                            cinder:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                volumeID:
+                                                  type: string
+                                              required:
+                                              - volumeID
+                                              type: object
+                                            csi:
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                nodePublishSecretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                readOnly:
+                                                  type: boolean
+                                                volumeAttributes:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              required:
+                                              - driver
+                                              type: object
+                                            emptyDir:
+                                              properties:
+                                                medium:
+                                                  type: string
+                                                sizeLimit:
+                                                  type: string
+                                              type: object
+                                            fc:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                lun:
+                                                  format: int32
+                                                  type: integer
+                                                readOnly:
+                                                  type: boolean
+                                                targetWWNs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                wwids:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            flexVolume:
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                options:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                              required:
+                                              - driver
+                                              type: object
+                                            flocker:
+                                              properties:
+                                                datasetName:
+                                                  type: string
+                                                datasetUUID:
+                                                  type: string
+                                              type: object
+                                            gcePersistentDisk:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  format: int32
+                                                  type: integer
+                                                pdName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - pdName
+                                              type: object
+                                            gitRepo:
+                                              properties:
+                                                directory:
+                                                  type: string
+                                                repository:
+                                                  type: string
+                                                revision:
+                                                  type: string
+                                              required:
+                                              - repository
+                                              type: object
+                                            glusterfs:
+                                              properties:
+                                                endpoints:
+                                                  type: string
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - endpoints
+                                              - path
+                                              type: object
+                                            hostPath:
+                                              properties:
+                                                path:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            iscsi:
+                                              properties:
+                                                chapAuthDiscovery:
+                                                  type: boolean
+                                                chapAuthSession:
+                                                  type: boolean
+                                                fsType:
+                                                  type: string
+                                                initiatorName:
+                                                  type: string
+                                                iqn:
+                                                  type: string
+                                                iscsiInterface:
+                                                  type: string
+                                                lun:
+                                                  format: int32
+                                                  type: integer
+                                                portals:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                targetPortal:
+                                                  type: string
+                                              required:
+                                              - iqn
+                                              - lun
+                                              - targetPortal
+                                              type: object
+                                            name:
+                                              type: string
+                                            nfs:
+                                              properties:
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                server:
+                                                  type: string
+                                              required:
+                                              - path
+                                              - server
+                                              type: object
+                                            persistentVolumeClaim:
+                                              properties:
+                                                claimName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - claimName
+                                              type: object
+                                            photonPersistentDisk:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                pdID:
+                                                  type: string
+                                              required:
+                                              - pdID
+                                              type: object
+                                            portworxVolume:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                              required:
+                                              - volumeID
+                                              type: object
+                                            projected:
+                                              properties:
+                                                defaultMode:
+                                                  format: int32
+                                                  type: integer
+                                                sources:
+                                                  items:
+                                                    properties:
+                                                      serviceAccountToken:
+                                                        properties:
+                                                          audience:
+                                                            type: string
+                                                          expirationSeconds:
+                                                            format: int64
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                        required:
+                                                        - path
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                              required:
+                                              - sources
+                                              type: object
+                                            quobyte:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                registry:
+                                                  type: string
+                                                tenant:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                                volume:
+                                                  type: string
+                                              required:
+                                              - registry
+                                              - volume
+                                              type: object
+                                            rbd:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                image:
+                                                  type: string
+                                                keyring:
+                                                  type: string
+                                                monitors:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                pool:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                user:
+                                                  type: string
+                                              required:
+                                              - image
+                                              - monitors
+                                              type: object
+                                            scaleIO:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                gateway:
+                                                  type: string
+                                                protectionDomain:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                sslEnabled:
+                                                  type: boolean
+                                                storageMode:
+                                                  type: string
+                                                storagePool:
+                                                  type: string
+                                                system:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - gateway
+                                              - secretRef
+                                              - system
+                                              type: object
+                                            storageos:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                volumeName:
+                                                  type: string
+                                                volumeNamespace:
+                                                  type: string
+                                              type: object
+                                            vsphereVolume:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                storagePolicyID:
+                                                  type: string
+                                                storagePolicyName:
+                                                  type: string
+                                                volumePath:
+                                                  type: string
+                                              required:
+                                              - volumePath
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                    required:
+                                    - containers
+                                    type: object
+                                type: object
+                              ttlSecondsAfterFinished:
+                                format: int32
+                                type: integer
+                            required:
+                            - template
+                            type: object
+                        required:
+                        - spec
+                        type: object
+                      kayenta:
+                        properties:
+                          address:
+                            type: string
+                          application:
+                            type: string
+                          canaryConfigName:
+                            type: string
+                          configurationAccountName:
+                            type: string
+                          metricsAccountName:
+                            type: string
+                          scopes:
+                            items:
+                              properties:
+                                controlScope:
+                                  properties:
+                                    end:
+                                      type: string
+                                    region:
+                                      type: string
+                                    scope:
+                                      type: string
+                                    start:
+                                      type: string
+                                    step:
+                                      type: integer
+                                  required:
+                                  - end
+                                  - region
+                                  - scope
+                                  - start
+                                  - step
+                                  type: object
+                                experimentScope:
+                                  properties:
+                                    end:
+                                      type: string
+                                    region:
+                                      type: string
+                                    scope:
+                                      type: string
+                                    start:
+                                      type: string
+                                    step:
+                                      type: integer
+                                  required:
+                                  - end
+                                  - region
+                                  - scope
+                                  - start
+                                  - step
+                                  type: object
+                                name:
+                                  type: string
+                              required:
+                              - controlScope
+                              - experimentScope
+                              - name
+                              type: object
+                            type: array
+                          storageAccountName:
+                            type: string
+                          threshold:
+                            properties:
+                              marginal:
+                                type: integer
+                              pass:
+                                type: integer
+                            required:
+                            - marginal
+                            - pass
+                            type: object
+                        required:
+                        - address
+                        - application
+                        - canaryConfigName
+                        - configurationAccountName
+                        - metricsAccountName
+                        - scopes
+                        - storageAccountName
+                        - threshold
+                        type: object
+                      prometheus:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
+                      wavefront:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
+                      web:
+                        properties:
+                          headers:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - key
+                              - value
+                              type: object
+                            type: array
+                          jsonPath:
+                            type: string
+                          timeoutSeconds:
+                            type: integer
+                          url:
+                            type: string
+                        required:
+                        - jsonPath
+                        - url
+                        type: object
+                    type: object
+                  successCondition:
+                    type: string
+                required:
+                - name
+                - provider
+                type: object
+              type: array
+            terminate:
+              type: boolean
+          required:
+          - metrics
+          type: object
+        status:
+          properties:
+            message:
+              type: string
+            metricResults:
+              items:
+                properties:
+                  consecutiveError:
+                    format: int32
+                    type: integer
+                  count:
+                    format: int32
+                    type: integer
+                  error:
+                    format: int32
+                    type: integer
+                  failed:
+                    format: int32
+                    type: integer
+                  inconclusive:
+                    format: int32
+                    type: integer
+                  measurements:
+                    items:
+                      properties:
+                        finishedAt:
+                          format: date-time
+                          type: string
+                        message:
+                          type: string
+                        metadata:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        phase:
+                          type: string
+                        resumeAt:
+                          format: date-time
+                          type: string
+                        startedAt:
+                          format: date-time
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - phase
+                      type: object
+                    type: array
+                  message:
+                    type: string
+                  name:
+                    type: string
+                  phase:
+                    type: string
+                  successful:
+                    format: int32
+                    type: integer
+                required:
+                - name
+                - phase
+                type: object
+              type: array
+            phase:
+              type: string
+            startedAt:
+              format: date-time
+              type: string
+          required:
+          - phase
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -1,0 +1,2648 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: analysistemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AnalysisTemplate
+    listKind: AnalysisTemplateList
+    plural: analysistemplates
+    singular: analysistemplate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            args:
+              items:
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            metrics:
+              items:
+                properties:
+                  consecutiveErrorLimit:
+                    format: int32
+                    type: integer
+                  count:
+                    format: int32
+                    type: integer
+                  failureCondition:
+                    type: string
+                  failureLimit:
+                    format: int32
+                    type: integer
+                  inconclusiveLimit:
+                    format: int32
+                    type: integer
+                  initialDelay:
+                    type: string
+                  interval:
+                    type: string
+                  name:
+                    type: string
+                  provider:
+                    properties:
+                      job:
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              backoffLimit:
+                                format: int32
+                                type: integer
+                              completions:
+                                format: int32
+                                type: integer
+                              manualSelector:
+                                type: boolean
+                              parallelism:
+                                format: int32
+                                type: integer
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              template:
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    properties:
+                                      activeDeadlineSeconds:
+                                        format: int64
+                                        type: integer
+                                      affinity:
+                                        properties:
+                                          nodeAffinity:
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    preference:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    items:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                items:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      automountServiceAccountToken:
+                                        type: boolean
+                                      containers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      dnsConfig:
+                                        properties:
+                                          nameservers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          options:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          searches:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      dnsPolicy:
+                                        type: string
+                                      enableServiceLinks:
+                                        type: boolean
+                                      ephemeralContainers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            targetContainerName:
+                                              type: string
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      hostAliases:
+                                        items:
+                                          properties:
+                                            hostnames:
+                                              items:
+                                                type: string
+                                              type: array
+                                            ip:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      hostIPC:
+                                        type: boolean
+                                      hostNetwork:
+                                        type: boolean
+                                      hostPID:
+                                        type: boolean
+                                      hostname:
+                                        type: string
+                                      imagePullSecrets:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      initContainers:
+                                        items:
+                                          properties:
+                                            args:
+                                              items:
+                                                type: string
+                                              type: array
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                            env:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                    type: object
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            envFrom:
+                                              items:
+                                                properties:
+                                                  configMapRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                type: object
+                                              type: array
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              properties:
+                                                postStart:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                                preStop:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                  type: object
+                                              type: object
+                                            livenessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            name:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  containerPort:
+                                                    format: int32
+                                                    type: integer
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    format: int32
+                                                    type: integer
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - containerPort
+                                                type: object
+                                              type: array
+                                            readinessProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            resources:
+                                              type: object
+                                            securityContext:
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  properties:
+                                                    add:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    drop:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  format: int64
+                                                  type: integer
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  format: int64
+                                                  type: integer
+                                                seLinuxOptions:
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                  type: object
+                                                windowsOptions:
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            startupProbe:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                failureThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                initialDelaySeconds:
+                                                  format: int32
+                                                  type: integer
+                                                periodSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                successThreshold:
+                                                  format: int32
+                                                  type: integer
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                timeoutSeconds:
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              items:
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                - devicePath
+                                                - name
+                                                type: object
+                                              type: array
+                                            volumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                - mountPath
+                                                - name
+                                                type: object
+                                              type: array
+                                            workingDir:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      nodeName:
+                                        type: string
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      overhead:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      preemptionPolicy:
+                                        type: string
+                                      priority:
+                                        format: int32
+                                        type: integer
+                                      priorityClassName:
+                                        type: string
+                                      readinessGates:
+                                        items:
+                                          properties:
+                                            conditionType:
+                                              type: string
+                                          required:
+                                          - conditionType
+                                          type: object
+                                        type: array
+                                      restartPolicy:
+                                        type: string
+                                      runtimeClassName:
+                                        type: string
+                                      schedulerName:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          fsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsGroup:
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          supplementalGroups:
+                                            items:
+                                              format: int64
+                                              type: integer
+                                            type: array
+                                          sysctls:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      serviceAccount:
+                                        type: string
+                                      serviceAccountName:
+                                        type: string
+                                      shareProcessNamespace:
+                                        type: boolean
+                                      subdomain:
+                                        type: string
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      tolerations:
+                                        items:
+                                          properties:
+                                            effect:
+                                              type: string
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            tolerationSeconds:
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      topologySpreadConstraints:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            maxSkew:
+                                              format: int32
+                                              type: integer
+                                            topologyKey:
+                                              type: string
+                                            whenUnsatisfiable:
+                                              type: string
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          type: object
+                                        type: array
+                                      volumes:
+                                        items:
+                                          properties:
+                                            awsElasticBlockStore:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  format: int32
+                                                  type: integer
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                              required:
+                                              - volumeID
+                                              type: object
+                                            azureDisk:
+                                              properties:
+                                                cachingMode:
+                                                  type: string
+                                                diskName:
+                                                  type: string
+                                                diskURI:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - diskName
+                                              - diskURI
+                                              type: object
+                                            azureFile:
+                                              properties:
+                                                readOnly:
+                                                  type: boolean
+                                                secretName:
+                                                  type: string
+                                                shareName:
+                                                  type: string
+                                              required:
+                                              - secretName
+                                              - shareName
+                                              type: object
+                                            cephfs:
+                                              properties:
+                                                monitors:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretFile:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                user:
+                                                  type: string
+                                              required:
+                                              - monitors
+                                              type: object
+                                            cinder:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                volumeID:
+                                                  type: string
+                                              required:
+                                              - volumeID
+                                              type: object
+                                            csi:
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                nodePublishSecretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                readOnly:
+                                                  type: boolean
+                                                volumeAttributes:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              required:
+                                              - driver
+                                              type: object
+                                            emptyDir:
+                                              properties:
+                                                medium:
+                                                  type: string
+                                                sizeLimit:
+                                                  type: string
+                                              type: object
+                                            fc:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                lun:
+                                                  format: int32
+                                                  type: integer
+                                                readOnly:
+                                                  type: boolean
+                                                targetWWNs:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                wwids:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            flexVolume:
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                options:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                              required:
+                                              - driver
+                                              type: object
+                                            flocker:
+                                              properties:
+                                                datasetName:
+                                                  type: string
+                                                datasetUUID:
+                                                  type: string
+                                              type: object
+                                            gcePersistentDisk:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  format: int32
+                                                  type: integer
+                                                pdName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - pdName
+                                              type: object
+                                            gitRepo:
+                                              properties:
+                                                directory:
+                                                  type: string
+                                                repository:
+                                                  type: string
+                                                revision:
+                                                  type: string
+                                              required:
+                                              - repository
+                                              type: object
+                                            glusterfs:
+                                              properties:
+                                                endpoints:
+                                                  type: string
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - endpoints
+                                              - path
+                                              type: object
+                                            hostPath:
+                                              properties:
+                                                path:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            iscsi:
+                                              properties:
+                                                chapAuthDiscovery:
+                                                  type: boolean
+                                                chapAuthSession:
+                                                  type: boolean
+                                                fsType:
+                                                  type: string
+                                                initiatorName:
+                                                  type: string
+                                                iqn:
+                                                  type: string
+                                                iscsiInterface:
+                                                  type: string
+                                                lun:
+                                                  format: int32
+                                                  type: integer
+                                                portals:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                targetPortal:
+                                                  type: string
+                                              required:
+                                              - iqn
+                                              - lun
+                                              - targetPortal
+                                              type: object
+                                            name:
+                                              type: string
+                                            nfs:
+                                              properties:
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                server:
+                                                  type: string
+                                              required:
+                                              - path
+                                              - server
+                                              type: object
+                                            persistentVolumeClaim:
+                                              properties:
+                                                claimName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                              required:
+                                              - claimName
+                                              type: object
+                                            photonPersistentDisk:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                pdID:
+                                                  type: string
+                                              required:
+                                              - pdID
+                                              type: object
+                                            portworxVolume:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                              required:
+                                              - volumeID
+                                              type: object
+                                            projected:
+                                              properties:
+                                                defaultMode:
+                                                  format: int32
+                                                  type: integer
+                                                sources:
+                                                  items:
+                                                    properties:
+                                                      serviceAccountToken:
+                                                        properties:
+                                                          audience:
+                                                            type: string
+                                                          expirationSeconds:
+                                                            format: int64
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                        required:
+                                                        - path
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                              required:
+                                              - sources
+                                              type: object
+                                            quobyte:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                registry:
+                                                  type: string
+                                                tenant:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                                volume:
+                                                  type: string
+                                              required:
+                                              - registry
+                                              - volume
+                                              type: object
+                                            rbd:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                image:
+                                                  type: string
+                                                keyring:
+                                                  type: string
+                                                monitors:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                pool:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                user:
+                                                  type: string
+                                              required:
+                                              - image
+                                              - monitors
+                                              type: object
+                                            scaleIO:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                gateway:
+                                                  type: string
+                                                protectionDomain:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                sslEnabled:
+                                                  type: boolean
+                                                storageMode:
+                                                  type: string
+                                                storagePool:
+                                                  type: string
+                                                system:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - gateway
+                                              - secretRef
+                                              - system
+                                              type: object
+                                            storageos:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  type: object
+                                                volumeName:
+                                                  type: string
+                                                volumeNamespace:
+                                                  type: string
+                                              type: object
+                                            vsphereVolume:
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                storagePolicyID:
+                                                  type: string
+                                                storagePolicyName:
+                                                  type: string
+                                                volumePath:
+                                                  type: string
+                                              required:
+                                              - volumePath
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                    required:
+                                    - containers
+                                    type: object
+                                type: object
+                              ttlSecondsAfterFinished:
+                                format: int32
+                                type: integer
+                            required:
+                            - template
+                            type: object
+                        required:
+                        - spec
+                        type: object
+                      kayenta:
+                        properties:
+                          address:
+                            type: string
+                          application:
+                            type: string
+                          canaryConfigName:
+                            type: string
+                          configurationAccountName:
+                            type: string
+                          metricsAccountName:
+                            type: string
+                          scopes:
+                            items:
+                              properties:
+                                controlScope:
+                                  properties:
+                                    end:
+                                      type: string
+                                    region:
+                                      type: string
+                                    scope:
+                                      type: string
+                                    start:
+                                      type: string
+                                    step:
+                                      type: integer
+                                  required:
+                                  - end
+                                  - region
+                                  - scope
+                                  - start
+                                  - step
+                                  type: object
+                                experimentScope:
+                                  properties:
+                                    end:
+                                      type: string
+                                    region:
+                                      type: string
+                                    scope:
+                                      type: string
+                                    start:
+                                      type: string
+                                    step:
+                                      type: integer
+                                  required:
+                                  - end
+                                  - region
+                                  - scope
+                                  - start
+                                  - step
+                                  type: object
+                                name:
+                                  type: string
+                              required:
+                              - controlScope
+                              - experimentScope
+                              - name
+                              type: object
+                            type: array
+                          storageAccountName:
+                            type: string
+                          threshold:
+                            properties:
+                              marginal:
+                                type: integer
+                              pass:
+                                type: integer
+                            required:
+                            - marginal
+                            - pass
+                            type: object
+                        required:
+                        - address
+                        - application
+                        - canaryConfigName
+                        - configurationAccountName
+                        - metricsAccountName
+                        - scopes
+                        - storageAccountName
+                        - threshold
+                        type: object
+                      prometheus:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
+                      wavefront:
+                        properties:
+                          address:
+                            type: string
+                          query:
+                            type: string
+                        type: object
+                      web:
+                        properties:
+                          headers:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - key
+                              - value
+                              type: object
+                            type: array
+                          jsonPath:
+                            type: string
+                          timeoutSeconds:
+                            type: integer
+                          url:
+                            type: string
+                        required:
+                        - jsonPath
+                        - url
+                        type: object
+                    type: object
+                  successCondition:
+                    type: string
+                required:
+                - name
+                - provider
+                type: object
+              type: array
+          required:
+          - metrics
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -1,0 +1,2599 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: experiments.argoproj.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Experiment status
+    name: Status
+    type: string
+  group: argoproj.io
+  names:
+    kind: Experiment
+    listKind: ExperimentList
+    plural: experiments
+    shortNames:
+    - exp
+    singular: experiment
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            analyses:
+              items:
+                properties:
+                  args:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                  requiredForCompletion:
+                    type: boolean
+                  templateName:
+                    type: string
+                required:
+                - name
+                - templateName
+                type: object
+              type: array
+            duration:
+              type: string
+            progressDeadlineSeconds:
+              format: int32
+              type: integer
+            templates:
+              items:
+                properties:
+                  minReadySeconds:
+                    format: int32
+                    type: integer
+                  name:
+                    type: string
+                  replicas:
+                    format: int32
+                    type: integer
+                  selector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  template:
+                    properties:
+                      metadata:
+                        type: object
+                      spec:
+                        properties:
+                          activeDeadlineSeconds:
+                            format: int64
+                            type: integer
+                          affinity:
+                            properties:
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        preference:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - preference
+                                      - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                          type: object
+                                        type: array
+                                    required:
+                                    - nodeSelectorTerms
+                                    type: object
+                                type: object
+                              podAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                type: object
+                              podAntiAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          automountServiceAccountToken:
+                            type: boolean
+                          containers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                type: string
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resources:
+                                  type: object
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          dnsConfig:
+                            properties:
+                              nameservers:
+                                items:
+                                  type: string
+                                type: array
+                              options:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              searches:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          dnsPolicy:
+                            type: string
+                          enableServiceLinks:
+                            type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                type: string
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resources:
+                                  type: object
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          hostAliases:
+                            items:
+                              properties:
+                                hostnames:
+                                  items:
+                                    type: string
+                                  type: array
+                                ip:
+                                  type: string
+                              type: object
+                            type: array
+                          hostIPC:
+                            type: boolean
+                          hostNetwork:
+                            type: boolean
+                          hostPID:
+                            type: boolean
+                          hostname:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          initContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                type: string
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resources:
+                                  type: object
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                      required:
+                                      - port
+                                      type: object
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          nodeName:
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          overhead:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          preemptionPolicy:
+                            type: string
+                          priority:
+                            format: int32
+                            type: integer
+                          priorityClassName:
+                            type: string
+                          readinessGates:
+                            items:
+                              properties:
+                                conditionType:
+                                  type: string
+                              required:
+                              - conditionType
+                              type: object
+                            type: array
+                          restartPolicy:
+                            type: string
+                          runtimeClassName:
+                            type: string
+                          schedulerName:
+                            type: string
+                          securityContext:
+                            properties:
+                              fsGroup:
+                                format: int64
+                                type: integer
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              supplementalGroups:
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                              sysctls:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          serviceAccount:
+                            type: string
+                          serviceAccountName:
+                            type: string
+                          shareProcessNamespace:
+                            type: boolean
+                          subdomain:
+                            type: string
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                maxSkew:
+                                  format: int32
+                                  type: integer
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                              type: object
+                            type: array
+                          volumes:
+                            items:
+                              properties:
+                                awsElasticBlockStore:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                azureDisk:
+                                  properties:
+                                    cachingMode:
+                                      type: string
+                                    diskName:
+                                      type: string
+                                    diskURI:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - diskName
+                                  - diskURI
+                                  type: object
+                                azureFile:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                    shareName:
+                                      type: string
+                                  required:
+                                  - secretName
+                                  - shareName
+                                  type: object
+                                cephfs:
+                                  properties:
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretFile:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    user:
+                                      type: string
+                                  required:
+                                  - monitors
+                                  type: object
+                                cinder:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                csi:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  required:
+                                  - driver
+                                  type: object
+                                emptyDir:
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: string
+                                  type: object
+                                fc:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    lun:
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    targetWWNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                    wwids:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                flexVolume:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  required:
+                                  - driver
+                                  type: object
+                                flocker:
+                                  properties:
+                                    datasetName:
+                                      type: string
+                                    datasetUUID:
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - pdName
+                                  type: object
+                                gitRepo:
+                                  properties:
+                                    directory:
+                                      type: string
+                                    repository:
+                                      type: string
+                                    revision:
+                                      type: string
+                                  required:
+                                  - repository
+                                  type: object
+                                glusterfs:
+                                  properties:
+                                    endpoints:
+                                      type: string
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - endpoints
+                                  - path
+                                  type: object
+                                hostPath:
+                                  properties:
+                                    path:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                iscsi:
+                                  properties:
+                                    chapAuthDiscovery:
+                                      type: boolean
+                                    chapAuthSession:
+                                      type: boolean
+                                    fsType:
+                                      type: string
+                                    initiatorName:
+                                      type: string
+                                    iqn:
+                                      type: string
+                                    iscsiInterface:
+                                      type: string
+                                    lun:
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      items:
+                                        type: string
+                                      type: array
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    targetPortal:
+                                      type: string
+                                  required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                  type: object
+                                name:
+                                  type: string
+                                nfs:
+                                  properties:
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    server:
+                                      type: string
+                                  required:
+                                  - path
+                                  - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    pdID:
+                                      type: string
+                                  required:
+                                  - pdID
+                                  type: object
+                                portworxVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                projected:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      items:
+                                        properties:
+                                          serviceAccountToken:
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                  required:
+                                  - sources
+                                  type: object
+                                quobyte:
+                                  properties:
+                                    group:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    registry:
+                                      type: string
+                                    tenant:
+                                      type: string
+                                    user:
+                                      type: string
+                                    volume:
+                                      type: string
+                                  required:
+                                  - registry
+                                  - volume
+                                  type: object
+                                rbd:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    image:
+                                      type: string
+                                    keyring:
+                                      type: string
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                    pool:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    user:
+                                      type: string
+                                  required:
+                                  - image
+                                  - monitors
+                                  type: object
+                                scaleIO:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    gateway:
+                                      type: string
+                                    protectionDomain:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    sslEnabled:
+                                      type: boolean
+                                    storageMode:
+                                      type: string
+                                    storagePool:
+                                      type: string
+                                    system:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                  type: object
+                                storageos:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    volumeName:
+                                      type: string
+                                    volumeNamespace:
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    storagePolicyID:
+                                      type: string
+                                    storagePolicyName:
+                                      type: string
+                                    volumePath:
+                                      type: string
+                                  required:
+                                  - volumePath
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        required:
+                        - containers
+                        type: object
+                    type: object
+                required:
+                - name
+                - selector
+                - template
+                type: object
+              type: array
+            terminate:
+              type: boolean
+          required:
+          - templates
+          type: object
+        status:
+          properties:
+            analysisRuns:
+              items:
+                properties:
+                  analysisRun:
+                    type: string
+                  message:
+                    type: string
+                  name:
+                    type: string
+                  phase:
+                    type: string
+                required:
+                - analysisRun
+                - name
+                - phase
+                type: object
+              type: array
+            availableAt:
+              format: date-time
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - lastTransitionTime
+                - lastUpdateTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+            message:
+              type: string
+            phase:
+              type: string
+            templateStatuses:
+              items:
+                properties:
+                  availableReplicas:
+                    format: int32
+                    type: integer
+                  collisionCount:
+                    format: int32
+                    type: integer
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  name:
+                    type: string
+                  readyReplicas:
+                    format: int32
+                    type: integer
+                  replicas:
+                    format: int32
+                    type: integer
+                  status:
+                    type: string
+                  updatedReplicas:
+                    format: int32
+                    type: integer
+                required:
+                - availableReplicas
+                - name
+                - readyReplicas
+                - replicas
+                - updatedReplicas
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -1,0 +1,2803 @@
+{{- if .Values.installCRDs }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: rollouts.argoproj.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Number of desired pods
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Total number of non-terminated pods targeted by this rollout
+    name: Current
+    type: integer
+  - JSONPath: .status.updatedReplicas
+    description: Total number of non-terminated pods targeted by this rollout that
+      have the desired template spec
+    name: Up-to-date
+    type: integer
+  - JSONPath: .status.availableReplicas
+    description: Total number of available pods (ready for at least minReadySeconds)
+      targeted by this rollout
+    name: Available
+    type: integer
+  group: argoproj.io
+  names:
+    kind: Rollout
+    listKind: RolloutList
+    plural: rollouts
+    shortNames:
+    - ro
+    singular: rollout
+  scope: Namespaced
+  subresources:
+    scale:
+      labelSelectorPath: .status.selector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.HPAReplicas
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            minReadySeconds:
+              format: int32
+              type: integer
+            paused:
+              type: boolean
+            progressDeadlineSeconds:
+              format: int32
+              type: integer
+            replicas:
+              format: int32
+              type: integer
+            revisionHistoryLimit:
+              format: int32
+              type: integer
+            selector:
+              properties:
+                matchExpressions:
+                  items:
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  type: object
+              type: object
+            strategy:
+              properties:
+                blueGreen:
+                  properties:
+                    activeService:
+                      type: string
+                    autoPromotionEnabled:
+                      type: boolean
+                    autoPromotionSeconds:
+                      format: int32
+                      type: integer
+                    previewReplicaCount:
+                      format: int32
+                      type: integer
+                    previewService:
+                      type: string
+                    scaleDownDelayRevisionLimit:
+                      format: int32
+                      type: integer
+                    scaleDownDelaySeconds:
+                      format: int32
+                      type: integer
+                  required:
+                  - activeService
+                  type: object
+                canary:
+                  properties:
+                    analysis:
+                      properties:
+                        args:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  podTemplateHashValue:
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        startingStep:
+                          format: int32
+                          type: integer
+                        templateName:
+                          type: string
+                      required:
+                      - templateName
+                      type: object
+                    canaryService:
+                      type: string
+                    maxSurge:
+                      anyOf:
+                      - type: string
+                      - type: integer
+                    maxUnavailable:
+                      anyOf:
+                      - type: string
+                      - type: integer
+                    stableService:
+                      type: string
+                    steps:
+                      items:
+                        properties:
+                          analysis:
+                            properties:
+                              args:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        podTemplateHashValue:
+                                          type: string
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              templateName:
+                                type: string
+                            required:
+                            - templateName
+                            type: object
+                          experiment:
+                            properties:
+                              analyses:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              podTemplateHashValue:
+                                                type: string
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    templateName:
+                                      type: string
+                                  required:
+                                  - name
+                                  - templateName
+                                  type: object
+                                type: array
+                              duration:
+                                type: string
+                              templates:
+                                items:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    replicas:
+                                      format: int32
+                                      type: integer
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    specRef:
+                                      type: string
+                                  required:
+                                  - name
+                                  - specRef
+                                  type: object
+                                type: array
+                            required:
+                            - templates
+                            type: object
+                          pause:
+                            properties:
+                              duration:
+                                format: int32
+                                type: integer
+                            type: object
+                          setWeight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    trafficRouting:
+                      properties:
+                        istio:
+                          properties:
+                            virtualService:
+                              properties:
+                                name:
+                                  type: string
+                                routes:
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - routes
+                              type: object
+                          required:
+                          - virtualService
+                          type: object
+                      type: object
+                  type: object
+              type: object
+            template:
+              properties:
+                metadata:
+                  type: object
+                spec:
+                  properties:
+                    activeDeadlineSeconds:
+                      format: int64
+                      type: integer
+                    affinity:
+                      properties:
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    automountServiceAccountToken:
+                      type: boolean
+                    containers:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          type: string
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          lifecycle:
+                            properties:
+                              postStart:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          ports:
+                            items:
+                              properties:
+                                containerPort:
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  type: string
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                                name:
+                                  type: string
+                                protocol:
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            type: object
+                          securityContext:
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                properties:
+                                  add:
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                type: boolean
+                              procMount:
+                                type: string
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            type: boolean
+                          stdinOnce:
+                            type: boolean
+                          terminationMessagePath:
+                            type: string
+                          terminationMessagePolicy:
+                            type: string
+                          tty:
+                            type: boolean
+                          volumeDevices:
+                            items:
+                              properties:
+                                devicePath:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    dnsConfig:
+                      properties:
+                        nameservers:
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      type: string
+                    enableServiceLinks:
+                      type: boolean
+                    ephemeralContainers:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          type: string
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          lifecycle:
+                            properties:
+                              postStart:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          ports:
+                            items:
+                              properties:
+                                containerPort:
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  type: string
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                                name:
+                                  type: string
+                                protocol:
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            type: object
+                          securityContext:
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                properties:
+                                  add:
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                type: boolean
+                              procMount:
+                                type: string
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            type: boolean
+                          stdinOnce:
+                            type: boolean
+                          targetContainerName:
+                            type: string
+                          terminationMessagePath:
+                            type: string
+                          terminationMessagePolicy:
+                            type: string
+                          tty:
+                            type: boolean
+                          volumeDevices:
+                            items:
+                              properties:
+                                devicePath:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    hostAliases:
+                      items:
+                        properties:
+                          hostnames:
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            type: string
+                        type: object
+                      type: array
+                    hostIPC:
+                      type: boolean
+                    hostNetwork:
+                      type: boolean
+                    hostPID:
+                      type: boolean
+                    hostname:
+                      type: string
+                    imagePullSecrets:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                    initContainers:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          type: string
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          lifecycle:
+                            properties:
+                              postStart:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: string
+                                        - type: integer
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          ports:
+                            items:
+                              properties:
+                                containerPort:
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  type: string
+                                hostPort:
+                                  format: int32
+                                  type: integer
+                                name:
+                                  type: string
+                                protocol:
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            type: object
+                          securityContext:
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                properties:
+                                  add:
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                type: boolean
+                              procMount:
+                                type: string
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  scheme:
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            type: boolean
+                          stdinOnce:
+                            type: boolean
+                          terminationMessagePath:
+                            type: string
+                          terminationMessagePolicy:
+                            type: string
+                          tty:
+                            type: boolean
+                          volumeDevices:
+                            items:
+                              properties:
+                                devicePath:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    nodeName:
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    overhead:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    preemptionPolicy:
+                      type: string
+                    priority:
+                      format: int32
+                      type: integer
+                    priorityClassName:
+                      type: string
+                    readinessGates:
+                      items:
+                        properties:
+                          conditionType:
+                            type: string
+                        required:
+                        - conditionType
+                        type: object
+                      type: array
+                    restartPolicy:
+                      type: string
+                    runtimeClassName:
+                      type: string
+                    schedulerName:
+                      type: string
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                    shareProcessNamespace:
+                      type: boolean
+                    subdomain:
+                      type: string
+                    terminationGracePeriodSeconds:
+                      format: int64
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          maxSkew:
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                    volumes:
+                      items:
+                        properties:
+                          awsElasticBlockStore:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            properties:
+                              cachingMode:
+                                type: string
+                              diskName:
+                                type: string
+                              diskURI:
+                                type: string
+                              fsType:
+                                type: string
+                              kind:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              secretName:
+                                type: string
+                              shareName:
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            properties:
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretFile:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          csi:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              nodePublishSecretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          emptyDir:
+                            properties:
+                              medium:
+                                type: string
+                              sizeLimit:
+                                type: string
+                            type: object
+                          fc:
+                            properties:
+                              fsType:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              targetWWNs:
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            properties:
+                              datasetName:
+                                type: string
+                              datasetUUID:
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              pdName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            properties:
+                              directory:
+                                type: string
+                              repository:
+                                type: string
+                              revision:
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            properties:
+                              endpoints:
+                                type: string
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            properties:
+                              path:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            properties:
+                              chapAuthDiscovery:
+                                type: boolean
+                              chapAuthSession:
+                                type: boolean
+                              fsType:
+                                type: string
+                              initiatorName:
+                                type: string
+                              iqn:
+                                type: string
+                              iscsiInterface:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              portals:
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              targetPortal:
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            type: string
+                          nfs:
+                            properties:
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              server:
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            properties:
+                              claimName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              pdID:
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              sources:
+                                items:
+                                  properties:
+                                    serviceAccountToken:
+                                      properties:
+                                        audience:
+                                          type: string
+                                        expirationSeconds:
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            required:
+                            - sources
+                            type: object
+                          quobyte:
+                            properties:
+                              group:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              registry:
+                                type: string
+                              tenant:
+                                type: string
+                              user:
+                                type: string
+                              volume:
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            properties:
+                              fsType:
+                                type: string
+                              image:
+                                type: string
+                              keyring:
+                                type: string
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            properties:
+                              fsType:
+                                type: string
+                              gateway:
+                                type: string
+                              protectionDomain:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                type: boolean
+                              storageMode:
+                                type: string
+                              storagePool:
+                                type: string
+                              system:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          storageos:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeName:
+                                type: string
+                              volumeNamespace:
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              storagePolicyID:
+                                type: string
+                              storagePolicyName:
+                                type: string
+                              volumePath:
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - containers
+                  type: object
+              type: object
+          required:
+          - selector
+          - template
+          type: object
+        status:
+          properties:
+            HPAReplicas:
+              format: int32
+              type: integer
+            abort:
+              type: boolean
+            availableReplicas:
+              format: int32
+              type: integer
+            blueGreen:
+              properties:
+                activeSelector:
+                  type: string
+                previewSelector:
+                  type: string
+                previousActiveSelector:
+                  type: string
+                scaleDownDelayStartTime:
+                  format: date-time
+                  type: string
+                scaleUpPreviewCheckPoint:
+                  type: boolean
+              type: object
+            canary:
+              properties:
+                currentBackgroundAnalysisRun:
+                  type: string
+                currentExperiment:
+                  type: string
+                currentStepAnalysisRun:
+                  type: string
+                stableRS:
+                  type: string
+              type: object
+            collisionCount:
+              format: int32
+              type: integer
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - lastTransitionTime
+                - lastUpdateTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+            controllerPause:
+              type: boolean
+            currentPodHash:
+              type: string
+            currentStepHash:
+              type: string
+            currentStepIndex:
+              format: int32
+              type: integer
+            observedGeneration:
+              type: string
+            pauseConditions:
+              items:
+                properties:
+                  reason:
+                    type: string
+                  startTime:
+                    format: date-time
+                    type: string
+                required:
+                - reason
+                - startTime
+                type: object
+              type: array
+            readyReplicas:
+              format: int32
+              type: integer
+            replicas:
+              format: int32
+              type: integer
+            selector:
+              type: string
+            updatedReplicas:
+              format: int32
+              type: integer
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+{{- end }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -1,0 +1,14 @@
+installCRDs: true
+
+clusterInstall: true
+
+controller:
+  name: argo-rollouts
+  component: rollouts-controller
+  image:
+    repository: argoproj/argo-rollouts
+    tag: v0.7.0
+    pullPolicy: IfNotPresent
+
+serviceAccount:
+  name: argo-rollouts


### PR DESCRIPTION
I've created this chart based on https://github.com/argoproj/argo-rollouts/tree/v0.7.0/manifests

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.