### PR TITLE
chore: Bump argo-rollouts version to v0.8.0

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.7"
+appVersion: "v0.8.0"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.2.0
+version: 1.0.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -2,7 +2,7 @@ Argo Rollouts Chart
 =============
 A Helm chart for Argo Rollouts, progressive delivery for Kubernetes.
 
-Current chart version is `0.2.0`
+Current chart version is `1.0.0`
 
 Source code can be found [here](https://github.com/argoproj/argo-rollouts)
 

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -7,7 +7,7 @@ controller:
   component: rollouts-controller
   image:
     repository: argoproj/argo-rollouts
-    tag: v0.7.0
+    tag: v0.8.0
     pullPolicy: IfNotPresent
 
 serviceAccount:


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.