### PR TITLE
feat(argo): add PriorityClass support

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.0
+version: 0.13.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-deployment.yaml
+++ b/charts/argo/templates/server-deployment.yaml
@@ -91,5 +91,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.server.priorityClassName }}
+      priorityClassName: {{ .Values.server.priorityClassName }}
+      {{- end }}
 
 {{- end -}}

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -83,3 +83,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+      {{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -125,6 +125,10 @@ controller:
     kubernetes.io/os: linux
   tolerations: []
   affinity: {}
+  # Leverage a PriorityClass to ensure your pods survive resource shortages
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  # PriorityClass: system-cluster-critical
+  priorityClassName: ""
 
 # executor controls how the init and wait container should be customized
 executor:
@@ -185,6 +189,10 @@ server:
     kubernetes.io/os: linux
   tolerations: []
   affinity: {}
+  # Leverage a PriorityClass to ensure your pods survive resource shortages
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  # PriorityClass: system-cluster-critical
+  priorityClassName: ""
 
   # Extra arguments to provide to the Argo server binary.
   extraArgs: []


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

---

This PR adds support to optionally use PriorityClasses in the Argo Workflows chart. In case the value is omitted, the pod will run with the cluster defaults.

Priority classes allow pods to avoid being evicted if there's resource contention in a cluster. In case of a race condition, the smaller priority pods will be kicked out first; similarly, when the kube-scheduler makes scheduling decisions, it will ensure first the higher priority pods get deployed.

This can be quite an important parameter for the Argo Workflows main components, as a [random user workflow](https://github.com/argoproj/argo/blob/346292b1b0152d5bfdc0387a8b2c11b5d6d5bac1/workflow/controller/workflowpod.go#L667-L672) is potentially able to evict the controller pods.

For more details you can read the [official docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).