### PR TITLE
feat(argo-workflows): Add support for name overrides.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.11.0
+version: 0.12.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/_helpers.tpl
+++ b/charts/argo/templates/_helpers.tpl
@@ -7,10 +7,56 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
+Create a fully qualified app name without the override capability.
+Used for cluster-scoped resources which cannot share the common override name
+when installed from different releases of the same chart in different
+namespaces.
+*/}}
+{{- define "fullnamenooverride" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "fullnamenooverride" . -}}
+{{- end -}}
+{{- end -}}
+
+/*
+Create a fully qualified name for Argo server.
+*/
+{{- define "serverfullname" -}}
+{{- include "fullname" . -}}-{{- .Values.server.name -}}
+{{- end -}}
+
+Create a fully qualified name for Argo server, without overridde support.
+*/
+{{- define "serverfullnamenooverride" -}}
+{{- include "fullnamenooverride" . -}}-{{- .Values.server.name -}}
+{{- end -}}
+
+/*
+Create a fully qualified name for Argo workflow controller.
+*/
+{{- define "controllerfullname" -}}
+{{- include "fullname" . -}}-{{- .Values.controller.name -}}
+{{- end -}}
+
+Create a fully qualified name for Argo workflow controller, without overridde
+support.
+*/
+{{- define "controllerfullnamenooverride" -}}
+{{- include "fullnamenooverride" . -}}-{{- .Values.controller.name -}}
 {{- end -}}

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  name: {{ include "serverfullnamenooverride" . }}
 rules:
 - apiGroups:
   - ""
@@ -64,7 +64,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}-cluster-template
+  name: {{ include "serverfullnamenooverride" . }}-cluster-template
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo/templates/server-crb.yaml
+++ b/charts/argo/templates/server-crb.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ include "serverfullname" . }}
 {{ else }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ include "serverfullnamenooverride" . }}
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21,11 +21,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
+  name: {{ include "serverfullnamenooverride" . }}-cluster-template
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
+  name: {{ include "serverfullnamenooverride" . }}-cluster-template
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.server.serviceAccount }}

--- a/charts/argo/templates/server-deployment-pdb.yaml
+++ b/charts/argo/templates/server-deployment-pdb.yaml
@@ -3,9 +3,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ include "serverfullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.server.name}}
+    app: {{ include "serverfullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -19,7 +19,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.server.name}}
+      app: {{ include "serverfullname" . }}
       release: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}

--- a/charts/argo/templates/server-deployment.yaml
+++ b/charts/argo/templates/server-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ include "serverfullname" . }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
@@ -11,12 +11,12 @@ spec:
   replicas: {{ .Values.server.replicas }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.server.name}}
+      app: {{ include "serverfullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-{{ .Values.server.name}}
+        app: {{ include "serverfullname" . }}
         release: {{ .Release.Name }}
         {{- if .Values.server.podLabels }}
         {{- toYaml .Values.server.podLabels | nindent 8 }}
@@ -34,14 +34,14 @@ spec:
         - name: argo-server
           args:
           - server
-          - --configmap={{ .Release.Name }}-{{ .Values.controller.name }}-configmap
+          - --configmap={{ include "controllerfullname" . }}-configmap
           {{- if .Values.server.extraArgs }}
           {{- toYaml .Values.server.extraArgs | nindent 10 }}
           {{- end }}
           {{- if .Values.singleNamespace }}
           - "--namespaced"
           {{- end }}
-          image: "{{ .Values.images.namespace }}/{{ .Values.images.server }}:{{ default .Values.images.tag .Values.server.image.tag }}"
+          image: {{ .Values.images.namespace }}/{{ .Values.images.server }}:{{ default .Values.images.tag .Values.server.image.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- if .Values.server.podPortName }}
           ports:
@@ -91,5 +91,4 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
 {{- end -}}

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: extensions/v1beta1
 {{ end -}}
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  name: {{ include "serverfullname" . }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
@@ -27,12 +27,12 @@ spec:
           {{- if $.Values.server.ingress.paths }}
           {{- range $.Values.server.ingress.paths }}
           - backend:
-              serviceName: {{ .serviceName }}
+              serviceName: {{ include "serverfullname" . }}
               servicePort: {{ .servicePort }}
           {{- end }}
           {{- end }}
           - backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ include "serverfullname" . }}
               servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.server.ingress.tls }}

