### PR TITLE
fix(argo): Map the /tmp directory into server pods.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v2.11.3
+appVersion: v2.11.7
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.2
+version: 0.13.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-deployment.yaml
+++ b/charts/argo/templates/server-deployment.yaml
@@ -67,16 +67,20 @@ spec:
             value: {{ .Values.server.baseHref | quote }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
-          {{- with .Values.server.volumeMounts }}
           volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          {{- with .Values.server.volumeMounts }}
             {{- toYaml . | nindent 12}}
           {{- end }}
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.volumes }}
       volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- with .Values.server.volumes }}
         {{- toYaml . | nindent 8}}
       {{- end }}
       {{- with .Values.server.nodeSelector }}
@@ -94,5 +98,4 @@ spec:
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName }}
       {{- end }}
-
 {{- end -}}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -7,7 +7,7 @@ images:
   # Secrets with credentials to pull images from a private registry
   pullSecrets: []
   # - name: argo-pull-secret
-  tag: v2.11.3
+  tag: v2.11.7
 
 crdVersion: v1alpha1
 installCRD: true


### PR DESCRIPTION
https://github.com/argoproj/argo/pull/4350 started using the `/tmp` directory for storing temporary files created for the purposes of downloading artifacts. But the standard image the project built is created from scratch and does not contain `/tmp`. The project's own manifests were updated to map the directory using an `emptyDir` volume, but this chart was not updated.  That started causing failures for users of this chart.

This change adds the `/tmp` mapping into the chart, thus fixing the artifact downloading.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.