### PR TITLE
feat: Helm chart contribution for argocd-notifications

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,16 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
+# Argo Workflows
+/charts/argo @benjaminws @stefansedich @paguos
+
 # Argo CD
 /charts/argo-cd @seanson @spencergilbert
 
 # Argo Events
 /charts/argo-events @jbehling
 
-# Argo Workflows
-/charts/argo @benjaminws @stefansedich @paguos
-
 # Argo Rollouts
 /charts/argo-rollouts @cabrinha
+
+# Argo CD Notifications
+/charts/argocd-notifications @alexmt @andyfeller

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ argocd app create guestbook --dest-namespace default --dest-server https://kuber
 argocd app sync guestbook
 ```
 
+## Testing Argo CD Notification Changes
+
+Thorough testing of argocd-notifications would require one or more notification services (Slack, OpsGenie, etc), however
+minimal testing mostly consists of successful Helm chart installation and the argocd-notifications controller having
+access to the `Application` resources in the same namespace that Argo CD is installed.
+
+```
+helm install argocd-notifications charts/argocd-notifications --namespace argocd
+```
+
 ## New Application Versions
 
 When raising application versions ensure you make the following changes:

--- a/charts/argocd-notifications/.helmignore
+++ b/charts/argocd-notifications/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -10,3 +10,5 @@ keywords:
   - argoproj
   - argocd
   - argocd-notifications
+maintainers:
+  - name: alexmt

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: 0.7.0
+description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
+name: argocd-notifications
+type: application
+version: 1.0.0
+home: https://github.com/argoproj/argo-helm
+icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
+keywords:
+  - argoproj
+  - argocd
+  - argocd-notifications

--- a/charts/argocd-notifications/README.md
+++ b/charts/argocd-notifications/README.md
@@ -1,0 +1,9 @@
+## ArgoCD Notifications Chart
+
+This is a **community maintained** chart. It installs the [argocd-notifications](https://github.com/argoproj-labs/argocd-notifications) application. This application comes packaged with:
+- Notifications Controller Deployment
+- Notifications Controller ConfigMap
+- Notifications Controller Secret
+- Service Account
+- Roles
+- Role Bindings

--- a/charts/argocd-notifications/templates/_helpers.tpl
+++ b/charts/argocd-notifications/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argocd-notifications.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "argocd-notifications.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argocd-notifications.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "argocd-notifications.labels" -}}
+helm.sh/chart: {{ include "argocd-notifications.chart" . }}
+{{ include "argocd-notifications.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "argocd-notifications.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argocd-notifications.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "argocd-notifications.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "argocd-notifications.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/argocd-notifications/templates/configmap.yaml
+++ b/charts/argocd-notifications/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-cm
+  labels:
+    {{- include "argocd-notifications.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    context:
+      argocdUrl: {{ .Values.argocdUrl | quote }}
+    subscriptions:
+      {{- toYaml .Values.subscriptions | nindent 6 }}
+    templates:
+      {{- toYaml .Values.templates | nindent 6 }}
+    triggers:
+      {{- toYaml .Values.triggers | nindent 6 }}

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-controller
+  labels:
+    {{- include "argocd-notifications.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "argocd-notifications.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "argocd-notifications.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "argocd-notifications.serviceAccountName" . }}
+      containers:
+        - name: {{ include "argocd-notifications.name" . }}-controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag}}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          command:
+            - /app/argocd-notifications
+            - controller
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         {{- include "argocd-notifications.selectorLabels" . | nindent 8 }}
     spec:
+      strategy:
+        type: Recreate
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/argocd-notifications/templates/role.yaml
+++ b/charts/argocd-notifications/templates/role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-controller
+  labels:
+    {{- include "argocd-notifications.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  - appprojects
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/argocd-notifications/templates/rolebinding.yaml
+++ b/charts/argocd-notifications/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-controller
+  labels:
+    {{- include "argocd-notifications.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "argocd-notifications.name" . }}-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argocd-notifications.serviceAccountName" . }}

--- a/charts/argocd-notifications/templates/secret.yaml
+++ b/charts/argocd-notifications/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-secret
+  labels:
+    {{- include "argocd-notifications.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  notifiers.yaml: |
+{{- if .Values.secret.notifiers.slack.enabled }}
+    slack:
+      token: {{ .Values.secret.notifiers.slack.token }}
+      username: {{ .Values.secret.notifiers.slack.username }}
+{{- end }}
+{{ end }}

--- a/charts/argocd-notifications/templates/serviceaccount.yaml
+++ b/charts/argocd-notifications/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argocd-notifications.serviceAccountName" . }}
+  labels:
+    {{- include "argocd-notifications.labels" . | nindent 4 }}

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -22,10 +22,10 @@ secret:
 
   notifiers:
     # For more information: https://argoproj-labs.github.io/argocd-notifications/services/overview/
-  
+
     slack:
       # For more information: https://argoproj-labs.github.io/argocd-notifications/services/slack/
-  
+
       # Specifies whether Slack notifier should be configured
       enabled: false
       # OAuth Access Token

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -1,0 +1,124 @@
+affinity: {}
+
+# ArgoCD dashboard url; used in place of {{.context.argocdUrl}} in templates
+argocdUrl:
+
+fullnameOverride: ""
+
+image:
+  repository: argoprojlabs/argocd-notifications
+  tag: v0.7.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: "argocd-notifications"
+
+nodeSelector: {}
+
+secret:
+  # Whether helm chart creates controller secret
+  create: true
+
+  notifiers:
+    # For more information: https://argoproj-labs.github.io/argocd-notifications/services/overview/
+  
+    slack:
+      # For more information: https://argoproj-labs.github.io/argocd-notifications/services/slack/
+  
+      # Specifies whether Slack notifier should be configured
+      enabled: false
+      # OAuth Access Token
+      token:
+      # Optional override username
+      username:
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: argocd-notifications-controller
+
+subscriptions: []
+  # Assignment of recipients by notification channel to triggers in several forms:
+  #
+  # global subscription for all type of notifications
+  # - recipients:
+  #     - slack:test1
+  #     - webhook:github
+  #
+  # subscription for on-sync-status-unknown trigger notifications
+  # - recipients:
+  #     - slack:test2
+  #     - email:test@gmail.com
+  #   trigger: on-sync-status-unknown
+  #
+  # global subscription restricted to applications with matching labels only
+  # - recipients:
+  #     - slack:test3
+  #   selector: test=true
+  #
+  # For more information: https://argoproj-labs.github.io/argocd-notifications/triggers_and_templates/
+
+templates: []
+  # The notification template is used to generate the notification content. The template is leveraging html/template
+  # golang package and allow to define notification title and body. The template is meant to be reusable and can be
+  # referenced by multiple triggers.
+  #
+  # Add your custom template
+  # - name: my-custom-template
+  #   title: Hello {{.app.metadata.name}}
+  #   body: |
+  #     Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+  #
+  # Override one field in built-in template
+  # - name: on-sync-succeeded
+  #   title: Application {{.app.metadata.name}} sync status is {{.app.status.sync.status}}
+  #
+  # For more information: https://argoproj-labs.github.io/argocd-notifications/triggers_and_templates/
+
+tolerations: []
+
+triggers:
+  # The condition when the notification should be sent. The definition includes name, condition and notification template reference.
+  #
+  # Enable built-in triggers:
+  #
+  # Application has degraded
+  # - name: on-health-degraded
+  #   enabled: true
+  #
+  # Application syncing has failed
+  # - name: on-sync-failed
+  #   enabled: true
+  #
+  # Application is being synced
+  # - name: on-sync-running
+  #   enabled: true
+  #
+  # Application status is 'Unknown'
+  # - name: on-sync-status-unknown
+  #   enabled: true
+  #
+  # Application syncing has succeeded
+  # - name: on-sync-succeeded
+  #   enabled: true
+  #
+  #
+  # Or define your custom triggers:
+  #
+  # - name: my-custom-trigger
+  #   condition: app.status.sync.status == 'Unknown'
+  #   template: my-custom-template
+  #
+  # For more information: https://argoproj-labs.github.io/argocd-notifications/triggers_and_templates/


### PR DESCRIPTION
The following chart is a contribution from work done at https://github.com/Bandwidth/ to facilitate installing https://github.com/argoproj-labs/argocd-notifications via Helm chart based on https://github.com/argoproj-labs/argocd-notifications/blob/master/manifests/install.yaml

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.