### PR TITLE
feat: Add support for configmaps annotations

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.1"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.5.0
+version: 2.5.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -68,6 +68,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | global.hostAliases | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]` |
 | nameOverride | Provide a name in place of `argocd` | `"argocd"` |
 | installCRDs | Install CRDs if you are using Helm2. | `true` |
+| configs.knownHostsAnnotations | Known Hosts configmap annotations | `{}` |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
 | configs.secret.annotations | Annotations for argocd-secret | `{}` |
 | configs.secret.argocdServerAdminPassword | Bcrypt hashed admin password | `null` |
@@ -76,6 +77,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | configs.secret.createSecret | Create the argocd-secret. | `true` |
 | configs.secret.githubSecret | GitHub incoming webhook secret | `""` |
 | configs.secret.gitlabSecret | GitLab incoming webhook secret | `""` |
+| configs.tlsCertsAnnotations | TLS certificate configmap annotations | `{}` |
 | configs.tlsCerts.data."argocd.example.com" | TLS certificate | See [values.yaml](values.yaml) |
 | configs.secret.extra | add additional secrets to be added to argocd-secret | `{}` |
 | openshift.enabled | enables using arbitrary uid for argo repo server | `false` |
@@ -194,6 +196,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.certificate.enabled | Enables a certificate manager certificate. | `false` |
 | server.certificate.issuer | Certificate manager issuer | `{}` |
 | server.clusterAdminAccess.enabled | Enable RBAC for local cluster deployments. | `true` |
+| server.configAnnotations | ArgoCD configuration configmap annotations | `{}` |
 | server.config | [General Argo CD configuration](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repositories) | See [values.yaml](values.yaml) |
 | server.containerPort | Server container port. | `8080` |
 | server.extraArgs | Additional arguments for the server. A list of flags. | `[]` |
@@ -231,6 +234,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.podAnnotations | Annotations for the server pods | `{}` |
 | server.podLabels | Labels for the server pods | `{}` |
 | server.priorityClassName | Priority class for the server | `""` |
+| server.rbacConfigAnnotations | RBAC configmap annotations | `{}` |
 | server.rbacConfig | [Argo CD RBAC policy](https://argoproj.github.io/argo-cd/operator-manual/rbac/) | `{}` |
 | server.readinessProbe.failureThreshold | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `3` |
 | server.readinessProbe.initialDelaySeconds | [Kubernetes probe configuration](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) | `10` |

--- a/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
@@ -9,5 +9,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
+  {{- if .Values.server.configAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.server.configAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 data:
 {{- toYaml .Values.server.config | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -9,6 +9,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
+  {{- if .Values.server.rbacConfigAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.server.rbacConfigAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 {{- if .Values.server.rbacConfig }}
 data:
 {{- toYaml .Values.server.rbacConfig | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
@@ -9,4 +9,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
+  {{- if .Values.configs.knownHostsAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.configs.knownHostsAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
   name: argocd-ssh-known-hosts-cm

--- a/charts/argo-cd/templates/argocd-configs/argocd-tls-certs-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-tls-certs-cm.yaml
@@ -11,4 +11,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.server.name }}
+  {{- if .Values.configs.tlsCertsAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.configs.tlsCertsAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
   name: argocd-tls-certs-cm

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -515,6 +515,9 @@ server:
     #     - profile
     #     - email
 
+  ## Annotations to be added to ArgoCD ConfigMap
+  configAnnotations: {}
+
   ## ArgoCD rbac config
   ## reference https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/rbac.md
   rbacConfig:
@@ -537,6 +540,9 @@ server:
     # scopes controls which OIDC scopes to examine during rbac enforcement (in addition to `sub` scope).
     # If omitted, defaults to: '[groups]'. The scope value can be a string, or a list of strings.
     # scopes: '[cognito:groups, email]'
+
+  ## Annotations to be added to ArgoCD rbac ConfigMap
+  rbacConfigAnnotations: {}
 
   ## Not well tested and not well supported on release v1.0.0.
   ## Applications
@@ -756,6 +762,7 @@ repoServer:
 
 ## Argo Configs
 configs:
+  knownHostsAnnotations: {}
   knownHosts:
     data:
       ssh_known_hosts: |
@@ -766,6 +773,7 @@ configs:
         gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
         ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
         vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
+  tlsCertsAnnotations: {}
   tlsCerts:
     {}
     # data:


### PR DESCRIPTION
This PR add support for annotating the ConfigMaps. This is useful when deploying ArgoCD with Spinnaker: [by default Spinnaker adds a suffix to the configmap](https://spinnaker.io/reference/providers/kubernetes-v2/#strategy), making the ArgoCD deployment fail.

Failing deployment
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/4821896/86133812-19ba2f80-bae9-11ea-8d5f-00054c2e3026.png">

Versioned ConfigMaps
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/4821896/86133866-28084b80-bae9-11ea-8ffa-f0fbb8c3ab73.png">

Unversioned ConfigMaps
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/4821896/86135921-b382dc00-baeb-11ea-9eab-4d09e9922436.png">

Working deployment
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/4821896/86136346-458ae480-baec-11ea-84f4-746a7b48cf9d.png">

The other deployments are not working because they're missing a Pod Security Policy, I will address that in another PR.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.