### PR TITLE
fix(argo-events): resources and tolerations for Argo-Events chart

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.14.0
+version: 0.14.1
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/templates/gateway-controller-deployment.yaml
+++ b/charts/argo-events/templates/gateway-controller-deployment.yaml
@@ -31,3 +31,17 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTROLLER_CONFIG_MAP
               value: {{ .Release.Name }}-{{ .Values.gatewayController.name }}-configmap
+          resources:
+{{ toYaml .Values.gatewayController.resources | indent 12 }}
+    {{- with .Values.gatewatController.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.gatewayController.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.gatewayController.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/argo-events/templates/gateway-controller-deployment.yaml
+++ b/charts/argo-events/templates/gateway-controller-deployment.yaml
@@ -33,7 +33,7 @@ spec:
               value: {{ .Release.Name }}-{{ .Values.gatewayController.name }}-configmap
           resources:
 {{ toYaml .Values.gatewayController.resources | indent 12 }}
-    {{- with .Values.gatewatController.nodeSelector }}
+    {{- with .Values.gatewayController.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/charts/argo-events/templates/sensor-controller-deployment.yaml
+++ b/charts/argo-events/templates/sensor-controller-deployment.yaml
@@ -31,3 +31,18 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTROLLER_CONFIG_MAP
               value: {{ .Release.Name }}-{{ .Values.sensorController.name }}-configmap
+          resources: 
+{{ toYaml .Values.sensorController.resources | indent 12 }}
+    {{- with .Values.sensorController.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.sensorController.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.sensorController.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -49,7 +49,6 @@ sensorController:
   tolerations: []
   affinity: {}
 
-
 gatewayController:
   name: gateway-controller
   image: gateway-controller
@@ -59,4 +58,3 @@ gatewayController:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -44,9 +44,19 @@ sensorController:
   image: sensor-controller
   tag: v0.14.0
   replicaCount: 1
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 
 gatewayController:
   name: gateway-controller
   image: gateway-controller
   tag: v0.14.0
   replicaCount: 1
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+


### PR DESCRIPTION
Adding resources, tolerations, and affinity to the controller deployments for argo-events.

If there are no nodes without a taint, the deployment will fail. We've become strict on taints with our nodes to ensure that workloads don't leak and that nodes are not accidentally overcommitted.  Defaults will be nothing.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.