### PR TITLE
docs(argo-rollouts): Fixing the README to hold the updated chart version

### DIFF
--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -44,3 +44,4 @@ $ helm install --name my-release argo/argo-rollouts
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | serviceAccount.name | string | `"argo-rollouts"` |  |
+| serviceAnnotations | object | `{}` | |

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -2,7 +2,7 @@ Argo Rollouts Chart
 =============
 A Helm chart for Argo Rollouts, progressive delivery for Kubernetes.
 
-Current chart version is `0.3.0`
+Current chart version is `0.3.6`
 
 Source code can be found [here](https://github.com/argoproj/argo-rollouts)
 


### PR DESCRIPTION
Also added `serviceAnnotations` since it was missing