### PR TITLE
feat: Argo Notifications - add extraArgs value

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.8
+version: 1.1.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.1.0
+version: 1.0.9
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             {{- if .Values.metrics.enabled }}
             - --metrics-port={{ .Values.metrics.port }}
             {{- end }}
+            {{- range .Values.extraArgs }}
+            - {{ . | squote }}
+            {{- end }}
           ports:
           {{- if .Values.metrics.enabled }}
           - containerPort: {{ .Values.metrics.port }}

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -89,6 +89,8 @@ secret:
 
 logLevel: info
 
+extraArgs: []
+
 metrics:
   enabled: false
   port: 9001


### PR DESCRIPTION
## What

- **Argo Notifications**: Add `extraArgs` value

## Why

- Allow for setting arbitrary extra arguments for the argo-notifications binary. Primarily we need this for `--argocd-repo-server` as we have some environments which run with a non-standard repo server service name.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.