--- a/charts/argo/templates/server-service.yaml
+++ b/charts/argo/templates/server-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  name: {{ include "serverfullname" . }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
@@ -21,7 +21,7 @@ spec:
     {{- end }}
     targetPort: 2746
   selector:
-    app: {{ .Release.Name }}-{{ .Values.server.name }}
+    app: {{ include "serverfullname" . }}
   sessionAffinity: None
   type: {{ .Values.server.serviceType }}
   {{- if and (eq .Values.server.serviceType "LoadBalancer") .Values.server.loadBalancerIP }}

--- a/charts/argo/templates/worfkflow-controller-secrets-access.yaml
+++ b/charts/argo/templates/worfkflow-controller-secrets-access.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}-minio-secret
+  name: {{ include "controllerfullname" . }}-minio-secret
 rules:
 - apiGroups:
   - ""

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
-  name: argo-aggregate-to-view
+  name: {{ include "fullnamenooverride" . }}-aggregate-to-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
@@ -31,7 +31,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
-  name: argo-aggregate-to-edit
+  name: {{ include "fullnamenooverride" . }}-aggregate-to-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
@@ -62,7 +62,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
-  name: argo-aggregate-to-admin
+  name: {{ include "fullnamenooverride" . }}-aggregate-to-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/charts/argo/templates/workflow-controller-cluster-roles.yaml
+++ b/charts/argo/templates/workflow-controller-cluster-roles.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ include "controllerfullnamenooverride" . }}
 rules:
 - apiGroups:
   - ""
@@ -110,7 +110,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+  name: {{ include "controllerfullnamenooverride" . }}-cluster-template
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo/templates/workflow-controller-config-map.yaml
+++ b/charts/argo/templates/workflow-controller-config-map.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-configmap
+  name: {{ include "controllerfullname" . }}-configmap
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}

--- a/charts/argo/templates/workflow-controller-crb.yaml
+++ b/charts/argo/templates/workflow-controller-crb.yaml
@@ -1,15 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding
+metadata:
+  name: {{ include "controllerfullname" . }}
 {{ else }}
 kind: ClusterRoleBinding
-{{- end }}
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ include "controllerfullnamenooverride" . }}
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ include "controllerfullnamenooverride" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount }}
@@ -29,11 +31,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+  name: {{ include "controllerfullnamenooverride" . }}-cluster-template
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+  name: {{ include "controllerfullnamenooverride" . }}-cluster-template
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount }}

