### PR TITLE
feat: add metrics for argo-cd/dex

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.7.3
+version: 2.7.4
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -273,6 +273,11 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | dex.initImage.repository | Argo CD init image repository. | `global.image.repository` |
 | dex.initImage.imagePullPolicy | Argo CD init image imagePullPolicy | `global.image.imagePullPolicy` |
 | dex.initImage.tag | Argo CD init image tag | `global.image.tag` |
+| dex.metrics.enabled | Deploy metrics service | `false` |
+| dex.metrics.service.annotations | Metrics service annotations | `{}` |
+| dex.metrics.service.labels | Metrics service labels | `{}` |
+| dex.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
+| dex.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | dex.name | Dex name | `"dex-server"` |
 | dex.env | Environment variables for the Dex server. | `[]` |
 | dex.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -80,6 +80,11 @@ spec:
         - name: grpc
           containerPort: {{ .Values.dex.containerPortGrpc }}
           protocol: TCP
+        {{- if .Values.dex.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ .Values.dex.containerPortMetrics }}
+          protocol: TCP
+        {{- end }}
 {{- if .Values.dex.volumeMounts }}
         volumeMounts:
 {{- toYaml .Values.dex.volumeMounts | nindent 10 }}

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -20,6 +20,12 @@ spec:
     protocol: TCP
     port: {{ .Values.dex.servicePortGrpc }}
     targetPort: grpc
+{{- if .Values.dex.metrics.enabled }}
+  - name: metrics
+    protocol: TCP
+    port: {{ .Values.dex.servicePortMetrics }}
+    targetPort: metrics
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.dex.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.dex.metrics.enabled .Values.dex.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "argo-cd.dex.fullname" . }}
+  {{- if .Values.dex.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.dex.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.dex.name }}
+    helm.sh/chart: {{ include "argo-cd.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: {{ .Values.dex.name }}
+    {{- if .Values.dex.metrics.serviceMonitor.selector }}
+{{- toYaml .Values.dex.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- end }}
+    {{- if .Values.dex.metrics.serviceMonitor.additionalLabels }}
+{{- toYaml .Values.dex.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.dex.name }}
+      app.kubernetes.io/component: {{ .Values.dex.name }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -172,6 +172,14 @@ dex:
   enabled: true
   name: dex-server
 
+  metrics:
+    enabled: false
+    service:
+      annotations: {}
+      labels: {}
+    serviceMonitor:
+      enabled: false
+
   image:
     repository: quay.io/dexidp/dex
     tag: v2.22.0
@@ -212,6 +220,8 @@ dex:
   servicePortHttp: 5556
   containerPortGrpc: 5557
   servicePortGrpc: 5557
+  containerPortMetrics: 5558
+  servicePortMetrics: 5558
 
   ## Node selectors and tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
Since https://github.com/argoproj/argo-cd/pull/3249 metrics are turned on in `dex`, but not on in helm chart

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.