### PR TITLE
fix: upgraded CRD version to apiextensions.k8s.io/v1

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.10.0
+version: 2.11.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/crds/crd-application.yaml
+++ b/charts/argo-cd/crds/crd-application.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/charts/argo-cd/crds/crd-project.yaml
+++ b/charts/argo-cd/crds/crd-project.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.0.0
+version: 1.1.0
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/crds/eventbus-crd.yml
+++ b/charts/argo-events/crds/eventbus-crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventbus.argoproj.io

--- a/charts/argo-events/crds/eventsource-crd.yml
+++ b/charts/argo-events/crds/eventsource-crd.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io

--- a/charts/argo-events/crds/sensor-crd.yml
+++ b/charts/argo-events/crds/sensor-crd.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io

--- a/charts/argo-events/templates/eventbus-crd.yaml
+++ b/charts/argo-events/templates/eventbus-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventbus.argoproj.io

--- a/charts/argo-events/templates/eventsource-crd.yaml
+++ b/charts/argo-events/templates/eventsource-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io

--- a/charts/argo-events/templates/sensor-crd.yaml
+++ b/charts/argo-events/templates/sensor-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.installCRD }}
 # Define a "sensor" custom resource definition
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -21,7 +21,7 @@ additionalSaNamespaces: []
 additionalServiceAccountRules:
 - apiGroups:
     - apiextensions.k8s.io
-    - apiextensions.k8s.io/v1beta1
+    - apiextensions.k8s.io/v1
   verbs:
     - create
     - delete

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.3.10
+version: 0.4.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v2.11.7
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.10
+version: 0.14.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/crds/cluster-workflow-template-crd.yaml
+++ b/charts/argo/crds/cluster-workflow-template-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterworkflowtemplates.argoproj.io

--- a/charts/argo/crds/cron-workflow-crd.yaml
+++ b/charts/argo/crds/cron-workflow-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cronworkflows.argoproj.io

--- a/charts/argo/crds/workflow-crd.yaml
+++ b/charts/argo/crds/workflow-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io

--- a/charts/argo/crds/workflow-eventbinding-crd.yaml
+++ b/charts/argo/crds/workflow-eventbinding-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workfloweventbindings.argoproj.io

--- a/charts/argo/crds/workflow-template-crd.yaml
+++ b/charts/argo/crds/workflow-template-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflowtemplates.argoproj.io

--- a/charts/argo/templates/cluster-workflow-template-crd.yaml
+++ b/charts/argo/templates/cluster-workflow-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterworkflowtemplates.argoproj.io

--- a/charts/argo/templates/cron-workflow-crd.yaml
+++ b/charts/argo/templates/cron-workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cronworkflows.argoproj.io

--- a/charts/argo/templates/workflow-crd.yaml
+++ b/charts/argo/templates/workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io

--- a/charts/argo/templates/workflow-template-crd.yaml
+++ b/charts/argo/templates/workflow-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflowtemplates.argoproj.io


### PR DESCRIPTION
I am using Kubernetes `v1.18.9` for one of my clusters. In this version, the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition". I get the following error while using Helm3:

```shell
➜ helm lint .
==> Linting .
[WARNING] templates/cluster-workflow-template-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[ERROR] templates/cluster-workflow-template-crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[WARNING] templates/cron-workflow-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[ERROR] templates/cron-workflow-crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[WARNING] templates/workflow-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[ERROR] templates/workflow-crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"
[WARNING] templates/workflow-template-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[ERROR] templates/workflow-template-crd.yaml: the kind "apiextensions.k8s.io/v1beta1 CustomResourceDefinition" is deprecated in favor of "apiextensions.k8s.io/v1 CustomResourceDefinition"

Error: 1 chart(s) linted, 1 chart(s) failed
```

After this fix:

```shell
➜ helm lint .
==> Linting .
[WARNING] templates/cluster-workflow-template-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/cron-workflow-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/workflow-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart
[WARNING] templates/workflow-template-crd.yaml: manifest is a crd-install hook. This hook is no longer supported in v3 and all CRDs should also exist the crds/ directory at the top level of the chart

1 chart(s) linted, 0 chart(s) failed
```

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.