### PR TITLE
feat: Enable specifying environment for Argo  workflow executor.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.9.0
+version: 0.9.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -16,10 +16,14 @@ data:
     {{- end }}
     {{- end }}
     containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
-    {{- with .Values.executor.resources }}
+    {{- if or .Values.executor.resources .Values.executor.env }}
     executor:
-      resources:
-        {{- toYaml . | nindent 8 }}
+      {{- with .Values.executor.resources }}
+      resources: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executor.env }}
+      env: {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     artifactRepository:
       {{- if or .Values.minio.install .Values.useDefaultArtifactRepo }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -111,6 +111,8 @@ executor:
     # Overrides .images.tag if defined.
     tag: ""
   resources: {}
+  # Adds environment variables for the executor.
+  env: {}
 
 server:
   enabled: true


### PR DESCRIPTION
Sometimes one needs to specify environment for the Argo workflow executor pods. For example, to control behavior of the AWS client.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.