### PR TITLE
feat(argocd-notifications): Add support for webhook triggers

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/secret.yaml
+++ b/charts/argocd-notifications/templates/secret.yaml
@@ -13,4 +13,11 @@ stringData:
       token: {{ .Values.secret.notifiers.slack.token }}
       username: {{ .Values.secret.notifiers.slack.username }}
 {{- end }}
+{{- if .Values.secret.notifiers.webhooks }}
+    webhook:
+{{- range $k, $v := .Values.secret.notifiers.webhooks }}
+      - name: {{ $k }}
+        {{- $v | toYaml | nindent 8 }}
+{{- end }}
+{{- end }}
 {{ end }}

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -36,6 +36,25 @@ secret:
       # Optional override username
       username:
 
+    webhooks: {}
+      # For more information: https://argoproj-labs.github.io/argocd-notifications/services/webhook/
+      # mywebhook:
+      #   url: http://example.com
+      #   headers:
+      #     - name: headerName
+      #       value: headerValue
+      #   basicAuth:
+      #     username: username
+      #     password: mypassword
+      # mywebhook2:
+      #   url: http://example.com
+      #   headers:
+      #     - name: headerName
+      #       value: headerValue
+      #   basicAuth:
+      #     username: username
+      #     password: mypassword
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Thanks for adding this @andyfeller! It looks like the existing version adds support for slack, but I didn't see webhooks. This adds support for webhooks (see: https://argoproj-labs.github.io/argocd-notifications/services/webhook/).