### PR TITLE
feat(Argo): Make Argo Server service account creation conditional.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.8.0
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.12.1
+version: 0.12.2
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-crb.yaml
+++ b/charts/argo/templates/server-crb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled -}}
+{{- if and .Values.server.enabled .Values.server.createServiceAccount -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding

--- a/charts/argo/templates/server-sa.yaml
+++ b/charts/argo/templates/server-sa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled -}}
+{{- if and .Values.server.enabled .Values.server.createServiceAccount -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -157,7 +157,7 @@ server:
   servicePort: 2746
   # servicePortName: http
   serviceAccount: argo-server
-  # Whether to create the service account wiht the name specified in
+  # Whether to create the service account with the name specified in
   # server.serviceAccount and bind it to the server role.
   createServiceAccount: true
   # Service account annotations

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -157,6 +157,9 @@ server:
   servicePort: 2746
   # servicePortName: http
   serviceAccount: argo-server
+  # Whether to create the service account wiht the name specified in
+  # server.serviceAccount and bind it to the server role.
+  createServiceAccount: true
   # Service account annotations
   serviceAccountAnnotations: {}
   # Annotations to be applied to the UI Service


### PR DESCRIPTION
In some situation, one needs to provide Argo Server with a different set of permissions. For example, to prohibit editing of workflow templates or prohibit creating new ones. This PR will allow users to use externally created service account which can be bound to a role with any desired set of permissions.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.