### PR TITLE
docs: Mention bcrypt hashing for admin password in README.md

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.2.11
+version: 2.2.12
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -70,7 +70,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | installCRDs | Install CRDs if you are using Helm2. | `true` |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
 | configs.secret.annotations | Annotations for argocd-secret | `{}` |
-| configs.secret.argocdServerAdminPassword | Admin password | `null` |
+| configs.secret.argocdServerAdminPassword | Bcrypt hashed admin password | `null` |
 | configs.secret.argocdServerAdminPasswordMtime | Admin password modification time | `date "2006-01-02T15:04:05Z" now` if configs.secret.argocdServerAdminPassword is set |
 | configs.secret.bitbucketSecret | BitBucket incoming webhook secret | `""` |
 | configs.secret.createSecret | Create the argocd-secret. | `true` |


### PR DESCRIPTION
Mention bcrypt hashing for admin password value
It took me while to figure out that value needs to be hashed. I spend an hour searching why it's not working for me when I was passing plain text password. :)

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.