### PR TITLE
Added initcontainers to server deployment.yaml

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.3.3
+version: 2.3.4
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -189,6 +189,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.certificate.domain | Certificate manager domain | `"argocd.example.com"` |
 | server.certificate.enabled | Enables a certificate manager certificate. | `false` |
 | server.certificate.issuer | Certificate manager issuer | `{}` |
+| server.initContainers | initContainers for server can be used for custom plugin wgets | `{}` |
 | server.clusterAdminAccess.enabled | Enable RBAC for local cluster deployments. | `true` |
 | server.config | [General Argo CD configuration](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repositories) | See [values.yaml](values.yaml) |
 | server.containerPort | Server container port. | `8080` |

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -47,6 +47,10 @@ spec:
       {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
+      {{- if .Values.server.initContainers }}
+      initContainers:
+{{- toYaml .Values.server.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.server.name }}
         image: {{ default .Values.global.image.repository .Values.server.image.repository }}:{{ default .Values.global.image.tag .Values.server.image.tag }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -342,6 +342,15 @@ server:
   ##
   podLabels: {}
 
+  ## initContainer
+  initContainers: {}
+    ## - name: download-tools
+    ##   image: alpine:3.8
+    ##   command: [sh, -c]
+    ##   args:
+    ##   - wget -qO- https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz | tar -xvzf - &&
+    ##     mv linux-amd64/helm /custom-tools/
+
   ## Configures the server port
   containerPort: 8080
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -343,7 +343,7 @@ server:
   podLabels: {}
 
   ## initContainer
-  initContainers: {}
+  initContainers: []
     ## - name: download-tools
     ##   image: alpine:3.8
     ##   command: [sh, -c]


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

Changes: Added initcontainers to server deployment.yaml

This gives the ability to have an init container on deploy, so if you are going to use custom plugin you can make your `deployment.yaml` similar to the one in the [documentation](https://argoproj.github.io/argo-cd/operator-manual/custom_tools/) 

```
    spec:
      # 1. Define an emptyDir volume which will hold the custom binaries
      volumes:
      - name: custom-tools
        emptyDir: {}
      # 2. Use an init container to download/copy custom binaries into the emptyDir
      initContainers:
      - name: download-tools
        image: alpine:3.8
        command: [sh, -c]
        args:
        - wget -qO- https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz | tar -xvzf - &&
          mv linux-amd64/helm /custom-tools/
        volumeMounts:
        - mountPath: /custom-tools
          name: custom-tools
      # 3. Volume mount the custom binary to the bin directory (overriding the existing version)
      containers:
      - name: argocd-repo-server
        volumeMounts:
        - mountPath: /usr/local/bin/helm
          name: custom-tools
          subPath: helm
```