### PR TITLE
fix: Add annotations and labels to dex service [argo-cd]

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.9.2
+version: 2.9.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -18,7 +18,8 @@ metadata:
     app.kubernetes.io/component: {{ .Values.dex.name }}
 {{- if .Values.dex.metrics.service.labels }}
 {{- toYaml .Values.dex.metrics.service.labels | nindent 4 }}
-{{- end }}spec:
+{{- end }}
+spec:
   ports:
   - name: http
     protocol: TCP

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "argo-cd.dex.fullname" . }}
+{{- if .Values.dex.metrics.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.dex.metrics.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.dex.name }}
     helm.sh/chart: {{ include "argo-cd.chart" . }}

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -16,7 +16,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/component: {{ .Values.dex.name }}
-spec:
+{{- if .Values.dex.metrics.service.labels }}
+{{- toYaml .Values.dex.metrics.service.labels | nindent 4 }}
+{{- end }}spec:
   ports:
   - name: http
     protocol: TCP


### PR DESCRIPTION
Currently `.Values.dex.metrics.service.annotations` is not used anywhere - this adds that to the template.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.