### PR TITLE
fix(rollouts): Fix CRD API versions

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.4.1
+version: 0.4.2
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
# Overview

This PR fixes the API versions of CRDs in the ArgoCD Rollouts Helm Chart.

The contents of the `spec` fields in those CRDs do not match with the CRD `v1` specification but the `v1beta1`'s.

In our Kubernetes clusters, the Helm Chart's deployment fails due to the following errors. I'm not sure why other people are not hitting this error though. The CRDs might be automatically matched with the old API format of `v1beta1` on old Kubernetes clusters?

```
> helm upgrade ...
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(CustomResourceDefinition.spec): unknown field "additionalPrinterColumns" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec, ValidationError(CustomResourceDefinition.spec): unknown field "subresources" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec, ValidationError(CustomResourceDefinition.spec): unknown field "validation" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec, ValidationError(CustomResourceDefinition.spec): unknown field "version" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec]
```

- [CustomResourceDefinitionSpec | Kubernetes API Reference v1.18](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#customresourcedefinitionspec-v1-apiextensions-k8s-io)

# Checklist

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.