### PR TITLE
fix(argo): Use https for readiness probe in secure mode

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.7
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.8
+version: 0.13.10
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-deployment.yaml
+++ b/charts/argo/templates/server-deployment.yaml
@@ -38,6 +38,9 @@ spec:
           {{- if .Values.server.extraArgs }}
           {{- toYaml .Values.server.extraArgs | nindent 10 }}
           {{- end }}
+          {{- if .Values.server.secure }}
+          - "--secure"
+          {{- end }}
           {{- if .Values.singleNamespace }}
           - "--namespaced"
           {{- end }}
@@ -52,7 +55,11 @@ spec:
             httpGet:
               path: /
               port: 2746
+              {{- if .Values.server.secure }}
+              scheme: HTTPS
+              {{- else }}
               scheme: HTTP
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 20
           env:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -201,6 +201,12 @@ server:
   # PriorityClass: system-cluster-critical
   priorityClassName: ""
 
+  # Run the argo server in "secure" mode. Configure this value instead of
+  # "--secure" in extraArgs. See the following documentation for more details
+  # on secure mode:
+  # https://argoproj.github.io/argo/tls/#encrypted
+  secure: false
+
   # Extra arguments to provide to the Argo server binary.
   extraArgs: []
 


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

This fixes the issue raised in https://github.com/argoproj/argo-helm/issues/505. It's worth noting this implementation is different than the suggestion in the original issue. Instead of requiring users to update both the `extraArgs` and readiness probe http scheme to enable tls, we can automatically change the http scheme if tls is enabled.

Tested this locally by:
* Deploying the chart with no extra args
* Submitting workflow defined in the app notes
* Update the values.yaml to have `server.secure: true` and re-deploy the chart
* Submitting workflow defined in the app notes

My test results:
✅ confirmed that the chart was deployed successfully with `server.secure` set to false
✅ confirmed that the workflow completed successfully with `server.secure` set to false
✅ confirmed that the chart was deployed successfully with the `server.secure` set to true
✅ confirmed that the workflow completed successfully with the `server.secure` set to true
✅ confirmed that the pods readiness probe used the https scheme when deployed with the secure flag
✅ confirmed that the pods readiness probe used the http scheme when deployed without any flags
✅ confirmed that without these changes, deploying with only the`--secure` flag in extra args result in a failed deployment because the readiness probe continually fails.