### PR TITLE
Adding resources and tolerations to Argo-Events

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.6.1
+version: 0.6.2
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -58,6 +58,7 @@ rules:
       - gateways/finalizers
       - sensors
       - sensors/finalizers
+      - namespaces
   - apiGroups:
       - ""
     resources:

--- a/charts/argo-events/templates/gateway-controller-deployment.yaml
+++ b/charts/argo-events/templates/gateway-controller-deployment.yaml
@@ -31,3 +31,17 @@ spec:
                   fieldPath: metadata.namespace
             - name: GATEWAY_CONTROLLER_CONFIG_MAP
               value: {{ .Release.Name }}-{{ .Values.gatewayController.name }}-configmap
+          resources:
+{{ toYaml .Values.gatewayController.resources | indent 12 }}
+    {{- with .Values.gatewatController.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.gatewayController.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.gatewayController.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/argo-events/templates/sensor-controller-deployment.yaml
+++ b/charts/argo-events/templates/sensor-controller-deployment.yaml
@@ -31,3 +31,17 @@ spec:
                   fieldPath: metadata.namespace
             - name: SENSOR_CONFIG_MAP
               value: {{ .Release.Name }}-{{ .Values.sensorController.name }}-configmap
+          resources:
+{{ toYaml .Values.sensorController.resources | indent 12 }}
+    {{- with .Values.sensorController.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.sensorController.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.sensorController.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -28,9 +28,17 @@ sensorController:
   image: sensor-controller
   tag: v0.11
   replicaCount: 1
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 gatewayController:
   name: gateway-controller
   image: gateway-controller
   tag: v0.11
   replicaCount: 1
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
We're managing a new cluster and migrating argo and argo events to the new cluster, but cannot deploy argo-events without `nodeSelector` as we are not using not tainted nodes in out kubernetes cluster.

Default is obviously nothing. I've forked my own version for the time being so we can deploy in the interim.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.