### PR TITLE
feat(argocd): Allow specifying annotations for serviceaccounts

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.5.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.3.6
+version: 2.3.7
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -120,6 +120,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.service.annotations | Controller service annotations. | `{}` |
 | controller.service.labels | Controller service labels. | `{}` |
 | controller.service.port | Controller service port. | `8082` |
+| controler.serviceAccount.annotations | Controller service account annotations | `{}` |
 | controller.serviceAccount.create | Create a service account for the controller | `true` |
 | controller.serviceAccount.name | Service account name. | `"argocd-application-controller"` |
 | controller.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
@@ -169,6 +170,9 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.service.annotations | Repo server service annotations. | `{}` |
 | repoServer.service.labels | Repo server service labels. | `{}` |
 | repoServer.service.port | Repo server service port. | `8081` |
+| repoServer.serviceAccount.annotations | Repo server service account annotations | `{}` |
+| repoServer.serviceAccount.create | Create repo server service account | `false` |
+| repoServer.serviceAccount.name | Repo server service account name | `"argocd-repo-server"` |
 | repoServer.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | repoServer.volumeMounts | Repo server volume mounts | `[]` |
 | repoServer.volumes | Repo server volumes | `[]` |
@@ -237,6 +241,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.service.servicePortHttpsName | Server service https port name, can be used to route traffic via istio | `https` |
 | server.service.loadBalancerSourceRanges | Source IP ranges to allow access to service from. | `[]` |
 | server.service.type | Server service type | `"ClusterIP"` |
+| server.serviceAccount.annotations | Server service account annotations | `{}` |
 | server.serviceAccount.create | Create server service account | `true` |
 | server.serviceAccount.name | Server service account name | `"argocd-server"` |
 | server.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |

--- a/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-cd.controllerServiceAccountName" . }}
+{{- if .Values.controller.serviceAccount.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.controller.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.controller.name }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-cd.serverServiceAccountName" . }}
+{{- if .Values.server.serviceAccount.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.server.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.server.name }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -113,6 +113,8 @@ controller:
   serviceAccount:
     create: true
     name: argocd-application-controller
+    ## Annotations applied to created service account
+    annotations: {}
 
   ## Server metrics controller configuration
   metrics:
@@ -426,6 +428,8 @@ server:
   serviceAccount:
     create: true
     name: argocd-server
+    ## Annotations applied to created service account
+    annotations: {}
 
   ingress:
     enabled: false


### PR DESCRIPTION
Updates the argo-cd helm chart allowing you to specify annotations for the ServiceAccounts for Controller and Server. Additionally adds a few missing parameters to the README.md.

Need these changes in order to add the IAM/EKS Service Account roles to enable cross-account cluster access. Looks like server is required for the argocd cli activity and Controller for the sync. 

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.