### PR TITLE
fix: ArgoCD Notifications - Deployment manifest udpateStrategy

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "argocd-notifications.labels" . | nindent 4 }}
 spec:
+  strategy:
+    {{- .Values.updateStrategy | toYaml | nindent 4 }}
   selector:
     matchLabels:
       {{- include "argocd-notifications.selectorLabels" . | nindent 6 }}
@@ -12,9 +14,6 @@ spec:
     metadata:
       labels:
         {{- include "argocd-notifications.selectorLabels" . | nindent 8 }}
-    spec:
-      strategy:
-        type: Recreate
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         {{- include "argocd-notifications.selectorLabels" . | nindent 8 }}
+    spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -16,6 +16,9 @@ nameOverride: "argocd-notifications"
 
 nodeSelector: {}
 
+updateStrategy:
+  type: Recreate
+
 secret:
   # Whether helm chart creates controller secret
   create: true


### PR DESCRIPTION
## What

- Move `strategy` from the Pod template spec to the Deployment spec
- Add `updateStrategy` value for configuring Deployment `strategy`

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.