### PR TITLE
fix: remove foreign character

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.0.1
+version: 2.0.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -760,7 +760,7 @@ configs:
     githubSecret: ""
     gitlabSecret: ""
     bitbucketServerSecret: ""
-    bitbucketUUÌD: ""
+    bitbucketUUID: ""
     gogsSecret: ""
 
     # Custom secrets. Useful for injecting SSO secrets into environment variables.


### PR DESCRIPTION
An accented character snuck into values.yaml: `bitbucketUUÌD` rather than `bitbucketUUID`

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.