### PR TITLE
feat(argo-cd): Add spec for the status field of AppProject CRD.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.14.5
+version: 2.14.6
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/crds/crd-project.yaml
+++ b/charts/argo-cd/crds/crd-project.yaml
@@ -224,6 +224,29 @@ spec:
                   type: object
                 type: array
             type: object
+          status:
+            description: Status of the AppProject
+            properties:
+              jwtTokensByRole:
+                additionalProperties:
+                  description: List of JWTToken objects for a given role
+                  items:
+                    description: Holds the issuedAt and expiresAt values of the token
+                    properties:
+                      exp:
+                        description: The expiresAt value of a token
+                        type: string
+                      iat:
+                        description: The issuedAt value of a token
+                        type: string
+                      id:
+                        description: ID of the token
+                        type: string
+                    type: object
+                  type: array
+                description: JWT Tokens issued for each of the roles in the project
+                type: object
+            type: object
         required:
         - metadata
         - spec


### PR DESCRIPTION
This fixes #578, which caused by switching of the `AppProject` CRD to the API version `apiextensions.k8s.io/v1`. Under that version Kubernetes [no longer](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/#pruning-don-t-preserve-unknown-fields) stores undeclared fields, which would cause Kubernetes to drop the `status` field when saving the `AppProject` objects. The change adds specification for the `status` field and its subfields.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