--- a/charts/argo/templates/workflow-controller-deployment-pdb.yaml
+++ b/charts/argo/templates/workflow-controller-deployment-pdb.yaml
@@ -2,9 +2,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}
+  name: {{ include "controllerfullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    app: {{ include "controllerfullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -18,6 +18,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      app: {{ include "controllerfullname" . }}
       release: {{ .Release.Name }}
 {{- end }}

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}
+  name: {{ include "controllerfullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    app: {{ include "controllerfullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -11,12 +11,12 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      app: {{ include "controllerfullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-{{ .Values.controller.name}}
+        app: {{ include "controllerfullname" . }}
         release: {{ .Release.Name }}
         {{- if .Values.controller.podLabels }}
         {{ toYaml .Values.controller.podLabels | nindent 8}}
@@ -32,27 +32,28 @@ spec:
       {{- end }}
       containers:
         - name: controller
-          image: "{{ .Values.images.namespace }}/{{ .Values.images.controller }}:{{ default .Values.images.tag .Values.controller.image.tag }}"
+          image: {{ .Values.images.namespace }}/{{ .Values.images.controller }}:{{ default .Values.images.tag .Values.controller.image.tag }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
-          command: [ "workflow-controller" ]
+          command:
+          - workflow-controller
           args:
-          - "--configmap"
-          - "{{ .Release.Name }}-{{ .Values.controller.name}}-configmap"
-          - "--executor-image"
-          - "{{ .Values.images.namespace }}/{{ .Values.images.executor }}:{{ default .Values.images.tag .Values.executor.image.tag }}"
-          - "--loglevel"
-          - "{{ .Values.controller.logging.level }}"
-          - "--gloglevel"
-          - "{{ .Values.controller.logging.globallevel }}"
+          - --configmap
+          - {{ include "controllerfullname" . }}-configmap
+          - --executor-image
+          - {{ .Values.images.namespace }}/{{ .Values.images.executor }}:{{ default .Values.images.tag .Values.executor.image.tag }}
+          - --loglevel
+          - {{ .Values.controller.logging.level }}
+          - --gloglevel
+          - {{ .Values.controller.logging.globallevel }}
           {{- if .Values.singleNamespace }}
-          - "--namespaced"
+          - --namespaced
           {{- end }}
           {{- with .Values.controller.workflowWorkers }}
-          - "--workflow-workers"
+          - --workflow-workers
           - {{ . | quote }}
           {{- end }}
           {{- if .Values.controller.podWorkers }}
-          - "--pod-workers"
+          - --pod-workers
           - {{ . | quote }}
           {{- end }}
           env:

--- a/charts/argo/templates/workflow-controller-minio-secret-crb.yaml
+++ b/charts/argo/templates/workflow-controller-minio-secret-crb.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}-minio-binding
+  name: {{ include "controllerfullname" . }}-minio-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}-minio-secret
+  name: {{ include "controllerfullname" . }}-minio-secret
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount }}

--- a/charts/argo/templates/workflow-controller-service.yaml
+++ b/charts/argo/templates/workflow-controller-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ include "controllerfullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    app: {{ include "controllerfullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -29,7 +29,7 @@ spec:
     targetPort: {{ .Values.controller.telemetryConfig.port }}
   {{- end }}
   selector:
-    app: {{ .Release.Name }}-{{ .Values.controller.name }}
+    app: {{ include "controllerfullname" . }}
   sessionAffinity: None
   type: {{ .Values.controller.serviceType }}
   {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}

--- a/charts/argo/templates/workflow-controller-servicemonitor.yaml
+++ b/charts/argo/templates/workflow-controller-servicemonitor.yaml
@@ -2,9 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ include "controllerfullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    app: {{ include "controllerfullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,6 +28,6 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      app: {{ include "controllerfullname" . }}
       release: {{ .Release.Name }}
 {{- end }}

--- a/charts/argo/templates/workflow-rb.yaml
+++ b/charts/argo/templates/workflow-rb.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-workflow
+  name: {{ include "fullname" . }}-workflow
 {{- if .Values.workflow.namespace }}
   namespace: {{ .Values.workflow.namespace }}
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-workflow
+  name: {{ include "fullname" . }}-workflow
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.workflow.serviceAccount.name }}

--- a/charts/argo/templates/workflow-role.yaml
+++ b/charts/argo/templates/workflow-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-workflow
+  name: {{ include "fullname" . }}-workflow
   {{- if .Values.workflow.namespace }}
   namespace: {{ .Values.workflow.namespace }}
   {{- end }}


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

---
This PR allows installation of multiple releases of Argo in different namespaces, while keeping the object names the same.

Currently, if you want to install two releases of Argo in different namespaces, you have to give them different names. Otherwise, they will generate cluster scoped objects such as `ClusterRole` with identical names, and the second release will fail to install them and so fail overall. But if you give them different names, that will generate different names for services, configmaps, and secrets. This will cause having to write more customized configuration for each release, an inconvenience.

With this change, you will be able to give releases the different name but then use `fullnameOverride` to give the namespace-scoped objects the name you desire. Cluster-scoped objects will have names generated automatically to avoid name collisions.