### PR TITLE
feat(argo-events): Support for customizing more Argo Events controller pod attributes

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.14.0
+version: 0.14.1
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/templates/gateway-controller-deployment.yaml
+++ b/charts/argo-events/templates/gateway-controller-deployment.yaml
@@ -18,6 +18,12 @@ spec:
       labels:
         app: {{ .Release.Name }}-{{ .Values.gatewayController.name }}
         release: {{ .Release.Name }}
+        {{- if .Values.gatewayController.podLabels -}}
+        {{ toYaml .Values.gatewayController.podLabels | nindent 8}}
+        {{- end }}
+      {{- if .Values.gatewayController.podAnnotations }}
+      annotations: {{- toYaml .Values.gatewayController.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       containers:
@@ -31,3 +37,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTROLLER_CONFIG_MAP
               value: {{ .Release.Name }}-{{ .Values.gatewayController.name }}-configmap
+          resources: {{- toYaml .Values.gatewayController.resources | nindent 12 }}
+      nodeSelector: {{- toYaml .Values.gatewayController.nodeSelector | nindent 8 }}
+      tolerations: {{- toYaml .Values.gatewayController.tolerations | nindent 8 }}
+      affinity: {{- toYaml .Values.gatewayController.affinity | nindent 8 }}

--- a/charts/argo-events/templates/sensor-controller-deployment.yaml
+++ b/charts/argo-events/templates/sensor-controller-deployment.yaml
@@ -18,6 +18,12 @@ spec:
       labels:
         app: {{ .Release.Name }}-{{ .Values.sensorController.name }}
         release: {{ .Release.Name }}
+        {{- if .Values.sensorController.podLabels -}}
+        {{ toYaml .Values.sensorController.podLabels | nindent 8}}
+        {{- end }}
+      {{- if .Values.sensorController.podAnnotations }}
+      annotations: {{- toYaml .Values.sensorController.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       containers:
@@ -31,3 +37,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTROLLER_CONFIG_MAP
               value: {{ .Release.Name }}-{{ .Values.sensorController.name }}-configmap
+          resources: {{- toYaml .Values.sensorController.resources | nindent 12 }}
+      nodeSelector: {{- toYaml .Values.sensorController.nodeSelector | nindent 8 }}
+      tolerations: {{- toYaml .Values.sensorController.tolerations | nindent 8 }}
+      affinity: {{- toYaml .Values.sensorController.affinity | nindent 8 }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -44,9 +44,33 @@ sensorController:
   image: sensor-controller
   tag: v0.14.0
   replicaCount: 1
+  # Optional labels to add to the controller pods
+  podLabels: {}
+  # Annotations to add to the controller pods
+  podAnnotations: {}
+  # Resources to request for the controller's container
+  resources: {}
+  # Optional constraints on controller's pod scheduling
+  # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # and https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 gatewayController:
   name: gateway-controller
   image: gateway-controller
   tag: v0.14.0
   replicaCount: 1
+  # Optional labels to add to the controller pods
+  podLabels: {}
+  # Annotations to add to the controller pods
+  podAnnotations: {}
+  # Resources to request for the controller's container
+  resources: {}
+  # Optional constraints on controller's pod scheduling
+  # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # and https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
This PR will enable the Argo Events chart users to specify the following for the gateway and sensor controllers:
- Extra pod labels
- Pod annotations
- Container resources
- Node selectors
- Tolerations
- Affinity

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.