### PR TITLE
fix: remove Argo CD server route status field

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.3.5
+version: 2.3.6
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/route.yaml
+++ b/charts/argo-cd/templates/argocd-server/route.yaml
@@ -26,6 +26,4 @@ spec:
     termination: {{ .Values.server.route.termination_type | default "passthrough" }}
     insecureEdgeTerminationPolicy: {{ .Values.server.route.termination_policy | default "None" }} 
   wildcardPolicy: None
-status:
-  ingress: []
 {{- end }}


### PR DESCRIPTION
Status fields prevent resources from converging.

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.