### PR TITLE
fix(argo-rollouts): When running argo-rollouts cluster-wide, the restart command is unable to restart pods

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.3.2
+version: 0.3.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -106,4 +106,11 @@ rules:
   - watch
   - get
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
 {{- end }}


### PR DESCRIPTION
The `ClusterRole` is missing the necessary permissions to list and delete `pods` causing the **restart** command to fail because the controller only has `list` and `delete` verb permissions for its own namespace through its namespaced role definition.

I've updated the `ClusterRole` to include the following rule to allow the controller to execute its restarts:
```yaml
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - list
  - delete
```

### Steps to reproduce
1) Install argo-rollouts in its own namespace with `.Values.clusterInstall` set to `true`.
2) Install a `Rollout` resource in different rollout and have it create a replicaset with pods
3) Run `kubectl argo rollouts restart ROLLOUT_NAME -n YOUR_NAMESPACE`

### What happened

The command silently fails and nothing happens to my Rollout and the following error was emitted in the controller log:

> E0812 01:47:25.730161       1 controller.go:169] pods is forbidden: User "system:serviceaccount:argo-rollouts:argo-rollouts" cannot list resource "pods" in API group "" in the namespace "dev"


### What I expected to happen

For the `argo-rollouts` controller to do a restart of my rollout by terminating pods.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.