### PR TITLE
argocd-notifications: fix serviceaccount name

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.5
+version: 1.0.6
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/_helpers.tpl
+++ b/charts/argocd-notifications/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Create the name of the bot service account to use
 */}}
 {{- define "argocd-notifications.bots.slack.serviceAccountName" -}}
 {{- if .Values.bots.slack.serviceAccount.create -}}
-    {{ default (include "argocd-notifications.fullname" .) .Values.bots.slack.serviceAccount.name }}
+    {{ default (printf "%s-bot" (include "argocd-notifications.fullname" .)) .Values.bots.slack.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.bots.slack.serviceAccount.name }}
 {{- end -}}

--- a/charts/argocd-notifications/templates/bots/slack/deployment.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "argocd-notifications.serviceAccountName" . }}-bot
+      serviceAccountName: {{ include "argocd-notifications.bots.slack.serviceAccountName" . }}
       containers:
         - name: {{ include "argocd-notifications.name" . }}-bot
           image: "{{ .Values.bots.slack.image.repository }}:{{ .Values.bots.slack.image.tag }}"

--- a/charts/argocd-notifications/templates/bots/slack/role.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/role.yaml
@@ -15,4 +15,13 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 {{ end }}

--- a/charts/argocd-notifications/templates/bots/slack/serviceaccount.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.bots.slack.enabled .Values.secret.create }}
+{{- if .Values.bots.slack.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/argocd-notifications/templates/serviceaccount.yaml
+++ b/charts/argocd-notifications/templates/serviceaccount.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "argocd-notifications.serviceAccountName" . }}
   labels:
     {{- include "argocd-notifications.labels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
This PR 
- Updates slack bot service account role permissions with configmap / secret
- Updates slack bot service account create to not require secret creation
- Ensures all service account naming is consistent via `argocd-notifications.bots.slack.serviceAccountName`
- Changes the default serviceaccount name to be suffixed with -bot for backwards compat.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.