### PR TITLE
fix(argo): Add RBAC permissions for v2.12.

### DIFF
--- a/.circleci/chart-testing.yaml
+++ b/.circleci/chart-testing.yaml
@@ -1,2 +1,3 @@
 chart-repos:
   - argo=https://argoproj.github.io/argo-helm
+  - minio=https://helm.min.io/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
     steps:
       - checkout
+      - run: helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR
   # so that it is regularly tested.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - run: git config --global user.name "Circle CI Build"
       - checkout
       - run: helm repo add stable https://charts.helm.sh/stable
+      - run: helm repo add minio https://helm.min.io/
       # Only actually publish charts on master.
       - run: |
           set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
     steps:
       - checkout
-      - run: helm init --client-only
+      - run: helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
       - run: helm repo add minio https://helm.min.io/
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,9 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
-      - run: helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR
   # so that it is regularly tested.
@@ -19,7 +18,7 @@ jobs:
       - run: git config --global user.email "nobody@circleci.com"
       - run: git config --global user.name "Circle CI Build"
       - checkout
-      - run: helm init --client-only
+      - run: helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
       # Only actually publish charts on master.
       - run: |
           set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
+      - run: helm repo add stable https://charts.helm.sh/stable
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR
   # so that it is regularly tested.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,10 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: quay.io/helmpack/chart-testing:v3.3.1
+      - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
     steps:
       - checkout
+      - run: helm init --client-only
       - run: helm repo add minio https://helm.min.io/
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.4.1
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,14 @@ jobs:
   publish:
     docker:
       # We just need an image with `helm` on it. Handily we know of one already.
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       # install the additional keys needed to push to Github. Alex Collins owns these keys.
       - add_ssh_keys
       - run: git config --global user.email "nobody@circleci.com"
       - run: git config --global user.name "Circle CI Build"
       - checkout
-      - run: helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
+      - run: helm repo add stable https://charts.helm.sh/stable
       # Only actually publish charts on master.
       - run: |
           set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ jobs:
       - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
     steps:
       - checkout
-      - run: helm init --client-only --stable-repo-url=https://charts.helm.sh/stable
-      - run: helm repo add minio https://helm.min.io/
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR
   # so that it is regularly tested.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v3.1.0
+      - image: gcr.io/kubernetes-charts-ci/test-image:v3.4.1
     steps:
       - checkout
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
+      - run: helm repo add minio https://helm.min.io/
       - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR
   # so that it is regularly tested.

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.11.0
+version: 2.11.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/crds/crd-application.yaml
+++ b/charts/argo-cd/crds/crd-application.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/charts/argo-cd/crds/crd-project.yaml
+++ b/charts/argo-cd/crds/crd-project.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/charts/argo-cd/requirements.lock
+++ b/charts/argo-cd/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 4.4.2
-digest: sha256:70fdd035c3aa3b7185882f12a73143c58ab32f04262dda2cf34a2b1a52116d96
-generated: "2020-03-29T14:37:59.349371452+01:00"
+digest: sha256:21780522f7047d49ccad6d79f79ee3e28b4839df044beea293e2e4fd69610f52
+generated: "2021-01-11T16:15:21.274802-08:00"

--- a/charts/argo-cd/requirements.yaml
+++ b/charts/argo-cd/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: redis-ha
   version: 4.4.2
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   condition: redis-ha.enabled

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.11.7
+appVersion: v2.12.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.14.0
+version: 0.15.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/requirements.lock
+++ b/charts/argo/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.6
-digest: sha256:373b459c6232e9fd4dd86fa0af01e024372f686a0cdfbfed69d3cd41859e8ad4
-generated: "2020-02-06T00:16:52.211425292Z"
+  repository: https://helm.min.io/
+  version: 8.0.9
+digest: sha256:0f43ad0a4b4e9af47615ef3da85054712eb28f154418d96b7b974a095cc19260
+generated: "2021-01-11T15:01:01.169105-08:00"

--- a/charts/argo/requirements.yaml
+++ b/charts/argo/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: minio
-  version: 5.0.6
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.0.9
+  repository: https://helm.min.io/
   condition: minio.install

--- a/charts/argo/templates/cluster-workflow-template-crd.yaml
+++ b/charts/argo/templates/cluster-workflow-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterworkflowtemplates.argoproj.io

--- a/charts/argo/templates/cron-workflow-crd.yaml
+++ b/charts/argo/templates/cron-workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cronworkflows.argoproj.io

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -24,12 +24,26 @@ rules:
   - list
   - watch
   - delete
+{{- if .Values.server.sso }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - sso
+  verbs:
+  - get
+  - update
+{{- end}}
+{{- if .Values.server.rbac }}
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   verbs:
   - get
+  - list
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -34,6 +34,12 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 {{- end}}
 {{- if .Values.server.rbac }}
 - apiGroups:

--- a/charts/argo/templates/workflow-controller-cluster-roles.yaml
+++ b/charts/argo/templates/workflow-controller-cluster-roles.yaml
@@ -106,6 +106,25 @@ rules:
   verbs:
   - get
 {{- end}}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - workflow-controller
+  - workflow-controller-lease
+  verbs:
+  - get
+  - watch
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/argo/templates/workflow-crd.yaml
+++ b/charts/argo/templates/workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io

--- a/charts/argo/templates/workflow-template-crd.yaml
+++ b/charts/argo/templates/workflow-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflowtemplates.argoproj.io

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -7,7 +7,7 @@ images:
   # Secrets with credentials to pull images from a private registry
   pullSecrets: []
   # - name: argo-pull-secret
-  tag: v2.11.7
+  tag: v2.12.3
 
 crdVersion: v1alpha1
 installCRD: true

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,7 +6,6 @@ GIT_PUSH=${GIT_PUSH:-false}
 
 rm -rf $SRCROOT/output && git clone -b gh-pages git@github.com:argoproj/argo-helm.git $SRCROOT/output
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm repo add argoproj https://argoproj.github.io/argo-helm
 
 for dir in $(find $SRCROOT/charts -mindepth 1 -maxdepth 1 -type d);


### PR DESCRIPTION
This PR adds some permissions missing for Argo v2.12:
- When SSO is enabled Argo server needs access to the `sso` secret.
- Access to service accounts by the server is only required when RBAC is enabled.
- The workflow controller needs access to particular lease objects to implement leader elections.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.