### PR TITLE
fix: Argo Server Secrets Permissions 

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.7.6"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.8.0
+version: 0.8.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-role.yaml
+++ b/charts/argo/templates/server-cluster-role.yaml
@@ -28,12 +28,23 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.controller.persistence }}
 - apiGroups:
   - ""
   resources:
   - secrets
+  resourceNames:
+  {{- if .Values.controller.persistence.postgresql }}
+  - {{ .Values.controller.persistence.postgresql.userNameSecret.name }}
+  - {{ .Values.controller.persistence.postgresql.passwordSecret.name }}
+  {{- end}}
+  {{- if .Values.controller.persistence.mysql }}
+  - {{ .Values.controller.persistence.mysql.userNameSecret.name }}
+  - {{ .Values.controller.persistence.mysql.passwordSecret.name }}
+  {{- end}}
   verbs:
   - get
+{{- end}}
 - apiGroups:
   - argoproj.io
   resources:

--- a/charts/argo/templates/workflow-controller-clusterrole.yaml
+++ b/charts/argo/templates/workflow-controller-clusterrole.yaml
@@ -78,4 +78,22 @@ rules:
   verbs:
   - get
   - list
+{{- if .Values.controller.persistence }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  {{- if .Values.controller.persistence.postgresql }}
+  - {{ .Values.controller.persistence.postgresql.userNameSecret.name }}
+  - {{ .Values.controller.persistence.postgresql.passwordSecret.name }}
+  {{- end}}
+  {{- if .Values.controller.persistence.mysql }}
+  - {{ .Values.controller.persistence.mysql.userNameSecret.name }}
+  - {{ .Values.controller.persistence.mysql.passwordSecret.name }}
+  {{- end}}
+  verbs:
+  - get
+{{- end}}
+
 


### PR DESCRIPTION
- Grant secret permission to argo server
- Limit the secrets permissions of the workflow controller

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.