### PR TITLE
fix: Helm giving linting error when no ingress or ingressGrpc extraPaths are given

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.6.2"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.6.2
+version: 2.6.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "argo-cd.server.fullname" . -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingressGrpc.https -}}
 {{- $paths := .Values.server.ingressGrpc.paths -}}
+{{- $extraPaths := .Values.server.ingressGrpc.extraPaths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
@@ -33,7 +34,9 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-  {{- toYaml .Values.server.ingressGrpc.extraPaths | nindent 10 }}
+  {{- if $extraPaths }}
+  {{- toYaml $extraPaths | nindent 10 }}
+  {{- end -}}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
@@ -44,7 +47,9 @@ spec:
   {{- else }}
     - http:
         paths:
-  {{- toYaml .Values.server.ingressGrpc.extraPaths | nindent 10 }}
+  {{- if $extraPaths }}
+  {{- toYaml $extraPaths | nindent 10 }}
+  {{- end -}}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -34,7 +34,9 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+  {{- if $extraPaths }}
   {{- toYaml $extraPaths | nindent 10 }}
+  {{- end }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:
@@ -45,7 +47,9 @@ spec:
   {{- else }}
     - http:
         paths:
+  {{- if $extraPaths }}
   {{- toYaml $extraPaths | nindent 10 }}
+  {{- end }}
   {{- range $p := $paths }}
           - path: {{ $p }}
             backend:


### PR DESCRIPTION
Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.