### PR TITLE
feat: Add support for ClusterWorkflowTemplates (a 2.8 feature).

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v2.7.6"
+appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.8.6
+version: 0.9.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/crds/cluster-workflow-template-crd.yaml
+++ b/charts/argo/crds/cluster-workflow-template-crd.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterworkflowtemplates.argoproj.io
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  group: argoproj.io
+  version: v1alpha1
+  scope: Cluster
+  names:
+    kind: ClusterWorkflowTemplate
+    plural: clusterworkflowtemplates
+    shortNames:
+    - clusterwftmpl
+    - cwft

--- a/charts/argo/templates/cluster-workflow-template-crd.yaml
+++ b/charts/argo/templates/cluster-workflow-template-crd.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.installCRD }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterworkflowtemplates.argoproj.io
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  group: argoproj.io
+  version: v1alpha1
+  scope: Cluster
+  names:
+    kind: ClusterWorkflowTemplate
+    plural: clusterworkflowtemplates
+    shortNames:
+    - clusterwftmpl
+    - cwft
+{{- end }}

--- a/charts/argo/templates/server-cluster-role.yaml
+++ b/charts/argo/templates/server-cluster-role.yaml
@@ -58,6 +58,7 @@ rules:
   - workflows
   - workflowtemplates
   - cronworkflows
+  - clusterworkflowtemplates
   verbs:
   - create
   - get

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -18,6 +18,8 @@ rules:
   - workflowtemplates/finalizers
   - cronworkflows
   - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
   verbs:
   - get
   - list
@@ -42,6 +44,8 @@ rules:
   - workflowtemplates/finalizers
   - cronworkflows
   - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
   verbs:
   - create
   - delete
@@ -71,6 +75,8 @@ rules:
   - workflowtemplates/finalizers
   - cronworkflows
   - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
   verbs:
   - create
   - delete

--- a/charts/argo/templates/workflow-controller-clusterrole.yaml
+++ b/charts/argo/templates/workflow-controller-clusterrole.yaml
@@ -55,6 +55,8 @@ rules:
   resources:
   - workflowtemplates
   - workflowtemplates/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION
This PR adds chart support for `ClusterWorkflowTemplate`, a feature implemented in Argo 2.8. It adds the CRD and modifies the RBAC rules to allow the workflow controller and the server to access the `ClusterWorkflowTemplate` objects. The chart's minor version has been bumped because the changes are new features.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.