### PR TITLE
fix --pod-workers helm context

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.7
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.7
+version: 0.13.8
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           - "--workflow-workers"
           - {{ . | quote }}
           {{- end }}
-          {{- if .Values.controller.podWorkers }}
+          {{- with .Values.controller.podWorkers }}
           - "--pod-workers"
           - {{ . | quote }}
           {{- end }}


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

the current podworkers templating includes an entire map of objects when we just want the one value. A quick test:
```
$ git checkout master
$ helm template argo charts/argo --set 'controller.podWorkers=64' > old.txt
$ git checkout fix_pod_workers_deployment_arg
$ helm template argo charts/argo --set 'controller.podWorkers=64' > new.txt
$ diff old.txt new.txt -C 1

*** 377,379 ****
            - "--pod-workers"
!           - "map[Capabilities:0x29b90a0 Chart:0xc000294360 Files:map[.helmignore:[35 32 80 97 116 116 101 114 110 115 32 116 111 32 105 103 110 111 114 101 32 119 104 101 110 32 98 117 105 108 100 105 110 103 32 112 97 99 107 97 103 101 115 46 10 35 32 84 104 105 115 32
115 117 112 112 111 114 116 115 32 115 104 101 108 108 32 103 108 111 98 32 109 97 116 99 104 105 110 103 44 32 114 101 108 97 116 105 118 101 32 112 97 116 104 32 109 97 116 99 104 105 110 103 44 32 97 110 100 10 35 32 110 101 103 97 116 105 111 110 32 40 112 114 101 102
105 120 101 100 32 119 105 116 104 32 33 41 46 32 79 110 108 121 32 111 110 101 32 112 97 116 116 101 114 110 32 112 101 114 32 108 105 110 101 46 10 46 68 83 95 83 116 111 114 101 10 35 32 67 111 109 109 111 110 32 86 67 83 32 100 105 114 115 10 46 103 105 116 47 10 46 10
... lots more of this ...
--- 377,379 ----
            - "--pod-workers"
!           - "64"
            env:
```