### PR TITLE
fix: set extraArgs default to be a sequence

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.0.0
+version: 2.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -36,8 +36,8 @@ controller:
   logLevel: info
 
   ## Additional command line arguments to pass to argocd-controller
-  ## key: value
-  extraArgs: {}
+  ##
+  extraArgs: []
 
   ## Environment variables to pass to argocd-controller
   ##
@@ -301,9 +301,9 @@ server:
     imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-server
-  ## key: value
-  extraArgs: {}
-  #   insecure: true
+  ##
+  extraArgs: []
+  #  - --insecure
 
   ## Environment variables to pass to argocd-server
   ##
@@ -556,8 +556,8 @@ repoServer:
     imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-repo-server
-  ## key: value
-  extraArgs: {}
+  ##
+  extraArgs: []
 
   ## Environment variables to pass to argocd-repo-server
   ##


### PR DESCRIPTION
Addresses issue #281 

Inconsistency introduced in #265

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.