### PR TITLE
feat: Enable dedicated grpc ingress for argo-cd-server

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.3.5
+version: 2.3.6
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.1"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.4.0
+version: 2.5.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -202,6 +202,12 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.ingress.hosts | List of ingress hosts | `[]` |
 | server.ingress.labels | Additional ingress labels. | `{}` |
 | server.ingress.tls | Ingress TLS configuration. | `[]` |
+| server.ingress.https | Uses `server.service.servicePortHttps` instead `server.service.servicePortHttp` | `false` |
+| server.ingressGrpc.annotations | Additional ingress annotations for dedicated [gRPC-ingress] | `{}` |
+| server.ingressGrpc.enabled | Enable an ingress resource for the server for dedicated [gRPC-ingress] | `false` |
+| server.ingressGrpc.hosts | List of ingress hosts for dedicated [gRPC-ingress] | `[]` |
+| server.ingressGrpc.labels | Additional ingress labels for dedicated [gRPC-ingress] | `{}` |
+| server.ingressGrpc.tls | Ingress TLS configuration for dedicated [gRPC-ingress] | `[]` |
 | server.route.enabled | Enable a OpenShift route for the server | `false` |
 | server.route.hostname | Hostname of OpenShift route | `""` |
 | server.livenessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
@@ -306,3 +312,5 @@ through `xxx.extraArgs`
 | redis-ha.redis.config.save | Will save the DB if both the given number of seconds and the given number of write operations against the DB occurred. `""`  is disabled | `""` |
 | redis-ha.haproxy.enabled | Enabled HAProxy LoadBalancing/Proxy | `true` |
 | redis-ha.haproxy.metrics.enabled | HAProxy enable prometheus metric scraping | `true` |
+
+[gRPC-ingress]: https://argoproj.github.io/argo-cd/operator-manual/ingress/

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.server.ingress.enabled -}}
+{{- if .Values.server.ingressGrpc.enabled -}}
 {{- $serviceName := include "argo-cd.server.fullname" . -}}
-{{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingress.https -}}
-{{- $paths := .Values.server.ingress.paths -}}
+{{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingressGrpc.https -}}
+{{- $paths := .Values.server.ingressGrpc.paths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
@@ -9,9 +9,9 @@ apiVersion: extensions/v1beta1
 {{ end -}}
 kind: Ingress
 metadata:
-{{- if .Values.server.ingress.annotations }}
+{{- if .Values.server.ingressGrpc.annotations }}
   annotations:
-  {{- range $key, $value := .Values.server.ingress.annotations }}
+  {{- range $key, $value := .Values.server.ingressGrpc.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}
@@ -23,13 +23,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
-{{- if .Values.server.ingress.labels }}
-{{- toYaml .Values.server.ingress.labels | nindent 4 }}
+{{- if .Values.server.ingressGrpc.labels }}
+{{- toYaml .Values.server.ingressGrpc.labels | nindent 4 }}
 {{- end }}
 spec:
   rules:
-  {{- if .Values.server.ingress.hosts }}
-  {{- range $host := .Values.server.ingress.hosts }}
+  {{- if .Values.server.ingressGrpc.hosts }}
+  {{- range $host := .Values.server.ingressGrpc.hosts }}
     - host: {{ $host }}
       http:
         paths:
@@ -50,8 +50,8 @@ spec:
               servicePort: {{ $servicePort }}
   {{- end -}}
   {{- end -}}
-  {{- if .Values.server.ingress.tls }}
+  {{- if .Values.server.ingressGrpc.tls }}
   tls:
-{{- toYaml .Values.server.ingress.tls | nindent 4 }}
+{{- toYaml .Values.server.ingressGrpc.tls | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -15,7 +15,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}
-  name: {{ template "argo-cd.server.fullname" . }}
+  name: {{ template "argo-cd.server.fullname" . }}-grpc
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -446,6 +446,29 @@ server:
       # - secretName: argocd-example-tls
       #   hosts:
       #     - argocd.example.com
+    https: false
+  # dedicated ingess for gRPC as documented at
+  # https://argoproj.github.io/argo-cd/operator-manual/ingress/
+  ingressGrpc:
+    enabled: false
+    annotations: {}
+    labels: {}
+
+    ## Argo Ingress.
+    ## Hostnames must be provided if Ingress is enabled.
+    ## Secrets must be manually created in the namespace
+    ##
+    hosts:
+      []
+      # - argocd.example.com
+    paths:
+      - /
+    tls:
+      []
+      # - secretName: argocd-example-tls
+      #   hosts:
+      #     - argocd.example.com
+    https: false
 
   # Create a OpenShift Route with SSL passthrough for UI and CLI
   # Consider setting 'hostname' e.g. https://argocd.apps-crc.testing/ using your Default Ingress Controller Domain


### PR DESCRIPTION
This is based on the information found at https://argoproj.github.io/argo-cd/operator-manual/ingress/

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches. 