### PR TITLE
fix: Hotfix server.baseHref value not being used

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.6.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.7.1
+version: 0.7.2
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-deployment.yaml
+++ b/charts/argo/templates/server-deployment.yaml
@@ -59,7 +59,7 @@ spec:
                 apiVersion: v1
                 fieldPath: metadata.namespace
           - name: BASE_HREF
-            value: /
+            value: {{ .Values.server.baseHref | quote }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
       {{- with .Values.server.nodeSelector }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -104,7 +104,9 @@ server:
   enabled: true
   # only show workflows where UI installed
   forceNamespaceIsolation: false
-  # UI BASE_HREF env variable
+  # only updates base url of resources on client side,
+  # it's expected that a proxy server rewrites the request URL and gets rid of this prefix
+  # https://github.com/argoproj/argo/issues/716#issuecomment-433213190
   baseHref: /
   image:
     # Overrides .images.tag if defined.


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.