### PR TITLE
feat(argo): Add argo SSO/RBAC support server cluster role

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.11.7
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.14.0
+version: 0.14.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -30,6 +30,7 @@ rules:
   - serviceaccounts
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -45,6 +46,22 @@ rules:
   - events
   verbs:
   - watch
+{{- if .Values.server.sso }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - sso
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+{{- end }}
 {{- if .Values.controller.persistence }}
 - apiGroups:
   - ""
@@ -54,14 +71,14 @@ rules:
   {{- with .Values.controller.persistence.postgresql }}
   - {{ .userNameSecret.name }}
   - {{ .passwordSecret.name }}
-  {{- end}}
+  {{- end }}
   {{- with .Values.controller.persistence.mysql }}
   - {{ .userNameSecret.name }}
   - {{ .passwordSecret.name }}
-  {{- end}}
+  {{- end }}
   verbs:
   - get
-{{- end}}
+{{- end }}
 - apiGroups:
   - argoproj.io
   resources:


### PR DESCRIPTION
## motivation

argo workflow 2.12.0 support SSO + RBAC, and it requires sa list + secret create. ref https://github.com/argoproj/argo/pull/4514.

----

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.