### PR TITLE
fix: Make port names configurable for repo-server and controller

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.7.3
+version: 1.7.4
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.7.4
+version: 1.7.5
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-application-controller/service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/service.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/component: {{ .Values.controller.name }}
 spec:
   ports:
-  - name: {{ .Values.controller.name }}
+  - name: {{ .Values.controller.service.portName }}
     port: {{ .Values.controller.service.port }}
     targetPort: {{ .Values.controller.containerPort }}
   selector:

--- a/charts/argo-cd/templates/argocd-repo-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/service.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ template "argo-cd.repoServer.fullname" . }}
 spec:
   ports:
-  - name: repo-server
+  - name: {{ .Values.repoServer.service.portName }}
     protocol: TCP
     port: {{ .Values.repoServer.service.port }}
     targetPort: repo-server

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -86,6 +86,7 @@ controller:
     annotations: {}
     labels: {}
     port: 8082
+    portName: https-controller
 
   ## Node selectors and tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -590,6 +591,7 @@ repoServer:
     annotations: {}
     labels: {}
     port: 8081
+    portName: https-repo-server
 
   ## Repo server metrics service configuration
   metrics:


### PR DESCRIPTION
When using istio with argocd the ports need to be named with the correct prefixes so it gets routed correctly. Therefore it would be nice to be able to configure port names of the helm chart.
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.