### PR TITLE
fix: Upgrade Argo CD with v1.5.2 for security patch

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.5.1"
+appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.4
+version: 2.2.5
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -47,7 +47,7 @@ $ helm install --name my-release argo/argo-cd
 
 ### Helm v3 Compatability
 
-Requires chart version 1.5.1 or newer.
+Requires chart version 1.5.2 or newer.
 
 Helm v3 has removed the `install-crds` hook so CRDs are now populated by files in the [crds](./crds) directory. Users of Helm v3 should set the `installCRDs` value to `false` to avoid warnings about nonexistant webhooks.
 
@@ -57,7 +57,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 |-----|------|---------|
 | global.image.imagePullPolicy | If defined, a imagePullPolicy applied to all ArgoCD deployments. | `"IfNotPresent"` |
 | global.image.repository | If defined, a repository applied to all ArgoCD deployments. | `"argoproj/argocd"` |
-| global.image.tag | If defined, a tag applied to all ArgoCD deployments. | `"v1.5.1"` |
+| global.image.tag | If defined, a tag applied to all ArgoCD deployments. | `"v1.5.2"` |
 | global.securityContext | Toggle and define securityContext | See [values.yaml](values.yaml) |
 | global.imagePullSecrets | If defined, uses a Secret to pull an image from a private Docker registry or repository. | `[]` |
 | global.hostAliases | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]` |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -10,7 +10,7 @@ installCRDs: true
 global:
   image:
     repository: argoproj/argocd
-    tag: v1.5.1
+    tag: v1.5.2
     imagePullPolicy: IfNotPresent
   securityContext: {}
   #  runAsUser: 999
@@ -28,7 +28,7 @@ controller:
 
   image:
     repository: # argoproj/argocd
-    tag: # v1.5.1
+    tag: # v1.5.2
     imagePullPolicy: # IfNotPresent
 
   ## Argo controller commandline flags
@@ -319,7 +319,7 @@ server:
 
   image:
     repository: # argoproj/argocd
-    tag: # v1.5.1
+    tag: # v1.5.2
     imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-server
@@ -576,7 +576,7 @@ repoServer:
 
   image:
     repository: # argoproj/argocd
-    tag: # v1.5.1
+    tag: # v1.5.2
     imagePullPolicy: # IfNotPresent
 
   ## Additional command line arguments to pass to argocd-repo-server


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

Simply upgrading the Argo CD version from v1.5.1 to v1.5.2, as the upgrade is strongly recommended to tackle the serious vulnerability detailed in https://github.com/argoproj/argo-cd/blob/master/docs/security_considerations.md#cve-2020-5260---possible-git-credential-leak