### PR TITLE
feat: add support for configuring bot port

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.7.0
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.10
+version: 1.0.11
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/templates/bots/slack/deployment.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           command:
             - /app/argocd-notifications
             - bot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
       {{- with .Values.bots.slack.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/argocd-notifications/templates/bots/slack/deployment.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/deployment.yaml
@@ -33,7 +33,6 @@ spec:
           ports:
           - containerPort: 8080
             name: http
-            protocol: TCP
       {{- with .Values.bots.slack.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/argocd-notifications/templates/bots/slack/service.yaml
+++ b/charts/argocd-notifications/templates/bots/slack/service.yaml
@@ -9,10 +9,10 @@ metadata:
   {{- end }}
 spec:
   ports:
-  - name: server
-    port: 80
+  - name: http
+    port: {{ .Values.bots.slack.service.port }}
     protocol: TCP
-    targetPort: 8080
+    targetPort: http
   selector:
     {{- include "argocd-notifications.bots.slack.selectorLabels" . | nindent 4 }}
   type: {{ .Values.bots.slack.service.type }}

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -211,6 +211,7 @@ bots:
 
     service:
       annotations: {}
+      port: 80
       type: LoadBalancer
 
     serviceAccount:


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

Changes:

Adds support for configuring the bot listening port for people who want it to listen on 443 (for example)