### PR TITLE
fix: implementing server service labels

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.1"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.1
+version: 2.2.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/service.yaml
@@ -15,6 +15,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
+{{- if .Values.server.service.labels }}
+{{- toYaml .Values.server.service.labels | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.server.service.type }}
   ports:


### PR DESCRIPTION
The [README.md](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/README.md) file lists the `server.service.labels` setting, and so does the [values.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml) file:

```yaml
  ## Server service configuration
  service:
    annotations: {}
    labels: {}
    type: ClusterIP
```

However, in the [argocd-server/service.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/templates/argocd-server/service.yaml) file this setting was not implemented. This commit adds that functionality.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.