### PR TITLE
fix(argo): Move dependencies into Chart.yaml.

### DIFF
--- a/charts/argo/Chart.lock
+++ b/charts/argo/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://helm.min.io/
   version: 8.0.9
 digest: sha256:0f43ad0a4b4e9af47615ef3da85054712eb28f154418d96b7b974a095cc19260
-generated: "2021-01-11T15:01:01.169105-08:00"
+generated: "2021-01-13T15:31:40.823086-08:00"

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.3
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.15.1
+version: 0.15.2
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -10,3 +10,8 @@ maintainers:
   - name: alexmt
   - name: jessesuen
   - name: benjaminws
+dependencies:
+- name: minio
+  version: 8.0.9
+  repository: https://helm.min.io/
+  condition: minio.install

--- a/charts/argo/requirements.yaml
+++ b/charts/argo/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- name: minio
-  version: 8.0.9
-  repository: https://helm.min.io/
-  condition: minio.install


### PR DESCRIPTION
This PR moves the chart dependencies into `Chart.yaml`. Using `dependencies.yaml` is deprecated and Helm is issuing warnings for it.

Signed-off-by: Vlad Losev <vladimir.losev@sage.com>

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.