### PR TITLE
feat: Add support for extra arguments to Argo Server

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.6.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.7.2
+version: 0.7.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-deployment.yaml
+++ b/charts/argo/templates/server-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - name: argo-server
           args:
           - server
+          {{- if .Values.server.extraArgs }}
+          {{- toYaml .Values.server.extraArgs | nindent 10 }}
+          {{- end }}
           image: "{{ .Values.images.namespace }}/{{ .Values.images.server }}:{{ default .Values.images.tag .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- if .Values.server.podPortName }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -143,7 +143,7 @@ server:
   tolerations: []
   affinity: {}
 
-  # Extra arguments to provided to the Argo server binary.
+  # Extra arguments to provide to the Argo server binary.
   extraArgs: []
 
   ## Ingress configuration.

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -143,6 +143,9 @@ server:
   tolerations: []
   affinity: {}
 
+  # Extra arguments to provided to the Argo server binary.
+  extraArgs: []
+
   ## Ingress configuration.
   ## ref: https://kubernetes.io/docs/user-guide/ingress/
   ##


### PR DESCRIPTION
This PR provides a way to specify additional command line arguments for `argo-server`. This gives chart users the flexibility in invoking `argo-server` without having to modify the chart.

One of the ways this can be used is to specify a custom config map. Currently, the chart creates a config map for the workflow controller and configures its command line to use it. It does not configure `argo-server` to use that map, however. That means `argo-server` installed via the chart cannot pick up persistence database configuration  and is unable to show archived workflows. Being able to specify a config map via extraArgs helps mitigate issues like this.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.