### PR TITLE
fix(argocd): Make dex init container not overwrite argocd-util

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.8.0
+version: 2.8.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -54,6 +54,7 @@ spec:
         {{- end }}
         command:
         - cp
+        - -n
         - /usr/local/bin/argocd-util
         - /shared
         volumeMounts:


### PR DESCRIPTION
This imports the change made in this PR https://github.com/argoproj/argo-cd/pull/3136/ 

This fixes the issue where the dex server init container `copyutil` runs more than once and ends up in a crashLoopBackoff state because the target file of the `cp` command is currently in use.

Checklist:

* [✅] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [✅ ] Any new values are backwards compatible and/or have sensible default.
* [✅ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [✅ ] I have signed the CLA and the build is green.
* [✅ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.