### PR TITLE
fix(argo): Update minio chart to solve install error

### DIFF
--- a/.circleci/chart-testing.yaml
+++ b/.circleci/chart-testing.yaml
@@ -1,2 +1,3 @@
 chart-repos:
   - argo=https://argoproj.github.io/argo-helm
+  - minio=https://helm.min.io/

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.2
+version: 0.13.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/requirements.lock
+++ b/charts/argo/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.6
-digest: sha256:373b459c6232e9fd4dd86fa0af01e024372f686a0cdfbfed69d3cd41859e8ad4
-generated: "2020-02-06T00:16:52.211425292Z"
+  repository: https://helm.min.io/
+  version: 8.0.0
+digest: sha256:8091a14cc00e44dffb93025e7dbb1640cf8e1aa1a5db6e8e5883a2c7f7a7e7a0
+generated: 2020-11-12T18:15:19.0599608Z

--- a/charts/argo/requirements.yaml
+++ b/charts/argo/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: minio
-  version: 5.0.6
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.0.0
+  repository: https://helm.min.io/
   condition: minio.install

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,7 @@ do
     echo "Running Helm linting for $name"
     docker run \
         -v "$SRCROOT:/workdir" \
-        gcr.io/kubernetes-charts-ci/test-image:v3.1.0 \
+        gcr.io/kubernetes-charts-ci/test-image:v3.3.0 \
         ct \
         lint \
         --config .circleci/chart-testing.yaml \

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,6 +8,7 @@ rm -rf $SRCROOT/output && git clone -b gh-pages git@github.com:argoproj/argo-hel
 
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm repo add argoproj https://argoproj.github.io/argo-helm
+helm repo add minio https://helm.min.io/
 
 for dir in $(find $SRCROOT/charts -mindepth 1 -maxdepth 1 -type d);
 do


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

Fixes https://github.com/argoproj/argo-helm/issues/455


---

The `8.0.3` version fails on `ct` with:
```
[ERROR] templates/: render error in "argo/charts/minio/templates/deployment.yaml": template: argo/charts/minio/templates/_helpers.tpl:49:43: executing "minio.deployment.apiVersion" at <.Capabilities.KubeVe...>: can't evaluate field Version in type *version.Info

Error: 1 chart(s) linted, 1 chart(s) failed
Error linting charts
------------------------------------------------------------------------------------------------------------------------
 ✖︎ /workdir/charts/argo > Error waiting for process: exit status 1
```

To solve that the repo should be updated to helm3 and use the `quay.io/repository/helmpack/chart-testing` image in version v3.3.0 or higher, so for now the latest minio that can be used is the `v8.0.0`.