### PR TITLE
fix: typo on spec.loadBalancerSourceRanges for argocd-server/service.yaml

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.3.2
+version: 2.3.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/service.yaml
@@ -37,7 +37,7 @@ spec:
   loadBalancerIP: {{ .Values.server.service.loadBalancerIP | quote }}
 {{- end }}
 {{- if .Values.server.service.loadBalancerSourceRanges }}
-  loadBalancerSourceranges:
+  loadBalancerSourceRanges:
 {{ toYaml .Values.server.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Hey team, while trying to set some elb security groups, I ran into an error:
```bash
 Comparing release=argocd, chart=argo/argo-cd
 in ./helmfile.yaml: failed processing release argocd: helm exited with status 1:
   Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Service.spec): unknown field "loadBalancerSourceranges" in io.k8s.api.core.v1.ServiceSpec
   
   Error: plugin "diff" exited with error
Running after_script
00:01
Uploading artifacts for failed job
 ERROR: Job failed: exit code 1
```

Upon looking at the chart, it appears there is a typo on the key `loadBalancerSourceRanges` -- per kube [docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service)
Please let me know if I can provide any additional information.



Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.