### PR TITLE
feat(argo-workflows): Populate workflow service account with pull secrets

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.15.2
+version: 0.15.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-sa.yaml
+++ b/charts/argo/templates/workflow-sa.yaml
@@ -10,4 +10,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.workflow.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -29,6 +29,7 @@ workflow:
     create: false  # Specifies whether a service account should be created
     annotations: {}
     name: "argo-workflow"  # Service account which is used to run workflows
+    imagePullSecrets: []  # Secrets with credentials to pull images from a private registry
   rbac:
     create: false  # adds Role and RoleBinding for the above specified service account to be able to run workflows
 


### PR DESCRIPTION
Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.

### Story

The argo-workflow service account may need image pull secrets to pull images from private registries. To support this use cse, a value should be accepted in the workflow's service account definition in `values.yaml` for populating its image pull secrets.

### How to test

* Deploy chart with no `workflow.serviceAccount.pullSecrets` defined
* Submit workflow defined in app notes (uses public docker image)
* Submit workflow that executes a container with a private docker image
* Deploy chart with `workflow.serviceAccount` defined as:

```
workflow:
  serviceAccount:
    create: true
    annotations: {}
    name: "argo-workflow"
    pullSecrets:
      - name: drydockcreds
```

* Submit workflow defined in app notes (uses public docker image)
* Submit workflow that executes a container with a private docker image

### Test Results

✅ chart with no pull secrets defined was successfully deployed
✅ workflow with public docker image executed successfully
✅ workflow with private docker image properly failed (because the image pull secrets were not defined)
✅ chart with pull secrets was successfully deployed
✅ workflow with public docker image executed successfully
✅ workflow with private docker image succeeded