### PR TITLE
feat: add BackendConfig configuration for GKE

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.7
+version: 2.2.8
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.8
+version: 2.2.9
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.6
+version: 2.2.7
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1,10 +1,11 @@
-Argo CD Chart
-======
+# Argo CD Chart
+
 A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 
 Source code can be found [here](https://argoproj.github.io/argo-cd/)
 
 ## Additional Information
+
 This is a **community maintained** chart. This chart installs [argo-cd](https://argoproj.github.io/argo-cd/), a declarative, GitOps continuous delivery tool for Kubernetes.
 
 The default installation is intended to be similar to the provided ArgoCD [releases](https://github.com/argoproj/argo-cd/releases).
@@ -18,7 +19,8 @@ This chart currently installs the non-HA version of ArgoCD.
 `controller.extraArgs`, `repoServer.extraArgs` and `server.extraArgs`  are not arrays of strings intead of a map
 
 What was
-```
+
+```yaml
 controller:
   extraArgs:
     insecure: ""
@@ -26,7 +28,7 @@ controller:
 
 is now
 
-```
+```yaml
 controller:
   extraArgs:
   - --insecure
@@ -42,7 +44,11 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add argo https://argoproj.github.io/argo-helm
+"argo" has been added to your repositories
+
 $ helm install --name my-release argo/argo-cd
+NAME: my-release
+...
 ```
 
 ### Helm v3 Compatability
@@ -62,7 +68,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | global.imagePullSecrets | If defined, uses a Secret to pull an image from a private Docker registry or repository. | `[]` |
 | global.hostAliases | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]` |
 | nameOverride | Provide a name in place of `argocd` | `"argocd"` |
-| installCRDs | bool | `true` | Install CRDs if you are using Helm2. |
+| installCRDs | Install CRDs if you are using Helm2. | `true` |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
 | configs.secret.annotations | Annotations for argocd-secret | `{}` |
 | configs.secret.argocdServerAdminPassword | Admin password | `null` |
@@ -76,9 +82,9 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 
 ## ArgoCD Controller
 
-| Key | Default | Description |
+| Parameter | Description | Default |
 |-----|---------|-------------|
-| controller.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
+| controller.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
 | controller.args.operationProcessors | define the controller `--operation-processors` | `"10"` |
 | controller.args.statusProcessors | define the controller `--status-processors` | `"20"` |
 | controller.clusterAdminAccess.enabled | Enable RBAC for local cluster deployments. | `true` |
@@ -88,11 +94,11 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.image.repository | Repository to use for the controller | `global.image.repository` |
 | controller.image.imagePullPolicy | Image pull policy for the controller | `global.image.imagePullPolicy` |
 | controller.image.tag | Tag to use for the controller | `global.image.tag` |
-| controller.livenessProbe.failureThreshold | int | `3` |
-| controller.livenessProbe.initialDelaySeconds | int | `10` |
-| controller.livenessProbe.periodSeconds | int | `10` |
-| controller.livenessProbe.successThreshold | int | `1` |
-| controller.livenessProbe.timeoutSeconds | int | `1` |
+| controller.livenessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
+| controller.livenessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| controller.livenessProbe.periodSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| controller.livenessProbe.successThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
+| controller.livenessProbe.timeoutSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
 | controller.logLevel | Controller log level | `"info"` |
 | controller.metrics.enabled | Deploy metrics service | `false` |
 | controller.metrics.service.annotations | Metrics service annotations | `{}` |
@@ -101,46 +107,46 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | controller.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | controller.name | Controller name string. | `"application-controller"` |
-| controller.nodeSelector | controller node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
+| controller.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | controller.podAnnotations | Annotations for the controller pods | `{}` |
 | controller.podLabels | Labels for the controller pods | `{}` |
 | controller.priorityClassName | Priority class for the controller pods | `""` |
-| controller.readinessProbe.failureThreshold | int | `3` |
-| controller.readinessProbe.initialDelaySeconds | int | `10` |
-| controller.readinessProbe.periodSeconds | int | `10` |
-| controller.readinessProbe.successThreshold | int | `1` |
-| controller.readinessProbe.timeoutSeconds | int | `1` |
+| controller.readinessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
+| controller.readinessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| controller.readinessProbe.periodSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| controller.readinessProbe.successThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
+| controller.readinessProbe.timeoutSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
 | controller.resources | Resource limits and requests for the controller pods. | `{}` |
 | controller.service.annotations | Controller service annotations. | `{}` |
 | controller.service.labels | Controller service labels. | `{}` |
 | controller.service.port | Controller service port. | `8082` |
 | controller.serviceAccount.create | Create a service account for the controller | `true` |
 | controller.serviceAccount.name | Service account name. | `"argocd-application-controller"` |
-| controller.tolerations | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
+| controller.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | controller.volumeMounts | Controller volume mounts | `[]` |
 | controller.volumes | Controller volumes | `[]` |
 
 ## Argo Repo Server
 
-| Key | Default | Description |
+| Property | Description | Default |
 |-----|---------|-------------|
-| repoServer.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
-| repoServer.autoscaling.enabled | Enable Horizontal Pod Autoscaler (HPA) for the repo server | `false` |
-| repoServer.autoscaling.minReplicas | Minimum number of replicas for the repo server HPA | `1` |
-| repoServer.autoscaling.maxReplicas | Maximum number of replicas for the repo server HPA | `5` |
-| repoServer.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the repo server HPA | `50` |
-| repoServer.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the repo server HPA | `50` |
+| repoServer.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| repoServer.autoscaling.enabled | Enable Horizontal Pod Autoscaler ([HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)) for the repo server | `false` |
+| repoServer.autoscaling.minReplicas | Minimum number of replicas for the repo server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `1` |
+| repoServer.autoscaling.maxReplicas | Maximum number of replicas for the repo server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `5` |
+| repoServer.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the repo server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
+| repoServer.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the repo server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
 | repoServer.containerPort | Repo server port | `8081` |
 | repoServer.extraArgs | Additional arguments for the repo server. A  list of flags. | `[]` |
 | repoServer.env | Environment variables for the repo server. | `[]` |
 | repoServer.image.repository | Repository to use for the repo server | `global.image.repository` |
 | repoServer.image.imagePullPolicy | Image pull policy for the repo server | `global.image.imagePullPolicy` |
 | repoServer.image.tag | Tag to use for the repo server | `global.image.tag` |
-| repoServer.livenessProbe.failureThreshold | int | `3` |
-| repoServer.livenessProbe.initialDelaySeconds | int | `10` |
-| repoServer.livenessProbe.periodSeconds | int | `10` |
-| repoServer.livenessProbe.successThreshold | int | `1` |
-| repoServer.livenessProbe.timeoutSeconds | int | `1` |
+| repoServer.livenessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
+| repoServer.livenessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| repoServer.livenessProbe.periodSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| repoServer.livenessProbe.successThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
+| repoServer.livenessProbe.timeoutSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
 | repoServer.logLevel | Log level | `"info"` |
 | repoServer.metrics.enabled | Deploy metrics service | `false` |
 | repoServer.metrics.service.annotations | Metrics service annotations | `{}` |
@@ -149,34 +155,34 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | repoServer.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | repoServer.name | Repo server name | `"repo-server"` |
-| repoServer.nodeSelector | controller node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
+| repoServer.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | repoServer.podAnnotations | Annotations for the repo server pods | `{}` |
 | repoServer.podLabels | Labels for the repo server pods | `{}` |
 | repoServer.priorityClassName | Priority class for the repo server | `""` |
-| repoServer.readinessProbe.failureThreshold | int | `3` |
-| repoServer.readinessProbe.initialDelaySeconds | int | `10` |
-| repoServer.readinessProbe.periodSeconds | int | `10` |
-| repoServer.readinessProbe.successThreshold | int | `1` |
-| repoServer.readinessProbe.timeoutSeconds | int | `1` |
+| repoServer.readinessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
+| repoServer.readinessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| repoServer.readinessProbe.periodSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| repoServer.readinessProbe.successThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
+| repoServer.readinessProbe.timeoutSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
 | repoServer.replicas | The number of repo server pods to run | `1` |
 | repoServer.resources | Resource limits and requests for the repo server pods. | `{}` |
 | repoServer.service.annotations | Repo server service annotations. | `{}` |
 | repoServer.service.labels | Repo server service labels. | `{}` |
 | repoServer.service.port | Repo server service port. | `8081` |
-| repoServer.tolerations | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
+| repoServer.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | repoServer.volumeMounts | Repo server volume mounts | `[]` |
 | repoServer.volumes | Repo server volumes | `[]` |
 
 ## Argo Server
 
-| Key | Default | Description |
+| Parameter | Description | Default |
 |-----|---------|-------------|
-| server.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
-| server.autoscaling.enabled | Enable Horizontal Pod Autoscaler (HPA) for the server | `false` |
-| server.autoscaling.minReplicas | Minimum number of replicas for the server HPA | `1` |
-| server.autoscaling.maxReplicas | Maximum number of replicas for the server HPA | `5` |
-| server.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the server HPA | `50` |
-| server.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the server HPA | `50` |
+| server.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| server.autoscaling.enabled | Enable Horizontal Pod Autoscaler ([HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)) for the server | `false` |
+| server.autoscaling.minReplicas | Minimum number of replicas for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `1` |
+| server.autoscaling.maxReplicas | Maximum number of replicas for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `5` |
+| server.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
+| server.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
 | server.certificate.additionalHosts | Certificate manager additional hosts | `[]` |
 | server.certificate.domain | Certificate manager domain | `"argocd.example.com"` |
 | server.certificate.enabled | Enables a certificate manager certificate. | `false` |
@@ -188,7 +194,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.env | Environment variables for the server. | `[]` |
 | server.image.repository | Repository to use for the server | `global.image.repository` |
 | server.image.imagePullPolicy | Image pull policy for the server | `global.image.imagePullPolicy` |
-| server.image.tag | Tag to use for the repo server | `global.image.tag` |
+| server.image.tag | Tag to use for the server | `global.image.tag` |
 | server.ingress.annotations | Additional ingress annotations | `{}` |
 | server.ingress.enabled | Enable an ingress resource for the server | `false` |
 | server.ingress.hosts | List of ingress hosts | `[]` |
@@ -196,11 +202,11 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.ingress.tls | Ingress TLS configuration. | `[]` |
 | server.route.enabled | Enable a OpenShift route for the server | `false` |
 | server.route.hostname | Hostname of OpenShift route | `""` |
-| server.livenessProbe.failureThreshold | int | `3` |
-| server.livenessProbe.initialDelaySeconds | int | `10` |
-| server.livenessProbe.periodSeconds | int | `10` |
-| server.livenessProbe.successThreshold | int | `1` |
-| server.livenessProbe.timeoutSeconds | int | `1` |
+| server.livenessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
+| server.livenessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| server.livenessProbe.periodSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| server.livenessProbe.successThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
+| server.livenessProbe.timeoutSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
 | server.logLevel | Log level | `"info"` |
 | server.metrics.enabled | Deploy metrics service | `false` |
 | server.metrics.service.annotations | Metrics service annotations | `{}` |
@@ -209,16 +215,16 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | server.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | server.name | Argo CD server name | `"server"` |
-| server.nodeSelector | controller node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
-| server.podAnnotations | Annotations for the repo server pods | `{}` |
-| server.podLabels | Labels for the repo server pods | `{}` |
-| server.priorityClassName | Priority class for the repo server | `""` |
+| server.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
+| server.podAnnotations | Annotations for the server pods | `{}` |
+| server.podLabels | Labels for the server pods | `{}` |
+| server.priorityClassName | Priority class for the server | `""` |
 | server.rbacConfig | [Argo CD RBAC policy](https://argoproj.github.io/argo-cd/operator-manual/rbac/) | `{}` |
-| server.readinessProbe.failureThreshold | int | `3` |
-| server.readinessProbe.initialDelaySeconds | int | `10` |
-| server.readinessProbe.periodSeconds | int | `10` |
-| server.readinessProbe.successThreshold | int | `1` |
-| server.readinessProbe.timeoutSeconds | int | `1` |
+| server.readinessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
+| server.readinessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| server.readinessProbe.periodSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |
+| server.readinessProbe.successThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
+| server.readinessProbe.timeoutSeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `1` |
 | server.replicas | The number of server pods to run | `1` |
 | server.resources | Resource limits and requests for the server | `{}` |
 | server.service.annotations | Server service annotations | `{}` |
@@ -229,15 +235,15 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.service.type | Server service type | `"ClusterIP"` |
 | server.serviceAccount.create | Create server service account | `true` |
 | server.serviceAccount.name | Server service account name | `"argocd-server"` |
-| server.tolerations | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
+| server.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | server.volumeMounts | Server volume mounts | `[]` |
 | server.volumes | Server volumes | `[]` |
 
 ## Dex
 
-| Key | Default | Description |
+| Property | Description | Default |
 |-----|---------|-------------|
-| dex.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
+| dex.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
 | dex.containerPortGrpc | GRPC container port | `5557` |
 | dex.containerPortHttp | HTTP container port | `5556` |
 | dex.enabled | Enable dex | `true` |
@@ -249,7 +255,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | dex.initImage.tag | Argo CD init image tag | `global.image.tag` |
 | dex.name | Dex name | `"dex-server"` |
 | dex.env | Environment variables for the Dex server. | `[]` |
-| dex.nodeSelector | Dex node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
+| dex.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | dex.podAnnotations | Annotations for the Dex server pods | `{}` |
 | dex.podLabels | Labels for the Dex server pods | `{}` |
 | dex.priorityClassName | Priority class for dex | `""` |
@@ -258,7 +264,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | dex.serviceAccount.name | Dex service account name | `"argocd-dex-server"` |
 | dex.servicePortGrpc | Server GRPC port | `5557` |
 | dex.servicePortHttp | Server HTTP port | `5556` |
-| dex.tolerations | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
+| dex.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | dex.volumeMounts | Dex volume mounts | `"/shared"` |
 | dex.volumes | Dex volumes | `{}` |
 
@@ -270,9 +276,9 @@ when Redis HA subcart is enabled (`redis.enabled=true and redis-ha.enabled=true`
 but HA proxy is disabled `redis-ha.haproxy.enabled=false` Redis flags need to be specified
 through `xxx.extraArgs`
 
-| Key | Default | Description |
+| Parameter | Description | Default |
 |-----|---------|-------------|
-| redis.affinity | Assign custom affinity rules to the deployment https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ | `{}` |
+| redis.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
 | redis.containerPort | Redis container port | `6379` |
 | redis.enabled | Enable redis | `true` |
 | redis.image.imagePullPolicy | Redis imagePullPolicy | `"IfNotPresent"` |
@@ -280,14 +286,14 @@ through `xxx.extraArgs`
 | redis.image.tag | Redis tag | `"5.0.3"` |
 | redis.name | Redis name | `"redis"` |
 | redis.env | Environment variables for the Redis server. | `[]` |
-| redis.nodeSelector | Redis node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
+| redis.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | redis.podAnnotations | Annotations for the Redis server pods | `{}` |
 | redis.podLabels | Labels for the Redis server pods | `{}` |
 | redis.priorityClassName | Priority class for redis | `""` |
 | redis.resources | Resource limits and requests for redis | `{}` |
 | redis.servicePort | Redis service port | `6379` |
-| redis.tolerations | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
-| redis-ha | Configures Redis HA subchart https://github.com/helm/charts/tree/master/stable/redis-ha | | |
+| redis.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
+| redis-ha | Configures [Redis HA subchart](https://github.com/helm/charts/tree/master/stable/redis-ha) The properties below have been changed from the subchart defaults | |
 | redis-ha.enabled | Enables the Redis HA subchart and disables the custom Redis single node deployment| `false` |
 | redis-ha.exporter.enabled | If `true`, the prometheus exporter sidecar is enabled | `true` |
 | redis-ha.persistentVolume.enabled | Configures persistency on Redis nodes | `false`
@@ -295,4 +301,4 @@ through `xxx.extraArgs`
 | redis-ha.redis.config | Any valid redis config options in this section will be applied to each server (see `redis-ha` chart) | `` |
 | redis-ha.redis.config.save | Will save the DB if both the given number of seconds and the given number of write operations against the DB occurred. `""`  is disabled | `""` |
 | redis-ha.haproxy.enabled | Enabled HAProxy LoadBalancing/Proxy | `true` |
-| redis-ha.haproxy.metrics.enabled | HAProxy enable prometheus metric scraping	 | `true` |
+| redis-ha.haproxy.metrics.enabled | HAProxy enable prometheus metric scraping | `true` |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -183,8 +183,8 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.autoscaling.maxReplicas | Maximum number of replicas for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `5` |
 | server.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
 | server.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
-| server.backendConfig.enabled | Enable BackendConfig custom resource for Google Kubernetes Engine. | `false` |
-| server.backendConfig.spec | [BackendConfigSpec](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig#backendconfigspec_v1beta1_cloudgooglecom) | `{}` |
+| server.GKEbackendConfig.enabled | Enable BackendConfig custom resource for Google Kubernetes Engine. | `false` |
+| server.GKEbackendConfig.spec | [BackendConfigSpec](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig#backendconfigspec_v1beta1_cloudgooglecom) | `{}` |
 | server.certificate.additionalHosts | Certificate manager additional hosts | `[]` |
 | server.certificate.domain | Certificate manager domain | `"argocd.example.com"` |
 | server.certificate.enabled | Enables a certificate manager certificate. | `false` |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -183,6 +183,8 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.autoscaling.maxReplicas | Maximum number of replicas for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `5` |
 | server.autoscaling.targetCPUUtilizationPercentage | Average CPU utilization percentage for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
 | server.autoscaling.targetMemoryUtilizationPercentage | Average memory utilization percentage for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `50` |
+| server.backendConfig.enabled | Enable BackendConfig custom resource for Google Kubernetes Engine. | `false` |
+| server.backendConfig.spec | [BackendConfigSpec](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig#backendconfigspec_v1beta1_cloudgooglecom) | `{}` |
 | server.certificate.additionalHosts | Certificate manager additional hosts | `[]` |
 | server.certificate.domain | Certificate manager domain | `"argocd.example.com"` |
 | server.certificate.enabled | Enables a certificate manager certificate. | `false` |

--- a/charts/argo-cd/templates/argocd-server/backendconfig.yaml
+++ b/charts/argo-cd/templates/argocd-server/backendconfig.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.backendConfig.enabled }}
+{{- if .Values.server.GKEbackendConfig.enabled }}
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
 spec:
-  {{- toYaml .Values.server.backendConfig.spec | nindent 2 }}
+  {{- toYaml .Values.server.GKEbackendConfig.spec | nindent 2 }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/backendconfig.yaml
+++ b/charts/argo-cd/templates/argocd-server/backendconfig.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.server.backendConfig.enabled }}
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ template "argo-cd.server.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: {{ .Values.server.name }}
+spec:
+  {{- toYaml .Values.server.backendConfig.spec | nindent 2 }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -561,6 +561,16 @@ server:
   clusterAdminAccess:
     enabled: true
 
+  ## Enable BackendConfig custom resource for Google Kubernetes Engine
+  backendConfig:
+    enabled: false
+    spec: {}
+  #  spec:
+  #    iap:
+  #      enabled: true
+  #      oauthclientCredentials:
+  #        secretName: argocd-iap
+
 ## Repo Server
 repoServer:
   name: repo-server

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -562,7 +562,7 @@ server:
     enabled: true
 
   ## Enable BackendConfig custom resource for Google Kubernetes Engine
-  backendConfig:
+  GKEbackendConfig:
     enabled: false
     spec: {}
   #  spec:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -569,7 +569,7 @@ server:
   #    iap:
   #      enabled: true
   #      oauthclientCredentials:
-  #        secretName: argocd-iap
+  #        secretName: argocd-secret
 
 ## Repo Server
 repoServer:


### PR DESCRIPTION
Hi!

This PR wants to add configuration about [CRD BackendConfig in Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig) to argocd-server.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.