### PR TITLE
feat(argo): Allow Argo server read access to events.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.12.0
+version: 0.12.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - events
   verbs:
   - get
   - watch


### PR DESCRIPTION
This change gives Argo server the permission to read events, to the event display [feature](https://github.com/argoproj/argo/issues/3673) in 2.11.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.