### PR TITLE
docs: Add archive option to values.yaml to clarify persistence options

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.9.3
+version: 0.9.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -39,6 +39,8 @@ controller:
   #   maxOpenConns: 0
   # # save the entire workflow into etcd and DB
   # nodeStatusOffLoad: false
+  # # enable archiving of old workflows
+  # archive: false
   # postgresql:
   #   host: localhost
   #   port: 5432


### PR DESCRIPTION
This has simply added the comment `archive: false` flag to the values.yaml file.

I have added it because it must be set to true in order for argo to actually start archiving old workflows. I had no idea the flag exised and it was only after hunting around on the argo website for a while that I found this:

https://argoproj.github.io/docs/argo/workflow-archive.html

Upon trying that the system sprang to life and all was good with the world.

I just thought having this here might save someone else the trouble!


Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.