### PR TITLE
fix: use networking.k8s.io/v1beta1 apiVersion for ingress if supported

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.5
+version: 2.2.6
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.7
+version: 2.2.8
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.6
+version: 2.2.7
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -2,11 +2,11 @@
 {{- $serviceName := include "argo-cd.server.fullname" . -}}
 {{- $servicePort := .Values.server.service.servicePortHttp -}}
 {{- $paths := .Values.server.ingress.paths -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+{{ else }}
 apiVersion: extensions/v1beta1
-{{- end }}
+{{ end -}}
 kind: Ingress
 metadata:
 {{- if .Values.server.ingress.annotations }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $serviceName := include "argo-cd.server.fullname" . -}}
 {{- $servicePort := .Values.server.service.servicePortHttp -}}
 {{- $paths := .Values.server.ingress.paths -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.server.ingress.annotations }}

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.6.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.7.3
+version: 0.7.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -2,7 +2,11 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := printf "%s-%s" .Release.Name .Values.server.name -}}
 {{- $servicePort := .Values.server.servicePort -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Values.server.name }}

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -2,11 +2,11 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := printf "%s-%s" .Release.Name .Values.server.name -}}
 {{- $servicePort := .Values.server.servicePort -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+{{ else }}
 apiVersion: extensions/v1beta1
-{{- end }}
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-{{ .Values.server.name }}


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.