### PR TITLE
feat: Argo CD allow custom paths for ingress

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.6.1
+version: 2.6.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -33,6 +33,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+  {{- toYaml .Values.server.ingressGrpc.extraPaths | nindent 10 }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
@@ -43,6 +44,7 @@ spec:
   {{- else }}
     - http:
         paths:
+  {{- toYaml .Values.server.ingressGrpc.extraPaths | nindent 10 }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "argo-cd.server.fullname" . -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingress.https -}}
 {{- $paths := .Values.server.ingress.paths -}}
+{{- $extraPaths := .Values.server.ingress.extraPaths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
@@ -33,6 +34,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+  {{- toYaml $extraPaths | nindent 10 }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
@@ -43,6 +45,7 @@ spec:
   {{- else }}
     - http:
         paths:
+  {{- toYaml $extraPaths | nindent 10 }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -454,6 +454,12 @@ server:
       # - argocd.example.com
     paths:
       - /
+    extraPaths:
+      []
+      # - path: /*
+      #   backend:
+      #     serviceName: ssl-redirect
+      #     servicePort: use-annotation
     tls:
       []
       # - secretName: argocd-example-tls
@@ -476,6 +482,12 @@ server:
       # - argocd.example.com
     paths:
       - /
+    extraPaths:
+      []
+      # - path: /*
+      #   backend:
+      #     serviceName: ssl-redirect
+      #     servicePort: use-annotation
     tls:
       []
       # - secretName: argocd-example-tls


### PR DESCRIPTION
Similar to #317, this allows us to add extra paths to Argo CD.
This adds compatibility with the ALB Ingress Controller when using EKS
to be able to add the additional listener rule to perform a HTTP->HTTPS
redirect on port 80.

Unfortunately, we can't use the same structure as used in #317 because
there is an existing .Values.server.ingress.paths that we have to maintain
backwards compatibility with. The existing one is hard-coded to use a
fixed serviceName and servicePort, which doesn't work for the EKS ALB case.

Instead, we add .Values.server.ingress.extraPaths (and a similar var for
ingressGrpc) where a user directly specifies the entire rule, including
the path and backend information. Examples are added to the values.yaml
file for the extra path for EKS, with an empty list as a backwards
compatible default.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.