### PR TITLE
fix: align bot role with argocd-notifications project

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.6
+version: 1.0.7
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/_helpers.tpl
+++ b/charts/argocd-notifications/templates/_helpers.tpl
@@ -92,3 +92,10 @@ Create the name of the bot service account to use
     {{ default "default" .Values.bots.slack.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "argocd-notifications.secretName" -}}
+{{- printf "%s-secret" (include "argocd-notifications.name" .) -}}
+{{- end -}}

--- a/charts/argocd-notifications/templates/bots/slack/role.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/role.yaml
@@ -18,7 +18,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - argocd-notifications-secret
+  - {{ include "argocd-notifications.secretName" . }}
   resources:
   - secrets
   verbs:

--- a/charts/argocd-notifications/templates/bots/slack/role.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/role.yaml
@@ -17,9 +17,10 @@ rules:
   - patch
 - apiGroups:
   - ""
+  resourceNames:
+  - argocd-notifications-secret
   resources:
   - secrets
-  - configmaps
   verbs:
   - get
   - list

--- a/charts/argocd-notifications/templates/secret.yaml
+++ b/charts/argocd-notifications/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "argocd-notifications.name" . }}-secret
+  name: {{ include "argocd-notifications.secretName" . }}
   labels:
     {{- include "argocd-notifications.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
In the recent #389 review, the role used by the bot added a policy allowing it
to broadly read secrets and configmaps, however this should align with the
changes in https://github.com/argoproj-labs/argocd-notifications/pull/95 where
limited access to the specific secret it needs should be granted.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.