### PR TITLE
fix(Argo): Unify settings for activating rbac.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.15.0
+version: 0.15.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -41,7 +41,8 @@ rules:
   verbs:
   - create
 {{- end}}
-{{- if .Values.server.sso.rbac }}
+{{- if .Values.server.sso }}
+  {{- if .Values.server.sso.rbac }}
 - apiGroups:
   - ""
   resources:
@@ -49,6 +50,7 @@ rules:
   verbs:
   - get
   - list
+  {{- end }}
 {{- end }}
 - apiGroups:
   - ""
@@ -56,9 +58,11 @@ rules:
   - secrets
   verbs:
   - get
-{{- if .Values.server.sso.rbac }}
-  {{- with .Values.server.sso.rbac.secretWhitelist }}
+{{- if .Values.server.sso }}
+  {{- if .Values.server.sso.rbac }}
+    {{- with .Values.server.sso.rbac.secretWhitelist }}
   resourceNames: {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}
 - apiGroups:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -41,7 +41,7 @@ rules:
   verbs:
   - create
 {{- end}}
-{{- if .Values.server.rbac }}
+{{- if .Values.server.sso.rbac }}
 - apiGroups:
   - ""
   resources:
@@ -56,8 +56,10 @@ rules:
   - secrets
   verbs:
   - get
-{{- with .Values.server.rbac.secretWhitelist }}
+{{- if .Values.server.sso.rbac }}
+  {{- with .Values.server.sso.rbac.secretWhitelist }}
   resourceNames: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 - apiGroups:
   - ""

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -167,9 +167,6 @@ server:
   serviceType: ClusterIP
   servicePort: 2746
   # servicePortName: http
-  rbac:
-    # When present, restricts secrets the server can read to a given list.
-    secretWhitelist: []
   serviceAccount: argo-server
   # Whether to create the service account with the name specified in
   # server.serviceAccount and bind it to the server role.
@@ -267,6 +264,18 @@ server:
     #   key: client-secret
     ## The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.
     # redirectUrl: https://argo/oauth2/callback
+    # rbac:
+    #   enabled: true
+    ## When present, restricts secrets the server can read to a given list.
+    ## You can use it to restrict the server to only be able to access the
+    ## service account token secrets that are associated with service accounts
+    ## used for authorization.
+    #   secretWhitelist: []
+    ## Scopes requested from the SSO ID provider.  The 'groups' scope requests
+    ## group membership information, which is usually used for authorization
+    ## decisions.
+    # scopes:
+    # - groups
 
 # Influences the creation of the ConfigMap for the workflow-controller itself.
 useDefaultArtifactRepo: false


### PR DESCRIPTION
Currently, the chart uses `.Values.server.rbac` for settings related to the RBAC authorization configuration. But the server itself uses the settings under `.Values.server.sso.rbac`, which results in a discrepancy and confusion. This change make the chart use `.Values.server.sso.rbac` as well.


Signed-off-by: Vlad Losev <vladimir.losev@sage.com>

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.