### PR TITLE
feat(argo): Adds SSO configuration for Argo Server.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v2.8.0
+appVersion: v2.9.0
 description: A Helm chart for Argo Workflows
 name: argo
 version: 0.9.7

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v2.9.0
+appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
 version: 0.9.7

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.9.7
+version: 0.9.8
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -68,6 +68,5 @@ data:
     workflowDefaults:
 {{ toYaml .Values.controller.workflowDefaults | indent 6 }}{{- end }}
     {{- with .Values.server.sso }}
-    server:
-      sso: {{- toYaml . | nindent 8 }}
+    sso: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -67,6 +67,7 @@ data:
     {{- if .Values.controller.workflowDefaults }}
     workflowDefaults:
 {{ toYaml .Values.controller.workflowDefaults | indent 6 }}{{- end }}
-    {{- with .Values.controller.sso }}
-    sso:
-{{ toYaml . | indent 6 }}{{- end }}
+    {{- with .Values.server.sso }}
+    server:
+      sso: {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,7 +4,7 @@ images:
   server: argocli
   executor: argoexec
   pullPolicy: Always
-  tag: v2.9.0-rc2
+  tag: v2.8.0
 
 crdVersion: v1alpha1
 installCRD: true

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -206,7 +206,7 @@ server:
     ## SSO configuration when SSO is specified as a server auth mode.
     ## All the values are requied. SSO is activated by adding --auth-mode=sso
     ## to the server command line.
-    # 
+    #
     ## The root URL of the OIDC identity provider.
     # issuer: https://accounts.google.com
     ## Name of a secret and a key in it to retrieve the app OIDC client ID from.

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,7 +4,7 @@ images:
   server: argocli
   executor: argoexec
   pullPolicy: Always
-  tag: v2.9.0
+  tag: v2.9.0-rc2
 
 crdVersion: v1alpha1
 installCRD: true
@@ -203,22 +203,22 @@ server:
     # Give the server permissions to edit ClusterWorkflowTemplates.
     enableEditing: true
   sso:
-    # SSO configuration when SSO is specified as a server auth mode.
-    # All the values are requied. SSO is activated by adding --auth-mode=sso
-    # to the server command line.
-    #
-    # The root URL of the OIDC identity provider.
-    issuer: https://accounts.google.com
-    # Name of a secret and a key in it to retrieve the app OIDC client ID from.
-    clientId:
-      name: argo-server-sso
-      key: client-id
-    # Name of a secret and a key in it to retrieve the app OIDC client secret from.
-    clientSecret:
-      name: argo-server-sso
-      key: client-secret
-    # The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.
-    redirectUrl: https://argo/oauth2/callback
+    ## SSO configuration when SSO is specified as a server auth mode.
+    ## All the values are requied. SSO is activated by adding --auth-mode=sso
+    ## to the server command line.
+    # 
+    ## The root URL of the OIDC identity provider.
+    # issuer: https://accounts.google.com
+    ## Name of a secret and a key in it to retrieve the app OIDC client ID from.
+    # clientId:
+    #   name: argo-server-sso
+    #   key: client-id
+    ## Name of a secret and a key in it to retrieve the app OIDC client secret from.
+    # clientSecret:
+    #   name: argo-server-sso
+    #   key: client-secret
+    ## The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.
+    # redirectUrl: https://argo/oauth2/callback
 
 # Influences the creation of the ConfigMap for the workflow-controller itself.
 useDefaultArtifactRepo: false

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,7 +4,7 @@ images:
   server: argocli
   executor: argoexec
   pullPolicy: Always
-  tag: v2.7.6
+  tag: v2.9.0
 
 crdVersion: v1alpha1
 installCRD: true
@@ -202,6 +202,23 @@ server:
   clusterWorkflowTemplates:
     # Give the server permissions to edit ClusterWorkflowTemplates.
     enableEditing: true
+  sso:
+    # SSO configuration when SSO is specified as a server auth mode.
+    # All the values are requied. SSO is activated by adding --auth-mode=sso
+    # to the server command line.
+    #
+    # The root URL of the OIDC identity provider.
+    issuer: https://accounts.google.com
+    # Name of a secret and a key in it to retrieve the app OIDC client ID from.
+    clientId:
+      name: argo-server-sso
+      key: client-id
+    # Name of a secret and a key in it to retrieve the app OIDC client secret from.
+    clientSecret:
+      name: argo-server-sso
+      key: client-secret
+    # The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.
+    redirectUrl: https://argo/oauth2/callback
 
 # Influences the creation of the ConfigMap for the workflow-controller itself.
 useDefaultArtifactRepo: false

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -54,7 +54,6 @@ controller:
   #     name: argo-postgres-config
   #     key: password
   workflowDefaults: {}  # Only valid for 2.7+
-  sso: {}  # Only valid for 2.9+
   #  spec:
   #    ttlStrategy:
   #      secondsAfterCompletion: 84600

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -4,7 +4,7 @@ images:
   server: argocli
   executor: argoexec
   pullPolicy: Always
-  tag: v2.8.0
+  tag: v2.7.6
 
 crdVersion: v1alpha1
 installCRD: true


### PR DESCRIPTION
This change will allow to configure the Argo Server SSO [support](https://github.com/argoproj/argo/pull/2745) (new feature in Argo 2.9).

This should only be merged after Argo v2.9.0 is released.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.