### PR TITLE
fix: workflow-controller-config-map.yaml

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.9.2
+version: 0.9.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -38,8 +38,8 @@ data:
         bucket: {{ .Values.artifactRepository.s3.bucket | default .Values.minio.defaultBucket.name }}
         endpoint: {{ .Values.artifactRepository.s3.endpoint | default (printf "%s-%s" .Release.Name "minio:9000") }}
         insecure: {{ .Values.artifactRepository.s3.insecure }}
-        {{- if .Values.artifactRepository.s3.keyPrefix }}
-        keyPrefix: {{ .Values.artifactRepository.s3.keyPrefix }}
+        {{- if .Values.artifactRepository.s3.keyFormat }}
+        keyFormat: {{ .Values.artifactRepository.s3.keyFormat }}
         {{- end }}
         {{- if .Values.artifactRepository.s3.region }}
         region: {{ .Values.artifactRepository.s3.region }}


### PR DESCRIPTION
keyPrefix is deprecated; use keyFormat instead: https://github.com/argoproj/argo/blob/master/config/config.go#L183

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.