### PR TITLE
Migrate from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,40 +2,17 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: quay.io/helmpack/chart-testing:v3.3.1
+      - image: quay.io/prometheus/busybox
     steps:
-      - checkout
-      - run: helm repo add stable https://charts.helm.sh/stable
-      - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
-  # Technically this only needs to be run on master, but it's good to have it run on every PR
-  # so that it is regularly tested.
+      - run: "true"
   publish:
     docker:
-      # We just need an image with `helm` on it. Handily we know of one already.
-      - image: quay.io/helmpack/chart-testing:v3.3.1
+      - image: quay.io/prometheus/busybox
     steps:
-      # install the additional keys needed to push to GitHub. Alex Collins owns these keys.
-      - add_ssh_keys
-      - run: git config --global user.email "nobody@circleci.com"
-      - run: git config --global user.name "Circle CI Build"
-      - checkout
-      - run: helm repo add stable https://charts.helm.sh/stable
-      - run: helm repo add minio https://helm.min.io/
-      - run: helm repo add dandydeveloper https://dandydeveloper.github.io/charts/
-      # Only actually publish charts on master.
-      - run: |
-          set -x
-          if [ "$CIRCLE_BRANCH" = "master" ]; then
-            export GIT_PUSH=true
-          else 
-            export GIT_PUSH=false
-          fi
-          sh ./scripts/publish.sh
+      - run: "true"
 workflows:
   version: 2
   workflow:
     jobs:
       - lint
-      - publish:
-          requires:
-            - lint
+      - publish

--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -1,0 +1,44 @@
+name: Helm
+on:
+  push:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: quay.io/helmpack/chart-testing:v3.3.1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - run: helm repo add stable https://charts.helm.sh/stable
+      - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
+  # Technically this only needs to be run on master, but it's good to have it run on every PR
+  # so that it is regularly tested.
+  publish:
+    needs: lint
+    runs-on: ubuntu-latest
+    # We just need an image with `helm` on it. Handily we know of one already.
+    container: quay.io/helmpack/chart-testing:v3.3.1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: output
+      # Only actually publish charts on master.
+      - name: Publish
+        run: |
+          set -x
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global user.name "$GITHUB_ACTOR"
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo add minio https://helm.min.io/
+          helm repo add dandydeveloper https://dandydeveloper.github.io/charts/
+          if [ "${GITHUB_REF#refs/heads/}" = "master" ]; then
+            export GIT_PUSH=true
+          else
+            export GIT_PUSH=false
+          fi
+          sh ./scripts/publish.sh

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.14.7
+version: 2.14.8
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -9,7 +9,7 @@ installCRDs: true
 
 global:
   image:
-    repository: argoproj/argocd
+    repository: quay.io/argoproj/argocd
     tag: v1.8.4
     imagePullPolicy: IfNotPresent
   securityContext: {}

--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Argo-CI
 name: argo-ci
-version: 0.1.7
+version: 0.1.8
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 appVersion: v1.0.0-alpha2
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.0.0
+version: 1.0.1
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/crds/eventbus-crd.yml
+++ b/charts/argo-events/crds/eventbus-crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventbus.argoproj.io

--- a/charts/argo-events/crds/eventsource-crd.yml
+++ b/charts/argo-events/crds/eventsource-crd.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io

--- a/charts/argo-events/crds/sensor-crd.yml
+++ b/charts/argo-events/crds/sensor-crd.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io

--- a/charts/argo-events/templates/eventbus-crd.yaml
+++ b/charts/argo-events/templates/eventbus-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventbus.argoproj.io

--- a/charts/argo-events/templates/eventsource-crd.yaml
+++ b/charts/argo-events/templates/eventsource-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.installCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io

--- a/charts/argo-events/templates/sensor-crd.yaml
+++ b/charts/argo-events/templates/sensor-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.installCRD }}
 # Define a "sensor" custom resource definition
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -21,7 +21,7 @@ additionalSaNamespaces: []
 additionalServiceAccountRules:
 - apiGroups:
     - apiextensions.k8s.io
-    - apiextensions.k8s.io/v1beta1
+    - apiextensions.k8s.io/v1
   verbs:
     - create
     - delete

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.4.3
+version: 0.4.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -12,7 +12,7 @@ controller:
   tolerations: []
   affinity: {}
   image:
-    repository: argoproj/argo-rollouts
+    repository: quay.io/argoproj/argo-rollouts
     tag: v0.10.2
     pullPolicy: IfNotPresent
 

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.2
+version: 0.16.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/crds/cluster-workflow-template-crd.yaml
+++ b/charts/argo/crds/cluster-workflow-template-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterworkflowtemplates.argoproj.io

--- a/charts/argo/crds/cron-workflow-crd.yaml
+++ b/charts/argo/crds/cron-workflow-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cronworkflows.argoproj.io

--- a/charts/argo/crds/workflow-crd.yaml
+++ b/charts/argo/crds/workflow-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io

--- a/charts/argo/crds/workflow-eventbinding-crd.yaml
+++ b/charts/argo/crds/workflow-eventbinding-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workfloweventbindings.argoproj.io

--- a/charts/argo/crds/workflow-template-crd.yaml
+++ b/charts/argo/crds/workflow-template-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflowtemplates.argoproj.io

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.0.1
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.0.14
+version: 1.0.15
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,8 +4,6 @@ set -eux
 SRCROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GIT_PUSH=${GIT_PUSH:-false}
 
-rm -rf $SRCROOT/output && git clone -b gh-pages git@github.com:argoproj/argo-helm.git $SRCROOT/output
-
 helm repo add argoproj https://argoproj.github.io/argo-helm
 
 for dir in $(find $SRCROOT/charts -mindepth 1 -maxdepth 1 -type d);
@@ -31,12 +29,14 @@ do
     helm --debug package $dir
 done
 
-cp $SRCROOT/*.tgz output/
-cd $SRCROOT/output && helm repo index .
+cp $SRCROOT/*.tgz $SRCROOT/output/
+cd $SRCROOT/output
+helm repo index .
 
-cd $SRCROOT/output && git status
+git status
+git add . && git commit -m "Publish charts"
 
 if [ "$GIT_PUSH" == "true" ]
 then
-    cd $SRCROOT/output && git add . && git commit -m "Publish charts" && git push git@github.com:argoproj/argo-helm.git gh-pages
+    git push origin gh-pages
 fi


### PR DESCRIPTION
Circle CI is a lot harder for contributors to use than just using native GitHub actions. It's also unfortunately somewhat flakey and quirky – if a contributor has a Circle CI account and the host had a paid account, then a PR might get a failure because of a run for the submitter's instance hitting limits. If one doesn't have a Circle CI account, then they can't test their work until they make a PR. Catch 22.

Checklist:

* [x] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green. -- The fact that the build is green is mostly a lie
    -- _This `.circleci/config.yml` is intentionally left blank._
* [x] I will test my changes again once merged to master and published.

_Changes are automatically published when merged to `master`. They are not published on branches._

Note: while this is true, with this PR, they are generated and an index file will be added to the local github repository -- the *only* thing that won't be performed is the actual push itself.

It is possible to switch from using container images to using GitHub actions for the other bits. But this is a minimal viable product to migrate to GitHub Actions.

The linter screamed very loudly when I didn't bump the api version of the `CustomResourceDefinition`s

I'm changing to quay.io as ArgoCD is doing this in general, and relying on docker.io in CI is asking for flaky builds (I've hit some making drive-by PRs to other projects).