### PR TITLE
feat: Add value for enable/disable redis securityContext; Bump chart version

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.7.0
+version: 2.7.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -311,6 +311,7 @@ through `xxx.extraArgs`
 | redis.podLabels | Labels for the Redis server pods | `{}` |
 | redis.priorityClassName | Priority class for redis | `""` |
 | redis.resources | Resource limits and requests for redis | `{}` |
+| redis.securityContextEnabled | Enable/Disable securityContext | `true` |
 | redis.securityContext | Redis Pod Security Context | See [values.yaml](values.yaml) |
 | redis.servicePort | Redis service port | `6379` |
 | redis.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -41,8 +41,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
+      {{- if .Values.redis.securityContextEnabled }}
       {{- if .Values.redis.securityContext }}
       securityContext: {{- toYaml .Values.redis.securityContext | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ template "argo-cd.redis.fullname" . }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -278,6 +278,7 @@ redis:
     #     - all
 
   ## Redis Pod specific security context
+  securityContextEnabled: true
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000


### PR DESCRIPTION
Signed-off-by: jaydee94 <janherber@gmx.de>

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.