### PR TITLE
fix(argo-cd): bump dex image for secretEnv in staticClients to work

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.11.3
+version: 2.11.4
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -195,7 +195,7 @@ dex:
 
   image:
     repository: quay.io/dexidp/dex
-    tag: v2.22.0
+    tag: v2.26.0
     imagePullPolicy: IfNotPresent
   initImage:
     repository:


### PR DESCRIPTION
The dex image needs to be bumped to at least [v2.23.0](https://github.com/dexidp/dex/releases/tag/v2.23.0) for `staticClients.secretEnv` to work, but why not go to latest. For reference, this is the full config I'm using to have Argo Workflows share the Argo CD Okta SSO connector:

argo-cd/values.yaml:
```yaml
     dex:
       image:
         tag: v2.26.0
       env:
         - name: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: argo-workflows-sso
               key: client-secret
...
     server:
       config:
         dex.config: |
           staticClients:
           - id: argo-workflows-sso
             name: Argo Workflow
             redirectURIs:
               - https://argo-workflows.mydomain.com/oauth2/callback
             secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
```

argo/values.yaml:
```yaml
     server:
       extraArgs:
         - --auth-mode=sso
       sso:
         issuer: https://argo-cd.mydomain.com/api/dex
         clientId:
           name: argo-workflows-sso
           key: client-id
         clientSecret:
           name: argo-workflows-sso
           key: client-secret
         redirectUrl: https://argo-workflows.mydomain.com/oauth2/callback
```

Checklist:

* [X] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.