### PR TITLE
feat: Add HPA for ArgoCD server and repoServer components

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.7.3
+version: 1.8.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -101,6 +101,11 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | repoServer.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
+| repoServer.autoscaling.enabled | Enable Horizontal Pod Autoscaler (HPA) for the repo server | `false` |
+| repoServer.autoscaling.minReplicas | Minimum number of replicas for the repo server HPA | `1` |
+| repoServer.autoscaling.maxReplicas | Minimum number of replicas for the repo server HPA | `5` |
+| repoServer.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the repo server HPA | `50` |
+| repoServer.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the repo server HPA | `50` |
 | repoServer.containerPort | Repo server port | `8081` |
 | repoServer.extraArgs | Additional arguments for the repo server. A  list of key:value pairs. | `[]` |
 | repoServer.env | Environment variables for the repo server. | `[]` |
@@ -143,6 +148,11 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | server.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
+| server.autoscaling.enabled | Enable Horizontal Pod Autoscaler (HPA) for the server | `false` |
+| server.autoscaling.minReplicas | Minimum number of replicas for the server HPA | `1` |
+| server.autoscaling.maxReplicas | Minimum number of replicas for the server HPA | `5` |
+| server.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the server HPA | `50` |
+| server.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the server HPA | `50` |
 | server.certificate.additionalHosts | Certificate manager additional hosts | `[]` |
 | server.certificate.domain | Certificate manager domain | `"argocd.example.com"` |
 | server.certificate.enabled | Enables a certificate manager certificate. | `false` |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -103,7 +103,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
 | repoServer.autoscaling.enabled | Enable Horizontal Pod Autoscaler (HPA) for the repo server | `false` |
 | repoServer.autoscaling.minReplicas | Minimum number of replicas for the repo server HPA | `1` |
-| repoServer.autoscaling.maxReplicas | Minimum number of replicas for the repo server HPA | `5` |
+| repoServer.autoscaling.maxReplicas | Maximum number of replicas for the repo server HPA | `5` |
 | repoServer.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the repo server HPA | `50` |
 | repoServer.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the repo server HPA | `50` |
 | repoServer.containerPort | Repo server port | `8081` |
@@ -150,7 +150,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
 | server.autoscaling.enabled | Enable Horizontal Pod Autoscaler (HPA) for the server | `false` |
 | server.autoscaling.minReplicas | Minimum number of replicas for the server HPA | `1` |
-| server.autoscaling.maxReplicas | Minimum number of replicas for the server HPA | `5` |
+| server.autoscaling.maxReplicas | Maximum number of replicas for the server HPA | `5` |
 | server.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the server HPA | `50` |
 | server.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the server HPA | `50` |
 | server.certificate.additionalHosts | Certificate manager additional hosts | `[]` |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         name: {{ .Values.controller.name }}
         {{- if .Values.controller.containerSecurityContext }}
         securityContext: {{- toYaml .Values.controller.containerSecurityContext | nindent 10 }}
-        {{- end }}      
+        {{- end }}
         {{- if .Values.controller.env }}
         env:
 {{- toYaml .Values.controller.env | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -16,7 +16,9 @@ spec:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.repoServer.name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   revisionHistoryLimit: 5
+  {{- if (ne .Values.repoServer.autoscaling.enabled true) }}
   replicas: {{ .Values.repoServer.replicas }}
+  {{- end }}
   template:
     metadata:
       {{- if .Values.repoServer.podAnnotations }}
@@ -61,7 +63,7 @@ spec:
         {{- end }}
         {{- if .Values.repoServer.containerSecurityContext }}
         securityContext: {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
-        {{- end }}           
+        {{- end }}
         {{- if .Values.repoServer.env }}
         env:
 {{- toYaml .Values.repoServer.env | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-repo-server/hpa.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.repoServer.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.repoServer.name }}-hpa
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: {{ .Values.repoServer.name }}
+  name: {{ template "argo-cd.repoServer.fullname" . }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "argo-cd.repoServer.fullname" . }}
+  minReplicas: {{ .Values.repoServer.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.repoServer.autoscaling.maxReplicas }}
+  metrics:
+{{- with .Values.repoServer.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.repoServer.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -16,7 +16,9 @@ spec:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   revisionHistoryLimit: 5
+  {{- if (ne .Values.server.autoscaling.enabled true) }}
   replicas: {{ .Values.server.replicas }}
+  {{- end }}
   template:
     metadata:
       {{- if .Values.server.podAnnotations }}
@@ -69,7 +71,7 @@ spec:
         {{- end }}
         {{- if .Values.server.containerSecurityContext }}
         securityContext: {{- toYaml .Values.server.containerSecurityContext | nindent 10 }}
-        {{- end }}          
+        {{- end }}
         {{- if .Values.server.env }}
         env:
 {{- toYaml .Values.server.env | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-server/hpa.yaml
+++ b/charts/argo-cd/templates/argocd-server/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.server.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}-hpa
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: {{ .Values.server.name }}
+  name: {{ template "argo-cd.server.fullname" . }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "argo-cd.server.fullname" . }}
+  minReplicas: {{ .Values.server.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
+  metrics:
+{{- with .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -270,6 +270,13 @@ server:
 
   replicas: 1
 
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
   image:
     repository: # argoproj/argocd
     tag: # v1.4.2
@@ -512,6 +519,13 @@ repoServer:
   name: repo-server
 
   replicas: 1
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
   image:
     repository: # argoproj/argocd


### PR DESCRIPTION
This PR adds a horizontal pod autoscaling to the server and repoServer components. The HPA template is inspired by the official nginx controller-hpa: https://github.com/helm/charts/blob/master/stable/nginx-ingress/templates/controller-hpa.yaml

Fixes https://github.com/argoproj/argo-helm/issues/218

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.