### PR TITLE
feat: Allow custom paths for server ingress

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.6.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.7.4
+version: 0.8.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v2.6.1"
+appVersion: "v2.7.6"
 description: A Helm chart for Argo Workflows
 name: argo
 version: 0.8.2

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -29,8 +29,8 @@ spec:
           - backend:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
-          {{- end -}}
-          {{- end -}}
+          {{- end }}
+          {{- end }}
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -27,10 +27,12 @@ spec:
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- if $.Values.server.ingress.paths -}}
           {{- range $.Values.server.ingress.paths }}
           - backend:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+          {{- end -}}
           {{- end -}}
     {{- end -}}
   {{- if .Values.server.ingress.tls }}

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -24,7 +24,7 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          {{- if $.Values.server.ingress.paths -}}
+          {{- if $.Values.server.ingress.paths }}
           {{- range $.Values.server.ingress.paths }}
           - backend:
               serviceName: {{ .serviceName }}

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -27,7 +27,7 @@ spec:
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-          {{- range .Values.server.ingress.paths }}
+          {{- range $.Values.server.ingress.paths }}
           - backend:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -24,9 +24,6 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
           {{- if $.Values.server.ingress.paths -}}
           {{- range $.Values.server.ingress.paths }}
           - backend:
@@ -34,6 +31,9 @@ spec:
               servicePort: {{ .servicePort }}
           {{- end -}}
           {{- end -}}
+          - backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -27,6 +27,11 @@ spec:
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- range .Values.server.ingress.paths }}
+          - backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end -}}
     {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -164,6 +164,11 @@ server:
     # hosts:
     #   - argo.domain.com
 
+    ##Additional Paths for each host
+    # paths:
+    #   - serviceName: "ssl-redirect"
+    #     servicePort: "use-annotation"
+
     ## TLS configuration.
     ## Secrets must be manually created in the namespace.
     ##

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -164,7 +164,7 @@ server:
     # hosts:
     #   - argo.domain.com
 
-    ##Additional Paths for each host
+    ## Additional Paths for each host
     # paths:
     #   - serviceName: "ssl-redirect"
     #     servicePort: "use-annotation"


### PR DESCRIPTION
We use AWS EKS to host our cluster.  When we setup services using https we normally use ACM for the certificate, route53 for the domain and an ALB for handling the traffic to the service itself.  As part of this we like to put an http -> https redirect on port 80.  To do this we need to add another backend, as well as add an additional annotation on the load balancer.
```
alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
```

This PR just gives us the ability to add the additional listener rule on the ALB to perform that redirect.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.