### PR TITLE
[Argo-cd] SSL passthrough requires https servicePort in ingress

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.3.2
+version: 2.3.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -199,6 +199,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.image.tag | Tag to use for the server | `global.image.tag` |
 | server.ingress.annotations | Additional ingress annotations | `{}` |
 | server.ingress.enabled | Enable an ingress resource for the server | `false` |
+| server.ingress.servicePort | Override servicePort used in ingress. Assign 443 when SSL passthrough is used | `` |
 | server.ingress.hosts | List of ingress hosts | `[]` |
 | server.ingress.labels | Additional ingress labels. | `{}` |
 | server.ingress.tls | Ingress TLS configuration. | `[]` |

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := include "argo-cd.server.fullname" . -}}
-{{- $servicePort := .Values.server.service.servicePortHttp -}}
+{{- $servicePort := default .Values.server.service.servicePortHttp  .Values.server.ingress.servicePort -}}
 {{- $paths := .Values.server.ingress.paths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -432,6 +432,9 @@ server:
     annotations: {}
     labels: {}
 
+    # Override service port when using SSL passthrough ingress
+    # servicePort: 443
+
     ## Argo Ingress.
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace


### PR DESCRIPTION
The seviceport must be 443 when ingress SSL-passthrough is used. This change makes it possible to override the chart's default servicePort (http/80).

If the default port 80 is used for SSL-passthrough then you will get errors like "502 Bad Gateway".

Example vaules using **servicePort** when using SSL-passthrough:
```
server:
  ingress:
    enabled: true
    servicePort: 443
    hosts:
      - 'argo.mycompany.foo.bar'
    tls:
      - secretName: argocd-secret
        hosts:
          - 'argo.mycompany.foo.bar'
    annotations:
      kubernetes.io/ingress.class: nginx
      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
```


Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.