### PR TITLE
feat: upgrade argo to v2.11

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v2.8.0
+appVersion: v2.11.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.12.2
+version: 0.13.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/crds/cluster-workflow-template-crd.yaml
+++ b/charts/argo/crds/cluster-workflow-template-crd.yaml
@@ -11,7 +11,13 @@ spec:
   scope: Cluster
   names:
     kind: ClusterWorkflowTemplate
+    listKind: ClusterWorkflowTemplateList
     plural: clusterworkflowtemplates
     shortNames:
     - clusterwftmpl
     - cwft
+    singular: clusterworkflowtemplate
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/argo/crds/cron-workflow-crd.yaml
+++ b/charts/argo/crds/cron-workflow-crd.yaml
@@ -9,9 +9,15 @@ spec:
   group: argoproj.io
   names:
     kind: CronWorkflow
+    listKind: CronWorkflowList
     plural: cronworkflows
     shortNames:
-    - cronwf
     - cwf
+    - cronwf
+    singular: cronworkflow
   scope: Namespaced
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/argo/crds/workflow-crd.yaml
+++ b/charts/argo/crds/workflow-crd.yaml
@@ -19,8 +19,15 @@ spec:
   group: argoproj.io
   names:
     kind: Workflow
+    listKind: WorkflowList
     plural: workflows
     shortNames:
     - wf
+    singular: workflow
   scope: Namespaced
+  subresources: {}
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/argo/crds/workflow-eventbinding-crd.yaml
+++ b/charts/argo/crds/workflow-eventbinding-crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: workfloweventbindings.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowEventBinding
+    listKind: WorkflowEventBindingList
+    plural: workfloweventbindings
+    shortNames:
+    - wfeb
+    singular: workfloweventbinding
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/argo/crds/workflow-template-crd.yaml
+++ b/charts/argo/crds/workflow-template-crd.yaml
@@ -11,6 +11,12 @@ spec:
   scope: Namespaced
   names:
     kind: WorkflowTemplate
+    listKind: WorkflowTemplateList
     plural: workflowtemplates
     shortNames:
     - wftmpl
+    singular: workflowtemplate
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -30,11 +30,18 @@ rules:
   - list
   - watch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - watch
 {{- if .Values.controller.persistence }}
 - apiGroups:
   - ""
   resources:
   - secrets
+  - serviceaccounts
   resourceNames:
   {{- if .Values.controller.persistence.postgresql }}
   - {{ .Values.controller.persistence.postgresql.userNameSecret.name }}
@@ -51,8 +58,11 @@ rules:
   - argoproj.io
   resources:
   - workflows
+  - workfloweventbindings
   - workflowtemplates
   - cronworkflows
+  - cronworkflows/finalizers
+  - clusterworkflowtemplates
   verbs:
   - create
   - get

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -7,7 +7,7 @@ images:
   # Secrets with credentials to pull images from a private registry
   pullSecrets: []
   # - name: argo-pull-secret
-  tag: v2.7.6
+  tag: v2.11.3
 
 crdVersion: v1alpha1
 installCRD: true


### PR DESCRIPTION
Changes taken from this comparison: https://github.com/argoproj/argo/compare/release-2.10...release-2.11?expand=1#diff-e6a7473c56a01263d2a13719d20af959R46 (`manifests/quick-start-minimal.yaml` diff)

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.