### PR TITLE
feat: Adds support for workflow defaults in Argo.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.6.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.7.5
+version: 0.7.6
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -49,3 +49,6 @@ data:
     {{- if .Values.controller.persistence }}
     persistence:
 {{ toYaml .Values.controller.persistence | indent 6 }}{{- end }}
+    {{- if .Values.controller.workflowDefaults }}
+    workflowDefaults:
+{{ toYaml .Values.controller.workflowDefaults | indent 6 }}{{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -47,6 +47,10 @@ controller:
     #    passwordSecret:
     #      name: argo-postgres-config
     #      key: password
+  workflowDefaults: {}  # Only valid for 2.7+
+  #  spec:
+  #    ttlStrategy:
+  #      secondsAfterCompletion: 84600
   telemetryConfig:
     enabled: false
     path: /telemetry


### PR DESCRIPTION
This adds support for the new Argo workflow defaults [feature](https://github.com/argoproj/argo/blob/master/docs/default-workflow-specs.md) to the chart.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.