### PR TITLE
feat(Argo): Add secret access whitelist for server.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.7
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.6
+version: 0.13.7
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -16,12 +16,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   - pods
   - pods/exec
   - pods/log
@@ -33,6 +27,21 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+{{- with .Values.server.rbac.secretWhitelist }}
+  resourceNames: {{- toYaml . | nindent 4 }}
+{{- end }}
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - watch
@@ -41,15 +50,14 @@ rules:
   - ""
   resources:
   - secrets
-  - serviceaccounts
   resourceNames:
-  {{- if .Values.controller.persistence.postgresql }}
-  - {{ .Values.controller.persistence.postgresql.userNameSecret.name }}
-  - {{ .Values.controller.persistence.postgresql.passwordSecret.name }}
+  {{- with .Values.controller.persistence.postgresql }}
+  - {{ .userNameSecret.name }}
+  - {{ .passwordSecret.name }}
   {{- end}}
-  {{- if .Values.controller.persistence.mysql }}
-  - {{ .Values.controller.persistence.mysql.userNameSecret.name }}
-  - {{ .Values.controller.persistence.mysql.passwordSecret.name }}
+  {{- with .Values.controller.persistence.mysql }}
+  - {{ .userNameSecret.name }}
+  - {{ .passwordSecret.name }}
   {{- end}}
   verbs:
   - get

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -164,6 +164,9 @@ server:
   serviceType: ClusterIP
   servicePort: 2746
   # servicePortName: http
+  rbac:
+    # When present, restricts secrets the server can read to a given list.
+    secretWhitelist: []
   serviceAccount: argo-server
   # Whether to create the service account with the name specified in
   # server.serviceAccount and bind it to the server role.


### PR DESCRIPTION
Currently, the chart allows the Argo server to access all the secrets in the namespace. It's not good security practice, as an attacker taking over a server pod will have access to all of them. This change adds support for restricting the secrets the server can read to a given list so that only need-to-know secrets can be allowed.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.