### PR TITLE
feat: Support GCS artifactRepository

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.9.8
+version: 0.9.9
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -31,7 +31,7 @@ data:
       archiveLogs: {{ .Values.artifactRepository.archiveLogs }}
       {{- end }}
       {{- if .Values.artifactRepository.gcs }}
-      gcp:
+      gcs:
 {{ toYaml .Values.artifactRepository.gcs | indent 8}}
       {{- else }}
       s3:

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -30,6 +30,10 @@ data:
       {{- if .Values.artifactRepository.archiveLogs }}
       archiveLogs: {{ .Values.artifactRepository.archiveLogs }}
       {{- end }}
+      {{- if .Values.artifactRepository.gcs }}
+      gcp:
+{{ toYaml .Values.artifactRepository.gcs | indent 8}}
+      {{- else }}
       s3:
         {{- if .Values.useStaticCredentials }}
         accessKeySecret:
@@ -54,6 +58,7 @@ data:
         {{- if .Values.artifactRepository.s3.useSDKCreds }}
         useSDKCreds: {{ .Values.artifactRepository.s3.useSDKCreds }}
         {{- end }}
+      {{- end }}
     {{- end}}
     {{- if .Values.controller.metricsConfig.enabled }}
     metricsConfig:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -240,6 +240,21 @@ artifactRepository:
     # region:
     # roleARN:
     # useSDKCreds: true
+  # gcs:
+    # bucket: <project>-argo
+    # keyFormat: "{{workflow.namespace}}/{{workflow.name}}/"
+    # serviceAccountKeySecret is a secret selector.
+    # It references the k8s secret named 'my-gcs-credentials'.
+    # This secret is expected to have have the key 'serviceAccountKey',
+    # containing the base64 encoded credentials
+    # to the bucket.
+    #
+    # If it's running on GKE and Workload Identity is used,
+    # serviceAccountKeySecret is not needed.
+    # serviceAccountKeySecret:
+      # name: my-gcs-credentials
+      # key: serviceAccountKey
+
 
 # NOTE: These are setting attributes for the `minio` optional dependency
 minio:


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

~~~

This PR allows GCS to be configured as the default artifact repository.

[PR 344](https://github.com/argoproj/argo-helm/pull/344) attempts to fix this but does not work as `s3` has defaults which Argo will use instead of any values in `gcs`.

Example gcs output:

```
  config: |
    artifactRepository:
      gcs:
        bucket: my-argo-artifacts
        keyFormat: '{{workflow.namespace}}/{{workflow.name}}/'
```

Example minio/s3 output:

```
  config: |
    artifactRepository:
      s3:
        accessKeySecret:
          key: accesskey
          name: argo-workflows-minio
        secretKeySecret:
          key: secretkey
          name: argo-workflows-minio
        bucket: argo-artifacts
        endpoint: argo-workflows-minio:9000
        insecure: true
```