### PR TITLE
feat: extraArgs allows same flag multiple times

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.8.7
+version: 2.0.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -11,6 +11,27 @@ The default installation is intended to be similar to the provided ArgoCD [relea
 
 This chart currently installs the non-HA version of ArgoCD.
 
+## Upgrading
+
+### 1.8.7 to 2.0.0
+
+`controller.extraArgs`, `repoServer.extraArgs` and `server.extraArgs`  are not arrays of strings intead of a map
+
+What was
+```
+controller:
+  extraArgs:
+    insecure: ""
+```
+
+is now
+
+```
+controller:
+  extraArgs:
+  - --insecure
+```
+
 ## Prerequisites
 
 - Kubernetes 1.7+
@@ -60,7 +81,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.args.statusProcessors | define the controller `--status-processors` | `"20"` |
 | controller.clusterAdminAccess.enabled | Enable RBAC for local cluster deployments. | `true` |
 | controller.containerPort | Controller listening port. | `8082` |
-| controller.extraArgs | Additional arguments for the controller. A list of key:value pairs | `[]` |
+| controller.extraArgs | Additional arguments for the controller. A list of flags | `[]` |
 | controller.env | Environment variables for the controller. | `[]` |
 | controller.image.repository | Repository to use for the controller | `global.image.repository` |
 | controller.image.imagePullPolicy | Image pull policy for the controller | `global.image.imagePullPolicy` |
@@ -108,7 +129,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the repo server HPA | `50` |
 | repoServer.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the repo server HPA | `50` |
 | repoServer.containerPort | Repo server port | `8081` |
-| repoServer.extraArgs | Additional arguments for the repo server. A  list of key:value pairs. | `[]` |
+| repoServer.extraArgs | Additional arguments for the repo server. A  list of flags. | `[]` |
 | repoServer.env | Environment variables for the repo server. | `[]` |
 | repoServer.image.repository | Repository to use for the repo server | `global.image.repository` |
 | repoServer.image.imagePullPolicy | Image pull policy for the repo server | `global.image.imagePullPolicy` |
@@ -161,7 +182,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.clusterAdminAccess.enabled | Enable RBAC for local cluster deployments. | `true` |
 | server.config | [General Argo CD configuration](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repositories) | See [values.yaml](values.yaml) |
 | server.containerPort | Server container port. | `8080` |
-| server.extraArgs | Additional arguments for the server. A list of key:value pairs. | `[]` |
+| server.extraArgs | Additional arguments for the server. A list of flags. | `[]` |
 | server.env | Environment variables for the server. | `[]` |
 | server.image.repository | Repository to use for the server | `global.image.repository` |
 | server.image.imagePullPolicy | Image pull policy for the server | `global.image.imagePullPolicy` |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -6,7 +6,7 @@ In order to access the server UI you have the following options:
 
 2. enable ingress in the values file `service.ingress.enabled` and either
       - Add the annotation for ssl passthrough: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/ingress.md#option-1-ssl-passthrough
-      - Add the `insecure: ""` flag to `server.extraArgs` in the values file and terminate SSL at your ingress: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/ingress.md#option-2-multiple-ingress-objects-and-hosts
+      - Add the `--insecure` flag to `server.extraArgs` in the values file and terminate SSL at your ingress: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/ingress.md#option-2-multiple-ingress-objects-and-hosts
 
 
 After reaching the UI the first time you can login with username: admin and the password will be the

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -60,12 +60,8 @@ spec:
         - --redis
         - {{ template "argo-cd.redis.fullname" . }}:{{ .Values.redis.servicePort }}
         {{- end }}
-        {{- range $key, $value := .Values.controller.extraArgs }}
-          {{- if $value }}
-        - --{{ $key }}={{ $value }}
-          {{- else }}
-        - --{{ $key }}
-          {{- end }}
+        {{- with .Values.controller.extraArgs }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
         image: {{ default .Values.global.image.repository .Values.controller.image.repository }}:{{ default .Values.global.image.tag .Values.controller.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.controller.image.imagePullPolicy }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -58,12 +58,8 @@ spec:
         {{- end }}
         - --loglevel
         - {{ .Values.repoServer.logLevel }}
-        {{- range $key, $value := .Values.repoServer.extraArgs }}
-          {{- if $value }}
-        - --{{ $key }}={{ $value }}
-          {{- else }}
-        - --{{ $key }}
-          {{- end }}
+        {{- with .Values.repoServer.extraArgs }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
         {{- if .Values.repoServer.containerSecurityContext }}
         securityContext: {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -66,12 +66,8 @@ spec:
         - --redis
         - {{ template "argo-cd.redis.fullname" . }}:{{ .Values.redis.servicePort }}
         {{- end }}
-        {{- range $key, $value := .Values.server.extraArgs }}
-          {{- if $value }}
-        - --{{ $key }}={{ $value }}
-          {{- else }}
-        - --{{ $key }}
-          {{- end }}
+        {{- with .Values.server.extraArgs }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
         {{- if .Values.server.containerSecurityContext }}
         securityContext: {{- toYaml .Values.server.containerSecurityContext | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.server.fullname" . }}
   {{- if .Values.server.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.server.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}


### PR DESCRIPTION
Supersedes #244 (I messed up the rebase :man_facepalming: )

Relates to #232

This change allows ArgoCD chart to render multiple times the same flag with different values

Mainly, if not only, used to specify multiple Redis Sentinel addresses
https://github.com/argoproj/argo-cd/blob/5ec5aeb002cfc9167dba0fb77e7a08a2dc0932cf/manifests/ha/base/overlays/argocd-application-controller-deployment.yaml#L16
https://github.com/argoproj/argo-cd/blob/aeb48b0a69be764f381511f7749d1e094fc79225/util/cache/cache.go#L33
```
--sentinel
```

using this syntax
```
controller:
  extraArgs:
  - --sentinel
  - argocd-redis-ha-announce-0
  - --sentinel
  - argocd-redis-ha-announce-1
  - --sentinel
  - argocd-redis-ha-announce-2
```

instead of

```
controller:
  extraArgs:
    sentinel=argocd-redis-ha-announce-0:
    sentinel=argocd-redis-ha-announce-1:
    sentinel=argocd-redis-ha-announce-2:
```

Basically same syntax as the flags documentation
```
docker run --rm argoproj/argocd:v1.4.2 argocd-server help
...
Flags:
      --app-state-cache-expiration duration           Cache expiration for app state (default 1h0m0s)
      --as string                                     Username to impersonate for the operation
      --as-group stringArray                          Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --basehref string                               Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from / (default "/")
      --certificate-authority string                  Path to a cert file for the certificate authority
      --client-certificate string                     Path to a client certificate file for TLS
      --client-key string                             Path to a client key file for TLS
      --cluster string                                The name of the kubeconfig cluster to use
      --connection-status-cache-expiration duration   Cache expiration for cluster/repo connection status (default 1h0m0s)
      --context string                                The name of the kubeconfig context to use
      --default-cache-expiration duration             Cache expiration default (default 24h0m0s)
      --dex-server string                             Dex server address (default "http://argocd-dex-server:5556")
      --disable-auth                                  Disable client authentication
      --gloglevel int                                 Set the glog logging level
  -h, --help                                          help for argocd-server
      --insecure                                      Run server without TLS
      --insecure-skip-tls-verify                      If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string                             Path to a kube config. Only required if out-of-cluster
      --loglevel string                               Set the logging level. One of: debug|info|warn|error (default "info")
      --metrics-port int                              Start metrics on given port (default 8083)
  -n, --namespace string                              If present, the namespace scope for this CLI request
      --oidc-cache-expiration duration                Cache expiration for OIDC state (default 3m0s)
      --password string                               Password for basic authentication to the API server
      --port int                                      Listen on given port (default 8080)
      --redis string                                  Redis server hostname and port (e.g. argocd-redis:6379).
      --redisdb int                                   Redis database.
      --repo-server string                            Repo server address (default "argocd-repo-server:8081")
      --repo-server-timeout-seconds int               Repo server RPC call timeout seconds. (default 60)
      --request-timeout string                        The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
      --sentinel stringArray                          Redis sentinel hostname and port (e.g. argocd-redis-ha-announce-0:6379).
      --sentinelmaster string                         Redis sentinel master group name. (default "master")
      --server string                                 The address and port of the Kubernetes API server
      --staticassets string                           Static assets directory path
      --tlsmaxversion string                          The maximum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2)
      --tlsminversion string                          The minimum SSL/TLS version that is acceptable (one of: 1.0|1.1|1.2)
      --token string                                  Bearer token for authentication to the API server
      --user string                                   The name of the kubeconfig user to use
      --username string                               Username for basic authentication to the API server
      --x-frame-options value                         Set X-Frame-Options header in HTTP responses to value. To disable, set to "". (default "sameorigin")
```

Looks like `--as-group` will also benefit from these change

Signed-off-by: Carlos Juan Gómez Peñalver <carlosjuangp@gmail.com>

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.