### PR TITLE
feat: argocd-notifications 1.0.10 add podAnnotations

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.9
+version: 1.0.10
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/deployment.yaml
+++ b/charts/argocd-notifications/templates/deployment.yaml
@@ -12,6 +12,12 @@ spec:
       {{- include "argocd-notifications.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         {{- include "argocd-notifications.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -101,6 +101,8 @@ metrics:
     # interval: 30s
     # scrapeTimeout: 10s
 
+podAnnotations: {}
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
This PR adds the ability to set arbitrary annotations on the deployment via `podAnnotations`. My use case was to add annotations that allow Datadog to scrape metrics from the pod.

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.