### PR TITLE
chore: bump image versions to v0.15.0

### DIFF
--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -42,11 +42,11 @@ singleNamespace: true
 sensorController:
   name: sensor-controller
   image: sensor-controller
-  tag: v0.14.0
+  tag: v0.15.0
   replicaCount: 1
 
 gatewayController:
   name: gateway-controller
   image: gateway-controller
-  tag: v0.14.0
+  tag: v0.15.0
   replicaCount: 1


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.