### PR TITLE
feat: argo-rollouts resources in helm values

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.3.0
+version: 0.3.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -38,6 +38,8 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        resources:
+{{- toYaml .Values.controller.resources | nindent 10 }}
       volumes:
       - name: tmp
         emptyDir: {}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -10,6 +10,15 @@ controller:
     tag: v0.8.0
     pullPolicy: IfNotPresent
 
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 50m
+  #    memory: 64Mi
+
+
 serviceAccount:
   name: argo-rollouts
 


### PR DESCRIPTION
I've simply updated the templates here such that I can set the requests and limits for argo-rollouts locally in values files.

I left the true default as it was -- there are no requests or limits for Argo Rollouts by default.

I wrote in some guessed "defaults if you want them" as comments in the values file.  They're based on one environment I have access to, but I admit that I see wide variance between environments so I don't know how useful those are.  :shrug: They're a starting point.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.