### PR TITLE
feat(argo-rollouts): Add configurable annotation to the metrics service

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.3"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.3.4
+version: 0.3.5
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
@@ -6,6 +6,10 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: {{ .Release.Name }}-metrics
     app.kubernetes.io/part-of: {{ .Release.Name }}
+  annotations:
+  {{- range $key, $value := .Values.serviceAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   ports:
   - name: metrics

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -28,11 +28,15 @@ controller:
 serviceAccount:
   name: argo-rollouts
 
-## Annotations to be added to the Redis server pods
+## Annotations to be added to the Rollout pods
 ##
 podAnnotations: {}
 
-## Labels to be added to the Redis server pods
+## Annotations to be added to the Rollout service
+##
+serviceAnnotations: {}
+
+## Labels to be added to the Rollout pods
 ##
 podLabels: {}
 


### PR DESCRIPTION
This allows user to add the necessary annotation on the metrics service to allow prometheus scraping.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.