### PR TITLE
fix(argo-rollouts): Fix critical deployment schema bug

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.4.0
+version: 0.4.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
-        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+      - image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         {{- if not .Values.clusterInstall }}
         args:
         - --namespaced


### PR DESCRIPTION
You can't install 0.4.0 chart, because of k8s validation error

Problem:
https://github.com/argoproj/argo-helm/commit/8baf0d4465e8784fdd0c769d3db000e221e1aab9

Invalid Deployment manifest
![image](https://user-images.githubusercontent.com/46970457/105469231-f9caa300-5ca8-11eb-96fc-f290b34a11e7.png)

```
Error: unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.containers): invalid type for io.k8s.api.core.v1.PodSpec.containers: got \"map\", expected \"array\"\n", "stderr": "Error: unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.containers): invalid type for io.k8s.api.core.v1.PodSpec.containers: got \"map\", expected \"array\"\n", "stderr_lines": ["Error: unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(Deployment.spec.template.spec.containers): invalid type for io.k8s.api.core.v1.PodSpec.containers: got \"map\", expected \"array\""]
```

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.