### PR TITLE
fix: Adding EmptyDir Volume for ArgoCD Repo Server on OpenShift

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.7.2
+version: 2.7.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -82,6 +82,10 @@ spec:
         {{- if .Values.repoServer.volumeMounts }}
 {{- toYaml .Values.repoServer.volumeMounts | nindent 8}}
         {{- end }}
+        {{- if .Values.openshift.enabled }}
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
+        {{- end }}
         {{- if .Values.configs.knownHosts }}
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
@@ -137,6 +141,10 @@ spec:
       volumes:
       {{- if .Values.repoServer.volumes }}
 {{- toYaml .Values.repoServer.volumes | nindent 6}}
+      {{- end }}
+      {{- if .Values.openshift.enabled }}
+      - emptyDir: {}
+        name: gpg-keyring
       {{- end }}
       {{- if .Values.configs.knownHosts }}
       - configMap:


### PR DESCRIPTION
## Description

When upgrading to the latest 1.7.x images of ArgoCD, we experienced issues with the repo server starting up due to https://github.com/argoproj/argo-cd/issues/4127.

This incorporates fixes from https://github.com/argoproj/argo-cd/pull/4136.

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.