### PR TITLE
[argocd-notifications] add monitoring and slack bot service annotations

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.7
+version: 1.0.8
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/_helpers.tpl
+++ b/charts/argocd-notifications/templates/_helpers.tpl
@@ -44,6 +44,19 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Common metrics labels
+*/}}
+{{- define "argocd-notifications.metrics.labels" -}}
+helm.sh/chart: {{ include "argocd-notifications.chart" . }}
+{{ include "argocd-notifications.metrics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+
+{{/*
 Common slack bot labels
 */}}
 {{- define "argocd-notifications.bots.slack.labels" -}}
@@ -60,6 +73,14 @@ Selector labels
 */}}
 {{- define "argocd-notifications.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "argocd-notifications.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Selector metrics labels
+*/}}
+{{- define "argocd-notifications.metrics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argocd-notifications.name" . }}-metrics
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 

--- a/charts/argocd-notifications/templates/bots/slack/service.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "argocd-notifications.name" . }}-bot
+  {{- if .Values.bots.slack.service.annotations }}
+  annotations:
+    {{- toYaml .Values.bots.slack.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - name: server

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -29,6 +29,16 @@ spec:
           command:
             - /app/argocd-notifications
             - controller
+            - --loglevel={{ .Values.logLevel }}
+            {{- if .Values.metrics.enabled }}
+            - --metrics-port={{ .Values.metrics.port }}
+            {{- end }}
+          ports:
+          {{- if .Values.metrics.enabled }}
+          - containerPort: {{ .Values.metrics.port }}
+            name: metrics
+            protocol: TCP
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/argocd-notifications/templates/service-metrics.yaml
+++ b/charts/argocd-notifications/templates/service-metrics.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-metrics
+  labels:
+    {{- include "argocd-notifications.metrics.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "argocd-notifications.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: metrics
+    port: {{ .Values.metrics.port }}
+    targetPort: {{ .Values.metrics.port }}
+{{- end }}

--- a/charts/argocd-notifications/templates/servicemonitor.yaml
+++ b/charts/argocd-notifications/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "argocd-notifications.name" . }}-metrics
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "argocd-notifications.metrics.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "argocd-notifications.metrics.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -194,6 +194,7 @@ bots:
     imagePullSecrets: []
 
     service:
+      annotations: {}
       type: LoadBalancer
 
     serviceAccount:

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -87,6 +87,18 @@ secret:
       # email address in from field
       from:
 
+logLevel: info
+
+metrics:
+  enabled: false
+  port: 9001
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    # namespace: monitoring
+    # interval: 30s
+    # scrapeTimeout: 10s
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

This PR
* Adds monitoring to the controller
* Adds `logLevel` option
* Adds slack bot service annotations allowing external DNS registration, e.g.:
  ```
  annotations:
    external-dns.alpha.kubernetes.io/hostname:  argocd-notifications-bot.example.com
  ```

documentation:
* argocd-notifications metrics -> https://github.com/argoproj-labs/argocd-notifications/blob/master/docs/monitoring.md