### PR TITLE
fix(argo-rollouts): update argo-rollouts charts to CRD new format

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.4.1
+version: 0.4.2
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -6,11 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.0
   name: analysisruns.argoproj.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: AnalysisRun status
-    name: Status
-    type: string
   group: argoproj.io
   names:
     kind: AnalysisRun
@@ -20,2820 +15,2824 @@ spec:
     - ar
     singular: analysisrun
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            args:
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
-                    properties:
-                      fieldRef:
-                        properties:
-                          fieldPath:
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            metrics:
-              items:
-                properties:
-                  consecutiveErrorLimit:
-                    format: int32
-                    type: integer
-                  count:
-                    format: int32
-                    type: integer
-                  failureCondition:
-                    type: string
-                  failureLimit:
-                    format: int32
-                    type: integer
-                  inconclusiveLimit:
-                    format: int32
-                    type: integer
-                  initialDelay:
-                    type: string
-                  interval:
-                    type: string
-                  name:
-                    type: string
-                  provider:
-                    properties:
-                      datadog:
-                        properties:
-                          interval:
-                            type: string
-                          query:
-                            type: string
-                        required:
-                        - query
-                        type: object
-                      job:
-                        properties:
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          spec:
-                            properties:
-                              activeDeadlineSeconds:
-                                format: int64
-                                type: integer
-                              backoffLimit:
-                                format: int32
-                                type: integer
-                              completions:
-                                format: int32
-                                type: integer
-                              manualSelector:
-                                type: boolean
-                              parallelism:
-                                format: int32
-                                type: integer
-                              selector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              template:
-                                properties:
-                                  metadata:
-                                    properties:
-                                      annotations:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      labels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  spec:
-                                    properties:
-                                      activeDeadlineSeconds:
-                                        format: int64
-                                        type: integer
-                                      affinity:
-                                        properties:
-                                          nodeAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    preference:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    items:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    type: array
-                                                required:
-                                                - nodeSelectorTerms
-                                                type: object
-                                            type: object
-                                          podAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          podAntiAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                        type: object
-                                      automountServiceAccountToken:
-                                        type: boolean
-                                      containers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      dnsConfig:
-                                        properties:
-                                          nameservers:
-                                            items:
-                                              type: string
-                                            type: array
-                                          options:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          searches:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      dnsPolicy:
-                                        type: string
-                                      enableServiceLinks:
-                                        type: boolean
-                                      ephemeralContainers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            targetContainerName:
-                                              type: string
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      hostAliases:
-                                        items:
-                                          properties:
-                                            hostnames:
-                                              items:
-                                                type: string
-                                              type: array
-                                            ip:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      hostIPC:
-                                        type: boolean
-                                      hostNetwork:
-                                        type: boolean
-                                      hostPID:
-                                        type: boolean
-                                      hostname:
-                                        type: string
-                                      imagePullSecrets:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      initContainers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      nodeName:
-                                        type: string
-                                      nodeSelector:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      overhead:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                      preemptionPolicy:
-                                        type: string
-                                      priority:
-                                        format: int32
-                                        type: integer
-                                      priorityClassName:
-                                        type: string
-                                      readinessGates:
-                                        items:
-                                          properties:
-                                            conditionType:
-                                              type: string
-                                          required:
-                                          - conditionType
-                                          type: object
-                                        type: array
-                                      restartPolicy:
-                                        type: string
-                                      runtimeClassName:
-                                        type: string
-                                      schedulerName:
-                                        type: string
-                                      securityContext:
-                                        properties:
-                                          fsGroup:
-                                            format: int64
-                                            type: integer
-                                          fsGroupChangePolicy:
-                                            type: string
-                                          runAsGroup:
-                                            format: int64
-                                            type: integer
-                                          runAsNonRoot:
-                                            type: boolean
-                                          runAsUser:
-                                            format: int64
-                                            type: integer
-                                          seLinuxOptions:
-                                            properties:
-                                              level:
-                                                type: string
-                                              role:
-                                                type: string
-                                              type:
-                                                type: string
-                                              user:
-                                                type: string
-                                            type: object
-                                          supplementalGroups:
-                                            items:
-                                              format: int64
-                                              type: integer
-                                            type: array
-                                          sysctls:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                              - name
-                                              - value
-                                              type: object
-                                            type: array
-                                          windowsOptions:
-                                            properties:
-                                              gmsaCredentialSpec:
-                                                type: string
-                                              gmsaCredentialSpecName:
-                                                type: string
-                                              runAsUserName:
-                                                type: string
-                                            type: object
-                                        type: object
-                                      serviceAccount:
-                                        type: string
-                                      serviceAccountName:
-                                        type: string
-                                      shareProcessNamespace:
-                                        type: boolean
-                                      subdomain:
-                                        type: string
-                                      terminationGracePeriodSeconds:
-                                        format: int64
-                                        type: integer
-                                      tolerations:
-                                        items:
-                                          properties:
-                                            effect:
-                                              type: string
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            tolerationSeconds:
-                                              format: int64
-                                              type: integer
-                                            value:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      topologySpreadConstraints:
-                                        items:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            maxSkew:
-                                              format: int32
-                                              type: integer
-                                            topologyKey:
-                                              type: string
-                                            whenUnsatisfiable:
-                                              type: string
-                                          required:
-                                          - maxSkew
-                                          - topologyKey
-                                          - whenUnsatisfiable
-                                          type: object
-                                        type: array
-                                      volumes:
-                                        items:
-                                          properties:
-                                            awsElasticBlockStore:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                partition:
-                                                  format: int32
-                                                  type: integer
-                                                readOnly:
-                                                  type: boolean
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            azureDisk:
-                                              properties:
-                                                cachingMode:
-                                                  type: string
-                                                diskName:
-                                                  type: string
-                                                diskURI:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                kind:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - diskName
-                                              - diskURI
-                                              type: object
-                                            azureFile:
-                                              properties:
-                                                readOnly:
-                                                  type: boolean
-                                                secretName:
-                                                  type: string
-                                                shareName:
-                                                  type: string
-                                              required:
-                                              - secretName
-                                              - shareName
-                                              type: object
-                                            cephfs:
-                                              properties:
-                                                monitors:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretFile:
-                                                  type: string
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                user:
-                                                  type: string
-                                              required:
-                                              - monitors
-                                              type: object
-                                            cinder:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            csi:
-                                              properties:
-                                                driver:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                nodePublishSecretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                readOnly:
-                                                  type: boolean
-                                                volumeAttributes:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              required:
-                                              - driver
-                                              type: object
-                                            emptyDir:
-                                              properties:
-                                                medium:
-                                                  type: string
-                                                sizeLimit:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                              type: object
-                                            fc:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                lun:
-                                                  format: int32
-                                                  type: integer
-                                                readOnly:
-                                                  type: boolean
-                                                targetWWNs:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                wwids:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            flexVolume:
-                                              properties:
-                                                driver:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                options:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                              required:
-                                              - driver
-                                              type: object
-                                            flocker:
-                                              properties:
-                                                datasetName:
-                                                  type: string
-                                                datasetUUID:
-                                                  type: string
-                                              type: object
-                                            gcePersistentDisk:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                partition:
-                                                  format: int32
-                                                  type: integer
-                                                pdName:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - pdName
-                                              type: object
-                                            gitRepo:
-                                              properties:
-                                                directory:
-                                                  type: string
-                                                repository:
-                                                  type: string
-                                                revision:
-                                                  type: string
-                                              required:
-                                              - repository
-                                              type: object
-                                            glusterfs:
-                                              properties:
-                                                endpoints:
-                                                  type: string
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - endpoints
-                                              - path
-                                              type: object
-                                            hostPath:
-                                              properties:
-                                                path:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                              required:
-                                              - path
-                                              type: object
-                                            iscsi:
-                                              properties:
-                                                chapAuthDiscovery:
-                                                  type: boolean
-                                                chapAuthSession:
-                                                  type: boolean
-                                                fsType:
-                                                  type: string
-                                                initiatorName:
-                                                  type: string
-                                                iqn:
-                                                  type: string
-                                                iscsiInterface:
-                                                  type: string
-                                                lun:
-                                                  format: int32
-                                                  type: integer
-                                                portals:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                targetPortal:
-                                                  type: string
-                                              required:
-                                              - iqn
-                                              - lun
-                                              - targetPortal
-                                              type: object
-                                            name:
-                                              type: string
-                                            nfs:
-                                              properties:
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                server:
-                                                  type: string
-                                              required:
-                                              - path
-                                              - server
-                                              type: object
-                                            persistentVolumeClaim:
-                                              properties:
-                                                claimName:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - claimName
-                                              type: object
-                                            photonPersistentDisk:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                pdID:
-                                                  type: string
-                                              required:
-                                              - pdID
-                                              type: object
-                                            portworxVolume:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            projected:
-                                              properties:
-                                                defaultMode:
-                                                  format: int32
-                                                  type: integer
-                                                sources:
-                                                  items:
-                                                    properties:
-                                                      serviceAccountToken:
-                                                        properties:
-                                                          audience:
-                                                            type: string
-                                                          expirationSeconds:
-                                                            format: int64
-                                                            type: integer
-                                                          path:
-                                                            type: string
-                                                        required:
-                                                        - path
-                                                        type: object
-                                                    type: object
-                                                  type: array
-                                              required:
-                                              - sources
-                                              type: object
-                                            quobyte:
-                                              properties:
-                                                group:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                registry:
-                                                  type: string
-                                                tenant:
-                                                  type: string
-                                                user:
-                                                  type: string
-                                                volume:
-                                                  type: string
-                                              required:
-                                              - registry
-                                              - volume
-                                              type: object
-                                            rbd:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                image:
-                                                  type: string
-                                                keyring:
-                                                  type: string
-                                                monitors:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                pool:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                user:
-                                                  type: string
-                                              required:
-                                              - image
-                                              - monitors
-                                              type: object
-                                            scaleIO:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                gateway:
-                                                  type: string
-                                                protectionDomain:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                sslEnabled:
-                                                  type: boolean
-                                                storageMode:
-                                                  type: string
-                                                storagePool:
-                                                  type: string
-                                                system:
-                                                  type: string
-                                                volumeName:
-                                                  type: string
-                                              required:
-                                              - gateway
-                                              - secretRef
-                                              - system
-                                              type: object
-                                            storageos:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                volumeName:
-                                                  type: string
-                                                volumeNamespace:
-                                                  type: string
-                                              type: object
-                                            vsphereVolume:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                storagePolicyID:
-                                                  type: string
-                                                storagePolicyName:
-                                                  type: string
-                                                volumePath:
-                                                  type: string
-                                              required:
-                                              - volumePath
-                                              type: object
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                    required:
-                                    - containers
-                                    type: object
-                                type: object
-                              ttlSecondsAfterFinished:
-                                format: int32
-                                type: integer
-                            required:
-                            - template
-                            type: object
-                        required:
-                        - spec
-                        type: object
-                      kayenta:
-                        properties:
-                          address:
-                            type: string
-                          application:
-                            type: string
-                          canaryConfigName:
-                            type: string
-                          configurationAccountName:
-                            type: string
-                          metricsAccountName:
-                            type: string
-                          scopes:
-                            items:
-                              properties:
-                                controlScope:
-                                  properties:
-                                    end:
-                                      type: string
-                                    region:
-                                      type: string
-                                    scope:
-                                      type: string
-                                    start:
-                                      type: string
-                                    step:
-                                      type: integer
-                                  required:
-                                  - end
-                                  - region
-                                  - scope
-                                  - start
-                                  - step
-                                  type: object
-                                experimentScope:
-                                  properties:
-                                    end:
-                                      type: string
-                                    region:
-                                      type: string
-                                    scope:
-                                      type: string
-                                    start:
-                                      type: string
-                                    step:
-                                      type: integer
-                                  required:
-                                  - end
-                                  - region
-                                  - scope
-                                  - start
-                                  - step
-                                  type: object
-                                name:
-                                  type: string
-                              required:
-                              - controlScope
-                              - experimentScope
-                              - name
-                              type: object
-                            type: array
-                          storageAccountName:
-                            type: string
-                          threshold:
-                            properties:
-                              marginal:
-                                type: integer
-                              pass:
-                                type: integer
-                            required:
-                            - marginal
-                            - pass
-                            type: object
-                        required:
-                        - address
-                        - application
-                        - canaryConfigName
-                        - configurationAccountName
-                        - metricsAccountName
-                        - scopes
-                        - storageAccountName
-                        - threshold
-                        type: object
-                      newRelic:
-                        properties:
-                          profile:
-                            type: string
-                          query:
-                            type: string
-                        required:
-                        - query
-                        type: object
-                      prometheus:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
-                        type: object
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
-                        type: object
-                      web:
-                        properties:
-                          headers:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - key
-                              - value
-                              type: object
-                            type: array
-                          insecure:
-                            type: boolean
-                          jsonPath:
-                            type: string
-                          timeoutSeconds:
-                            type: integer
-                          url:
-                            type: string
-                        required:
-                        - url
-                        type: object
-                    type: object
-                  successCondition:
-                    type: string
-                required:
-                - name
-                - provider
-                type: object
-              type: array
-            terminate:
-              type: boolean
-          required:
-          - metrics
-          type: object
-        status:
-          properties:
-            message:
-              type: string
-            metricResults:
-              items:
-                properties:
-                  consecutiveError:
-                    format: int32
-                    type: integer
-                  count:
-                    format: int32
-                    type: integer
-                  error:
-                    format: int32
-                    type: integer
-                  failed:
-                    format: int32
-                    type: integer
-                  inconclusive:
-                    format: int32
-                    type: integer
-                  measurements:
-                    items:
-                      properties:
-                        finishedAt:
-                          format: date-time
-                          type: string
-                        message:
-                          type: string
-                        metadata:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        phase:
-                          type: string
-                        resumeAt:
-                          format: date-time
-                          type: string
-                        startedAt:
-                          format: date-time
-                          type: string
-                        value:
-                          type: string
-                      required:
-                      - phase
-                      type: object
-                    type: array
-                  message:
-                    type: string
-                  name:
-                    type: string
-                  phase:
-                    type: string
-                  successful:
-                    format: int32
-                    type: integer
-                required:
-                - name
-                - phase
-                type: object
-              type: array
-            phase:
-              type: string
-            startedAt:
-              format: date-time
-              type: string
-          required:
-          - phase
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    additionalPrinterColumns:
+    - jsonPath: .status.phase
+      description: AnalysisRun status
+      name: Status
+      type: string
+    subresources: {}
+    schema:
+      openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                args:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          fieldRef:
+                            properties:
+                              fieldPath:
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                metrics:
+                  items:
+                    properties:
+                      consecutiveErrorLimit:
+                        format: int32
+                        type: integer
+                      count:
+                        format: int32
+                        type: integer
+                      failureCondition:
+                        type: string
+                      failureLimit:
+                        format: int32
+                        type: integer
+                      inconclusiveLimit:
+                        format: int32
+                        type: integer
+                      initialDelay:
+                        type: string
+                      interval:
+                        type: string
+                      name:
+                        type: string
+                      provider:
+                        properties:
+                          datadog:
+                            properties:
+                              interval:
+                                type: string
+                              query:
+                                type: string
+                            required:
+                            - query
+                            type: object
+                          job:
+                            properties:
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              spec:
+                                properties:
+                                  activeDeadlineSeconds:
+                                    format: int64
+                                    type: integer
+                                  backoffLimit:
+                                    format: int32
+                                    type: integer
+                                  completions:
+                                    format: int32
+                                    type: integer
+                                  manualSelector:
+                                    type: boolean
+                                  parallelism:
+                                    format: int32
+                                    type: integer
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      spec:
+                                        properties:
+                                          activeDeadlineSeconds:
+                                            format: int64
+                                            type: integer
+                                          affinity:
+                                            properties:
+                                              nodeAffinity:
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    items:
+                                                      properties:
+                                                        preference:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchFields:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                          type: object
+                                                        weight:
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                      - preference
+                                                      - weight
+                                                      type: object
+                                                    type: array
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        items:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchFields:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                    required:
+                                                    - nodeSelectorTerms
+                                                    type: object
+                                                type: object
+                                              podAffinity:
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    items:
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          properties:
+                                                            labelSelector:
+                                                              properties:
+                                                                matchExpressions:
+                                                                  items:
+                                                                    properties:
+                                                                      key:
+                                                                        type: string
+                                                                      operator:
+                                                                        type: string
+                                                                      values:
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                    required:
+                                                                    - key
+                                                                    - operator
+                                                                    type: object
+                                                                  type: array
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  type: object
+                                                              type: object
+                                                            namespaces:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            topologyKey:
+                                                              type: string
+                                                          required:
+                                                          - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                      - podAffinityTerm
+                                                      - weight
+                                                      type: object
+                                                    type: array
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    items:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              podAntiAffinity:
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    items:
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          properties:
+                                                            labelSelector:
+                                                              properties:
+                                                                matchExpressions:
+                                                                  items:
+                                                                    properties:
+                                                                      key:
+                                                                        type: string
+                                                                      operator:
+                                                                        type: string
+                                                                      values:
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                    required:
+                                                                    - key
+                                                                    - operator
+                                                                    type: object
+                                                                  type: array
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  type: object
+                                                              type: object
+                                                            namespaces:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                            topologyKey:
+                                                              type: string
+                                                          required:
+                                                          - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                      - podAffinityTerm
+                                                      - weight
+                                                      type: object
+                                                    type: array
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    items:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                            type: object
+                                          automountServiceAccountToken:
+                                            type: boolean
+                                          containers:
+                                            items:
+                                              properties:
+                                                args:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                env:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                      valueFrom:
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            required:
+                                                            - fieldPath
+                                                            type: object
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                type: string
+                                                            required:
+                                                            - resource
+                                                            type: object
+                                                          secretKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                        type: object
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                envFrom:
+                                                  items:
+                                                    properties:
+                                                      configMapRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                      prefix:
+                                                        type: string
+                                                      secretRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                                image:
+                                                  type: string
+                                                imagePullPolicy:
+                                                  type: string
+                                                lifecycle:
+                                                  properties:
+                                                    postStart:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                    preStop:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                  type: object
+                                                livenessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                ports:
+                                                  items:
+                                                    properties:
+                                                      containerPort:
+                                                        format: int32
+                                                        type: integer
+                                                      hostIP:
+                                                        type: string
+                                                      hostPort:
+                                                        format: int32
+                                                        type: integer
+                                                      name:
+                                                        type: string
+                                                      protocol:
+                                                        type: string
+                                                    required:
+                                                    - containerPort
+                                                    type: object
+                                                  type: array
+                                                readinessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                resources:
+                                                  type: object
+                                                securityContext:
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      type: boolean
+                                                    capabilities:
+                                                      properties:
+                                                        add:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        drop:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    privileged:
+                                                      type: boolean
+                                                    procMount:
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      format: int64
+                                                      type: integer
+                                                    runAsNonRoot:
+                                                      type: boolean
+                                                    runAsUser:
+                                                      format: int64
+                                                      type: integer
+                                                    seLinuxOptions:
+                                                      properties:
+                                                        level:
+                                                          type: string
+                                                        role:
+                                                          type: string
+                                                        type:
+                                                          type: string
+                                                        user:
+                                                          type: string
+                                                      type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                stdin:
+                                                  type: boolean
+                                                stdinOnce:
+                                                  type: boolean
+                                                terminationMessagePath:
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  type: string
+                                                tty:
+                                                  type: boolean
+                                                volumeDevices:
+                                                  items:
+                                                    properties:
+                                                      devicePath:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    required:
+                                                    - devicePath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                volumeMounts:
+                                                  items:
+                                                    properties:
+                                                      mountPath:
+                                                        type: string
+                                                      mountPropagation:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      readOnly:
+                                                        type: boolean
+                                                      subPath:
+                                                        type: string
+                                                      subPathExpr:
+                                                        type: string
+                                                    required:
+                                                    - mountPath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                workingDir:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          dnsConfig:
+                                            properties:
+                                              nameservers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              options:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              searches:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          dnsPolicy:
+                                            type: string
+                                          enableServiceLinks:
+                                            type: boolean
+                                          ephemeralContainers:
+                                            items:
+                                              properties:
+                                                args:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                env:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                      valueFrom:
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            required:
+                                                            - fieldPath
+                                                            type: object
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                type: string
+                                                            required:
+                                                            - resource
+                                                            type: object
+                                                          secretKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                        type: object
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                envFrom:
+                                                  items:
+                                                    properties:
+                                                      configMapRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                      prefix:
+                                                        type: string
+                                                      secretRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                                image:
+                                                  type: string
+                                                imagePullPolicy:
+                                                  type: string
+                                                lifecycle:
+                                                  properties:
+                                                    postStart:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                    preStop:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                  type: object
+                                                livenessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                ports:
+                                                  items:
+                                                    properties:
+                                                      containerPort:
+                                                        format: int32
+                                                        type: integer
+                                                      hostIP:
+                                                        type: string
+                                                      hostPort:
+                                                        format: int32
+                                                        type: integer
+                                                      name:
+                                                        type: string
+                                                      protocol:
+                                                        type: string
+                                                    required:
+                                                    - containerPort
+                                                    type: object
+                                                  type: array
+                                                readinessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                resources:
+                                                  type: object
+                                                securityContext:
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      type: boolean
+                                                    capabilities:
+                                                      properties:
+                                                        add:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        drop:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    privileged:
+                                                      type: boolean
+                                                    procMount:
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      format: int64
+                                                      type: integer
+                                                    runAsNonRoot:
+                                                      type: boolean
+                                                    runAsUser:
+                                                      format: int64
+                                                      type: integer
+                                                    seLinuxOptions:
+                                                      properties:
+                                                        level:
+                                                          type: string
+                                                        role:
+                                                          type: string
+                                                        type:
+                                                          type: string
+                                                        user:
+                                                          type: string
+                                                      type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                stdin:
+                                                  type: boolean
+                                                stdinOnce:
+                                                  type: boolean
+                                                targetContainerName:
+                                                  type: string
+                                                terminationMessagePath:
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  type: string
+                                                tty:
+                                                  type: boolean
+                                                volumeDevices:
+                                                  items:
+                                                    properties:
+                                                      devicePath:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    required:
+                                                    - devicePath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                volumeMounts:
+                                                  items:
+                                                    properties:
+                                                      mountPath:
+                                                        type: string
+                                                      mountPropagation:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      readOnly:
+                                                        type: boolean
+                                                      subPath:
+                                                        type: string
+                                                      subPathExpr:
+                                                        type: string
+                                                    required:
+                                                    - mountPath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                workingDir:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          hostAliases:
+                                            items:
+                                              properties:
+                                                hostnames:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                ip:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          hostIPC:
+                                            type: boolean
+                                          hostNetwork:
+                                            type: boolean
+                                          hostPID:
+                                            type: boolean
+                                          hostname:
+                                            type: string
+                                          imagePullSecrets:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          initContainers:
+                                            items:
+                                              properties:
+                                                args:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                env:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                      valueFrom:
+                                                        properties:
+                                                          configMapKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            required:
+                                                            - fieldPath
+                                                            type: object
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                type: string
+                                                            required:
+                                                            - resource
+                                                            type: object
+                                                          secretKeyRef:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                            required:
+                                                            - key
+                                                            type: object
+                                                        type: object
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                envFrom:
+                                                  items:
+                                                    properties:
+                                                      configMapRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                      prefix:
+                                                        type: string
+                                                      secretRef:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                                image:
+                                                  type: string
+                                                imagePullPolicy:
+                                                  type: string
+                                                lifecycle:
+                                                  properties:
+                                                    postStart:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                    preStop:
+                                                      properties:
+                                                        exec:
+                                                          properties:
+                                                            command:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        httpGet:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            httpHeaders:
+                                                              items:
+                                                                properties:
+                                                                  name:
+                                                                    type: string
+                                                                  value:
+                                                                    type: string
+                                                                required:
+                                                                - name
+                                                                - value
+                                                                type: object
+                                                              type: array
+                                                            path:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                            scheme:
+                                                              type: string
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                        tcpSocket:
+                                                          properties:
+                                                            host:
+                                                              type: string
+                                                            port:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              x-kubernetes-int-or-string: true
+                                                          required:
+                                                          - port
+                                                          type: object
+                                                      type: object
+                                                  type: object
+                                                livenessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                ports:
+                                                  items:
+                                                    properties:
+                                                      containerPort:
+                                                        format: int32
+                                                        type: integer
+                                                      hostIP:
+                                                        type: string
+                                                      hostPort:
+                                                        format: int32
+                                                        type: integer
+                                                      name:
+                                                        type: string
+                                                      protocol:
+                                                        type: string
+                                                    required:
+                                                    - containerPort
+                                                    type: object
+                                                  type: array
+                                                readinessProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                resources:
+                                                  type: object
+                                                securityContext:
+                                                  properties:
+                                                    allowPrivilegeEscalation:
+                                                      type: boolean
+                                                    capabilities:
+                                                      properties:
+                                                        add:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        drop:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    privileged:
+                                                      type: boolean
+                                                    procMount:
+                                                      type: string
+                                                    readOnlyRootFilesystem:
+                                                      type: boolean
+                                                    runAsGroup:
+                                                      format: int64
+                                                      type: integer
+                                                    runAsNonRoot:
+                                                      type: boolean
+                                                    runAsUser:
+                                                      format: int64
+                                                      type: integer
+                                                    seLinuxOptions:
+                                                      properties:
+                                                        level:
+                                                          type: string
+                                                        role:
+                                                          type: string
+                                                        type:
+                                                          type: string
+                                                        user:
+                                                          type: string
+                                                      type: object
+                                                    windowsOptions:
+                                                      properties:
+                                                        gmsaCredentialSpec:
+                                                          type: string
+                                                        gmsaCredentialSpecName:
+                                                          type: string
+                                                        runAsUserName:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                startupProbe:
+                                                  properties:
+                                                    exec:
+                                                      properties:
+                                                        command:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    failureThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    httpGet:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          items:
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            type: object
+                                                          type: array
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        scheme:
+                                                          type: string
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    initialDelaySeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    periodSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    successThreshold:
+                                                      format: int32
+                                                      type: integer
+                                                    tcpSocket:
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                      required:
+                                                      - port
+                                                      type: object
+                                                    timeoutSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                  type: object
+                                                stdin:
+                                                  type: boolean
+                                                stdinOnce:
+                                                  type: boolean
+                                                terminationMessagePath:
+                                                  type: string
+                                                terminationMessagePolicy:
+                                                  type: string
+                                                tty:
+                                                  type: boolean
+                                                volumeDevices:
+                                                  items:
+                                                    properties:
+                                                      devicePath:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    required:
+                                                    - devicePath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                volumeMounts:
+                                                  items:
+                                                    properties:
+                                                      mountPath:
+                                                        type: string
+                                                      mountPropagation:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      readOnly:
+                                                        type: boolean
+                                                      subPath:
+                                                        type: string
+                                                      subPathExpr:
+                                                        type: string
+                                                    required:
+                                                    - mountPath
+                                                    - name
+                                                    type: object
+                                                  type: array
+                                                workingDir:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          nodeName:
+                                            type: string
+                                          nodeSelector:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          overhead:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          preemptionPolicy:
+                                            type: string
+                                          priority:
+                                            format: int32
+                                            type: integer
+                                          priorityClassName:
+                                            type: string
+                                          readinessGates:
+                                            items:
+                                              properties:
+                                                conditionType:
+                                                  type: string
+                                              required:
+                                              - conditionType
+                                              type: object
+                                            type: array
+                                          restartPolicy:
+                                            type: string
+                                          runtimeClassName:
+                                            type: string
+                                          schedulerName:
+                                            type: string
+                                          securityContext:
+                                            properties:
+                                              fsGroup:
+                                                format: int64
+                                                type: integer
+                                              fsGroupChangePolicy:
+                                                type: string
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              supplementalGroups:
+                                                items:
+                                                  format: int64
+                                                  type: integer
+                                                type: array
+                                              sysctls:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          serviceAccount:
+                                            type: string
+                                          serviceAccountName:
+                                            type: string
+                                          shareProcessNamespace:
+                                            type: boolean
+                                          subdomain:
+                                            type: string
+                                          terminationGracePeriodSeconds:
+                                            format: int64
+                                            type: integer
+                                          tolerations:
+                                            items:
+                                              properties:
+                                                effect:
+                                                  type: string
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                tolerationSeconds:
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          topologySpreadConstraints:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                maxSkew:
+                                                  format: int32
+                                                  type: integer
+                                                topologyKey:
+                                                  type: string
+                                                whenUnsatisfiable:
+                                                  type: string
+                                              required:
+                                              - maxSkew
+                                              - topologyKey
+                                              - whenUnsatisfiable
+                                              type: object
+                                            type: array
+                                          volumes:
+                                            items:
+                                              properties:
+                                                awsElasticBlockStore:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    partition:
+                                                      format: int32
+                                                      type: integer
+                                                    readOnly:
+                                                      type: boolean
+                                                    volumeID:
+                                                      type: string
+                                                  required:
+                                                  - volumeID
+                                                  type: object
+                                                azureDisk:
+                                                  properties:
+                                                    cachingMode:
+                                                      type: string
+                                                    diskName:
+                                                      type: string
+                                                    diskURI:
+                                                      type: string
+                                                    fsType:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                  required:
+                                                  - diskName
+                                                  - diskURI
+                                                  type: object
+                                                azureFile:
+                                                  properties:
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretName:
+                                                      type: string
+                                                    shareName:
+                                                      type: string
+                                                  required:
+                                                  - secretName
+                                                  - shareName
+                                                  type: object
+                                                cephfs:
+                                                  properties:
+                                                    monitors:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretFile:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    user:
+                                                      type: string
+                                                  required:
+                                                  - monitors
+                                                  type: object
+                                                cinder:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    volumeID:
+                                                      type: string
+                                                  required:
+                                                  - volumeID
+                                                  type: object
+                                                csi:
+                                                  properties:
+                                                    driver:
+                                                      type: string
+                                                    fsType:
+                                                      type: string
+                                                    nodePublishSecretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    readOnly:
+                                                      type: boolean
+                                                    volumeAttributes:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  required:
+                                                  - driver
+                                                  type: object
+                                                emptyDir:
+                                                  properties:
+                                                    medium:
+                                                      type: string
+                                                    sizeLimit:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                  type: object
+                                                fc:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    lun:
+                                                      format: int32
+                                                      type: integer
+                                                    readOnly:
+                                                      type: boolean
+                                                    targetWWNs:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    wwids:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                flexVolume:
+                                                  properties:
+                                                    driver:
+                                                      type: string
+                                                    fsType:
+                                                      type: string
+                                                    options:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                  required:
+                                                  - driver
+                                                  type: object
+                                                flocker:
+                                                  properties:
+                                                    datasetName:
+                                                      type: string
+                                                    datasetUUID:
+                                                      type: string
+                                                  type: object
+                                                gcePersistentDisk:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    partition:
+                                                      format: int32
+                                                      type: integer
+                                                    pdName:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                  required:
+                                                  - pdName
+                                                  type: object
+                                                gitRepo:
+                                                  properties:
+                                                    directory:
+                                                      type: string
+                                                    repository:
+                                                      type: string
+                                                    revision:
+                                                      type: string
+                                                  required:
+                                                  - repository
+                                                  type: object
+                                                glusterfs:
+                                                  properties:
+                                                    endpoints:
+                                                      type: string
+                                                    path:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                  required:
+                                                  - endpoints
+                                                  - path
+                                                  type: object
+                                                hostPath:
+                                                  properties:
+                                                    path:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                iscsi:
+                                                  properties:
+                                                    chapAuthDiscovery:
+                                                      type: boolean
+                                                    chapAuthSession:
+                                                      type: boolean
+                                                    fsType:
+                                                      type: string
+                                                    initiatorName:
+                                                      type: string
+                                                    iqn:
+                                                      type: string
+                                                    iscsiInterface:
+                                                      type: string
+                                                    lun:
+                                                      format: int32
+                                                      type: integer
+                                                    portals:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    targetPortal:
+                                                      type: string
+                                                  required:
+                                                  - iqn
+                                                  - lun
+                                                  - targetPortal
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                nfs:
+                                                  properties:
+                                                    path:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    server:
+                                                      type: string
+                                                  required:
+                                                  - path
+                                                  - server
+                                                  type: object
+                                                persistentVolumeClaim:
+                                                  properties:
+                                                    claimName:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                  required:
+                                                  - claimName
+                                                  type: object
+                                                photonPersistentDisk:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    pdID:
+                                                      type: string
+                                                  required:
+                                                  - pdID
+                                                  type: object
+                                                portworxVolume:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    volumeID:
+                                                      type: string
+                                                  required:
+                                                  - volumeID
+                                                  type: object
+                                                projected:
+                                                  properties:
+                                                    defaultMode:
+                                                      format: int32
+                                                      type: integer
+                                                    sources:
+                                                      items:
+                                                        properties:
+                                                          serviceAccountToken:
+                                                            properties:
+                                                              audience:
+                                                                type: string
+                                                              expirationSeconds:
+                                                                format: int64
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                            required:
+                                                            - path
+                                                            type: object
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - sources
+                                                  type: object
+                                                quobyte:
+                                                  properties:
+                                                    group:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    registry:
+                                                      type: string
+                                                    tenant:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                    volume:
+                                                      type: string
+                                                  required:
+                                                  - registry
+                                                  - volume
+                                                  type: object
+                                                rbd:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    image:
+                                                      type: string
+                                                    keyring:
+                                                      type: string
+                                                    monitors:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    pool:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    user:
+                                                      type: string
+                                                  required:
+                                                  - image
+                                                  - monitors
+                                                  type: object
+                                                scaleIO:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    gateway:
+                                                      type: string
+                                                    protectionDomain:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    sslEnabled:
+                                                      type: boolean
+                                                    storageMode:
+                                                      type: string
+                                                    storagePool:
+                                                      type: string
+                                                    system:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - gateway
+                                                  - secretRef
+                                                  - system
+                                                  type: object
+                                                storageos:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      type: object
+                                                    volumeName:
+                                                      type: string
+                                                    volumeNamespace:
+                                                      type: string
+                                                  type: object
+                                                vsphereVolume:
+                                                  properties:
+                                                    fsType:
+                                                      type: string
+                                                    storagePolicyID:
+                                                      type: string
+                                                    storagePolicyName:
+                                                      type: string
+                                                    volumePath:
+                                                      type: string
+                                                  required:
+                                                  - volumePath
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        required:
+                                        - containers
+                                        type: object
+                                    type: object
+                                  ttlSecondsAfterFinished:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - template
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                          kayenta:
+                            properties:
+                              address:
+                                type: string
+                              application:
+                                type: string
+                              canaryConfigName:
+                                type: string
+                              configurationAccountName:
+                                type: string
+                              metricsAccountName:
+                                type: string
+                              scopes:
+                                items:
+                                  properties:
+                                    controlScope:
+                                      properties:
+                                        end:
+                                          type: string
+                                        region:
+                                          type: string
+                                        scope:
+                                          type: string
+                                        start:
+                                          type: string
+                                        step:
+                                          type: integer
+                                      required:
+                                      - end
+                                      - region
+                                      - scope
+                                      - start
+                                      - step
+                                      type: object
+                                    experimentScope:
+                                      properties:
+                                        end:
+                                          type: string
+                                        region:
+                                          type: string
+                                        scope:
+                                          type: string
+                                        start:
+                                          type: string
+                                        step:
+                                          type: integer
+                                      required:
+                                      - end
+                                      - region
+                                      - scope
+                                      - start
+                                      - step
+                                      type: object
+                                    name:
+                                      type: string
+                                  required:
+                                  - controlScope
+                                  - experimentScope
+                                  - name
+                                  type: object
+                                type: array
+                              storageAccountName:
+                                type: string
+                              threshold:
+                                properties:
+                                  marginal:
+                                    type: integer
+                                  pass:
+                                    type: integer
+                                required:
+                                - marginal
+                                - pass
+                                type: object
+                            required:
+                            - address
+                            - application
+                            - canaryConfigName
+                            - configurationAccountName
+                            - metricsAccountName
+                            - scopes
+                            - storageAccountName
+                            - threshold
+                            type: object
+                          newRelic:
+                            properties:
+                              profile:
+                                type: string
+                              query:
+                                type: string
+                            required:
+                            - query
+                            type: object
+                          prometheus:
+                            properties:
+                              address:
+                                type: string
+                              query:
+                                type: string
+                            type: object
+                          wavefront:
+                            properties:
+                              address:
+                                type: string
+                              query:
+                                type: string
+                            type: object
+                          web:
+                            properties:
+                              headers:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                type: array
+                              insecure:
+                                type: boolean
+                              jsonPath:
+                                type: string
+                              timeoutSeconds:
+                                type: integer
+                              url:
+                                type: string
+                            required:
+                            - url
+                            type: object
+                        type: object
+                      successCondition:
+                        type: string
+                    required:
+                    - name
+                    - provider
+                    type: object
+                  type: array
+                terminate:
+                  type: boolean
+              required:
+              - metrics
+              type: object
+            status:
+              properties:
+                message:
+                  type: string
+                metricResults:
+                  items:
+                    properties:
+                      consecutiveError:
+                        format: int32
+                        type: integer
+                      count:
+                        format: int32
+                        type: integer
+                      error:
+                        format: int32
+                        type: integer
+                      failed:
+                        format: int32
+                        type: integer
+                      inconclusive:
+                        format: int32
+                        type: integer
+                      measurements:
+                        items:
+                          properties:
+                            finishedAt:
+                              format: date-time
+                              type: string
+                            message:
+                              type: string
+                            metadata:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            phase:
+                              type: string
+                            resumeAt:
+                              format: date-time
+                              type: string
+                            startedAt:
+                              format: date-time
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - phase
+                          type: object
+                        type: array
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      phase:
+                        type: string
+                      successful:
+                        format: int32
+                        type: integer
+                    required:
+                    - name
+                    - phase
+                    type: object
+                  type: array
+                phase:
+                  type: string
+                startedAt:
+                  format: date-time
+                  type: string
+              required:
+              - phase
+              type: object
+          required:
+          - spec
+          type: object
 {{- end }}

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -15,2747 +15,2746 @@ spec:
     - at
     singular: analysistemplate
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            args:
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
-                    properties:
-                      fieldRef:
-                        properties:
-                          fieldPath:
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            metrics:
-              items:
-                properties:
-                  consecutiveErrorLimit:
-                    format: int32
-                    type: integer
-                  count:
-                    format: int32
-                    type: integer
-                  failureCondition:
-                    type: string
-                  failureLimit:
-                    format: int32
-                    type: integer
-                  inconclusiveLimit:
-                    format: int32
-                    type: integer
-                  initialDelay:
-                    type: string
-                  interval:
-                    type: string
-                  name:
-                    type: string
-                  provider:
-                    properties:
-                      datadog:
-                        properties:
-                          interval:
-                            type: string
-                          query:
-                            type: string
-                        required:
-                        - query
-                        type: object
-                      job:
-                        properties:
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          spec:
-                            properties:
-                              activeDeadlineSeconds:
-                                format: int64
-                                type: integer
-                              backoffLimit:
-                                format: int32
-                                type: integer
-                              completions:
-                                format: int32
-                                type: integer
-                              manualSelector:
-                                type: boolean
-                              parallelism:
-                                format: int32
-                                type: integer
-                              selector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              template:
-                                properties:
-                                  metadata:
-                                    properties:
-                                      annotations:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      labels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  spec:
-                                    properties:
-                                      activeDeadlineSeconds:
-                                        format: int64
-                                        type: integer
-                                      affinity:
-                                        properties:
-                                          nodeAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    preference:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    items:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    type: array
-                                                required:
-                                                - nodeSelectorTerms
-                                                type: object
-                                            type: object
-                                          podAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          podAntiAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                        type: object
-                                      automountServiceAccountToken:
-                                        type: boolean
-                                      containers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      dnsConfig:
-                                        properties:
-                                          nameservers:
-                                            items:
-                                              type: string
-                                            type: array
-                                          options:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          searches:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      dnsPolicy:
-                                        type: string
-                                      enableServiceLinks:
-                                        type: boolean
-                                      ephemeralContainers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            targetContainerName:
-                                              type: string
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      hostAliases:
-                                        items:
-                                          properties:
-                                            hostnames:
-                                              items:
-                                                type: string
-                                              type: array
-                                            ip:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      hostIPC:
-                                        type: boolean
-                                      hostNetwork:
-                                        type: boolean
-                                      hostPID:
-                                        type: boolean
-                                      hostname:
-                                        type: string
-                                      imagePullSecrets:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      initContainers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      nodeName:
-                                        type: string
-                                      nodeSelector:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      overhead:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                      preemptionPolicy:
-                                        type: string
-                                      priority:
-                                        format: int32
-                                        type: integer
-                                      priorityClassName:
-                                        type: string
-                                      readinessGates:
-                                        items:
-                                          properties:
-                                            conditionType:
-                                              type: string
-                                          required:
-                                          - conditionType
-                                          type: object
-                                        type: array
-                                      restartPolicy:
-                                        type: string
-                                      runtimeClassName:
-                                        type: string
-                                      schedulerName:
-                                        type: string
-                                      securityContext:
-                                        properties:
-                                          fsGroup:
-                                            format: int64
-                                            type: integer
-                                          fsGroupChangePolicy:
-                                            type: string
-                                          runAsGroup:
-                                            format: int64
-                                            type: integer
-                                          runAsNonRoot:
-                                            type: boolean
-                                          runAsUser:
-                                            format: int64
-                                            type: integer
-                                          seLinuxOptions:
-                                            properties:
-                                              level:
-                                                type: string
-                                              role:
-                                                type: string
-                                              type:
-                                                type: string
-                                              user:
-                                                type: string
-                                            type: object
-                                          supplementalGroups:
-                                            items:
-                                              format: int64
-                                              type: integer
-                                            type: array
-                                          sysctls:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                              - name
-                                              - value
-                                              type: object
-                                            type: array
-                                          windowsOptions:
-                                            properties:
-                                              gmsaCredentialSpec:
-                                                type: string
-                                              gmsaCredentialSpecName:
-                                                type: string
-                                              runAsUserName:
-                                                type: string
-                                            type: object
-                                        type: object
-                                      serviceAccount:
-                                        type: string
-                                      serviceAccountName:
-                                        type: string
-                                      shareProcessNamespace:
-                                        type: boolean
-                                      subdomain:
-                                        type: string
-                                      terminationGracePeriodSeconds:
-                                        format: int64
-                                        type: integer
-                                      tolerations:
-                                        items:
-                                          properties:
-                                            effect:
-                                              type: string
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            tolerationSeconds:
-                                              format: int64
-                                              type: integer
-                                            value:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      topologySpreadConstraints:
-                                        items:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            maxSkew:
-                                              format: int32
-                                              type: integer
-                                            topologyKey:
-                                              type: string
-                                            whenUnsatisfiable:
-                                              type: string
-                                          required:
-                                          - maxSkew
-                                          - topologyKey
-                                          - whenUnsatisfiable
-                                          type: object
-                                        type: array
-                                      volumes:
-                                        items:
-                                          properties:
-                                            awsElasticBlockStore:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                partition:
-                                                  format: int32
-                                                  type: integer
-                                                readOnly:
-                                                  type: boolean
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            azureDisk:
-                                              properties:
-                                                cachingMode:
-                                                  type: string
-                                                diskName:
-                                                  type: string
-                                                diskURI:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                kind:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - diskName
-                                              - diskURI
-                                              type: object
-                                            azureFile:
-                                              properties:
-                                                readOnly:
-                                                  type: boolean
-                                                secretName:
-                                                  type: string
-                                                shareName:
-                                                  type: string
-                                              required:
-                                              - secretName
-                                              - shareName
-                                              type: object
-                                            cephfs:
-                                              properties:
-                                                monitors:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretFile:
-                                                  type: string
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                user:
-                                                  type: string
-                                              required:
-                                              - monitors
-                                              type: object
-                                            cinder:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            csi:
-                                              properties:
-                                                driver:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                nodePublishSecretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                readOnly:
-                                                  type: boolean
-                                                volumeAttributes:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              required:
-                                              - driver
-                                              type: object
-                                            emptyDir:
-                                              properties:
-                                                medium:
-                                                  type: string
-                                                sizeLimit:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                              type: object
-                                            fc:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                lun:
-                                                  format: int32
-                                                  type: integer
-                                                readOnly:
-                                                  type: boolean
-                                                targetWWNs:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                wwids:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            flexVolume:
-                                              properties:
-                                                driver:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                options:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                              required:
-                                              - driver
-                                              type: object
-                                            flocker:
-                                              properties:
-                                                datasetName:
-                                                  type: string
-                                                datasetUUID:
-                                                  type: string
-                                              type: object
-                                            gcePersistentDisk:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                partition:
-                                                  format: int32
-                                                  type: integer
-                                                pdName:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - pdName
-                                              type: object
-                                            gitRepo:
-                                              properties:
-                                                directory:
-                                                  type: string
-                                                repository:
-                                                  type: string
-                                                revision:
-                                                  type: string
-                                              required:
-                                              - repository
-                                              type: object
-                                            glusterfs:
-                                              properties:
-                                                endpoints:
-                                                  type: string
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - endpoints
-                                              - path
-                                              type: object
-                                            hostPath:
-                                              properties:
-                                                path:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                              required:
-                                              - path
-                                              type: object
-                                            iscsi:
-                                              properties:
-                                                chapAuthDiscovery:
-                                                  type: boolean
-                                                chapAuthSession:
-                                                  type: boolean
-                                                fsType:
-                                                  type: string
-                                                initiatorName:
-                                                  type: string
-                                                iqn:
-                                                  type: string
-                                                iscsiInterface:
-                                                  type: string
-                                                lun:
-                                                  format: int32
-                                                  type: integer
-                                                portals:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                targetPortal:
-                                                  type: string
-                                              required:
-                                              - iqn
-                                              - lun
-                                              - targetPortal
-                                              type: object
-                                            name:
-                                              type: string
-                                            nfs:
-                                              properties:
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                server:
-                                                  type: string
-                                              required:
-                                              - path
-                                              - server
-                                              type: object
-                                            persistentVolumeClaim:
-                                              properties:
-                                                claimName:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - claimName
-                                              type: object
-                                            photonPersistentDisk:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                pdID:
-                                                  type: string
-                                              required:
-                                              - pdID
-                                              type: object
-                                            portworxVolume:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            projected:
-                                              properties:
-                                                defaultMode:
-                                                  format: int32
-                                                  type: integer
-                                                sources:
-                                                  items:
-                                                    properties:
-                                                      serviceAccountToken:
-                                                        properties:
-                                                          audience:
-                                                            type: string
-                                                          expirationSeconds:
-                                                            format: int64
-                                                            type: integer
-                                                          path:
-                                                            type: string
-                                                        required:
-                                                        - path
-                                                        type: object
-                                                    type: object
-                                                  type: array
-                                              required:
-                                              - sources
-                                              type: object
-                                            quobyte:
-                                              properties:
-                                                group:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                registry:
-                                                  type: string
-                                                tenant:
-                                                  type: string
-                                                user:
-                                                  type: string
-                                                volume:
-                                                  type: string
-                                              required:
-                                              - registry
-                                              - volume
-                                              type: object
-                                            rbd:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                image:
-                                                  type: string
-                                                keyring:
-                                                  type: string
-                                                monitors:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                pool:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                user:
-                                                  type: string
-                                              required:
-                                              - image
-                                              - monitors
-                                              type: object
-                                            scaleIO:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                gateway:
-                                                  type: string
-                                                protectionDomain:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                sslEnabled:
-                                                  type: boolean
-                                                storageMode:
-                                                  type: string
-                                                storagePool:
-                                                  type: string
-                                                system:
-                                                  type: string
-                                                volumeName:
-                                                  type: string
-                                              required:
-                                              - gateway
-                                              - secretRef
-                                              - system
-                                              type: object
-                                            storageos:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                volumeName:
-                                                  type: string
-                                                volumeNamespace:
-                                                  type: string
-                                              type: object
-                                            vsphereVolume:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                storagePolicyID:
-                                                  type: string
-                                                storagePolicyName:
-                                                  type: string
-                                                volumePath:
-                                                  type: string
-                                              required:
-                                              - volumePath
-                                              type: object
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                    required:
-                                    - containers
-                                    type: object
-                                type: object
-                              ttlSecondsAfterFinished:
-                                format: int32
-                                type: integer
-                            required:
-                            - template
-                            type: object
-                        required:
-                        - spec
-                        type: object
-                      kayenta:
-                        properties:
-                          address:
-                            type: string
-                          application:
-                            type: string
-                          canaryConfigName:
-                            type: string
-                          configurationAccountName:
-                            type: string
-                          metricsAccountName:
-                            type: string
-                          scopes:
-                            items:
-                              properties:
-                                controlScope:
-                                  properties:
-                                    end:
-                                      type: string
-                                    region:
-                                      type: string
-                                    scope:
-                                      type: string
-                                    start:
-                                      type: string
-                                    step:
-                                      type: integer
-                                  required:
-                                  - end
-                                  - region
-                                  - scope
-                                  - start
-                                  - step
-                                  type: object
-                                experimentScope:
-                                  properties:
-                                    end:
-                                      type: string
-                                    region:
-                                      type: string
-                                    scope:
-                                      type: string
-                                    start:
-                                      type: string
-                                    step:
-                                      type: integer
-                                  required:
-                                  - end
-                                  - region
-                                  - scope
-                                  - start
-                                  - step
-                                  type: object
-                                name:
-                                  type: string
-                              required:
-                              - controlScope
-                              - experimentScope
-                              - name
-                              type: object
-                            type: array
-                          storageAccountName:
-                            type: string
-                          threshold:
-                            properties:
-                              marginal:
-                                type: integer
-                              pass:
-                                type: integer
-                            required:
-                            - marginal
-                            - pass
-                            type: object
-                        required:
-                        - address
-                        - application
-                        - canaryConfigName
-                        - configurationAccountName
-                        - metricsAccountName
-                        - scopes
-                        - storageAccountName
-                        - threshold
-                        type: object
-                      newRelic:
-                        properties:
-                          profile:
-                            type: string
-                          query:
-                            type: string
-                        required:
-                        - query
-                        type: object
-                      prometheus:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
-                        type: object
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
-                        type: object
-                      web:
-                        properties:
-                          headers:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - key
-                              - value
-                              type: object
-                            type: array
-                          insecure:
-                            type: boolean
-                          jsonPath:
-                            type: string
-                          timeoutSeconds:
-                            type: integer
-                          url:
-                            type: string
-                        required:
-                        - url
-                        type: object
-                    type: object
-                  successCondition:
-                    type: string
-                required:
-                - name
-                - provider
-                type: object
-              type: array
-          required:
-          - metrics
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      format: int32
+                      type: integer
+                    count:
+                      format: int32
+                      type: integer
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      format: int32
+                      type: integer
+                    inconclusiveLimit:
+                      format: int32
+                      type: integer
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        datadog:
+                          properties:
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                completions:
+                                  format: int32
+                                  type: integer
+                                manualSelector:
+                                  type: boolean
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              ip:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                        volumes:
+                                          items:
+                                            properties:
+                                              awsElasticBlockStore:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  partition:
+                                                    format: int32
+                                                    type: integer
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              azureDisk:
+                                                properties:
+                                                  cachingMode:
+                                                    type: string
+                                                  diskName:
+                                                    type: string
+                                                  diskURI:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - diskName
+                                                - diskURI
+                                                type: object
+                                              azureFile:
+                                                properties:
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretName:
+                                                    type: string
+                                                  shareName:
+                                                    type: string
+                                                required:
+                                                - secretName
+                                                - shareName
+                                                type: object
+                                              cephfs:
+                                                properties:
+                                                  monitors:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretFile:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  user:
+                                                    type: string
+                                                required:
+                                                - monitors
+                                                type: object
+                                              cinder:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              csi:
+                                                properties:
+                                                  driver:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  nodePublishSecretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeAttributes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - driver
+                                                type: object
+                                              emptyDir:
+                                                properties:
+                                                  medium:
+                                                    type: string
+                                                  sizeLimit:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                              fc:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  lun:
+                                                    format: int32
+                                                    type: integer
+                                                  readOnly:
+                                                    type: boolean
+                                                  targetWWNs:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  wwids:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              flexVolume:
+                                                properties:
+                                                  driver:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  options:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                required:
+                                                - driver
+                                                type: object
+                                              flocker:
+                                                properties:
+                                                  datasetName:
+                                                    type: string
+                                                  datasetUUID:
+                                                    type: string
+                                                type: object
+                                              gcePersistentDisk:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  partition:
+                                                    format: int32
+                                                    type: integer
+                                                  pdName:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - pdName
+                                                type: object
+                                              gitRepo:
+                                                properties:
+                                                  directory:
+                                                    type: string
+                                                  repository:
+                                                    type: string
+                                                  revision:
+                                                    type: string
+                                                required:
+                                                - repository
+                                                type: object
+                                              glusterfs:
+                                                properties:
+                                                  endpoints:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - endpoints
+                                                - path
+                                                type: object
+                                              hostPath:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              iscsi:
+                                                properties:
+                                                  chapAuthDiscovery:
+                                                    type: boolean
+                                                  chapAuthSession:
+                                                    type: boolean
+                                                  fsType:
+                                                    type: string
+                                                  initiatorName:
+                                                    type: string
+                                                  iqn:
+                                                    type: string
+                                                  iscsiInterface:
+                                                    type: string
+                                                  lun:
+                                                    format: int32
+                                                    type: integer
+                                                  portals:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  targetPortal:
+                                                    type: string
+                                                required:
+                                                - iqn
+                                                - lun
+                                                - targetPortal
+                                                type: object
+                                              name:
+                                                type: string
+                                              nfs:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  server:
+                                                    type: string
+                                                required:
+                                                - path
+                                                - server
+                                                type: object
+                                              persistentVolumeClaim:
+                                                properties:
+                                                  claimName:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - claimName
+                                                type: object
+                                              photonPersistentDisk:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  pdID:
+                                                    type: string
+                                                required:
+                                                - pdID
+                                                type: object
+                                              portworxVolume:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              projected:
+                                                properties:
+                                                  defaultMode:
+                                                    format: int32
+                                                    type: integer
+                                                  sources:
+                                                    items:
+                                                      properties:
+                                                        serviceAccountToken:
+                                                          properties:
+                                                            audience:
+                                                              type: string
+                                                            expirationSeconds:
+                                                              format: int64
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - sources
+                                                type: object
+                                              quobyte:
+                                                properties:
+                                                  group:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  registry:
+                                                    type: string
+                                                  tenant:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                  volume:
+                                                    type: string
+                                                required:
+                                                - registry
+                                                - volume
+                                                type: object
+                                              rbd:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  image:
+                                                    type: string
+                                                  keyring:
+                                                    type: string
+                                                  monitors:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  pool:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  user:
+                                                    type: string
+                                                required:
+                                                - image
+                                                - monitors
+                                                type: object
+                                              scaleIO:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  gateway:
+                                                    type: string
+                                                  protectionDomain:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  sslEnabled:
+                                                    type: boolean
+                                                  storageMode:
+                                                    type: string
+                                                  storagePool:
+                                                    type: string
+                                                  system:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - gateway
+                                                - secretRef
+                                                - system
+                                                type: object
+                                              storageos:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  volumeName:
+                                                    type: string
+                                                  volumeNamespace:
+                                                    type: string
+                                                type: object
+                                              vsphereVolume:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  storagePolicyID:
+                                                    type: string
+                                                  storagePolicyName:
+                                                    type: string
+                                                  volumePath:
+                                                    type: string
+                                                required:
+                                                - volumePath
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  type: integer
+                                pass:
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonPath:
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+            required:
+            - metrics
+            type: object
+        required:
+        - spec
+        type: object
 {{- end }}

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -15,2747 +15,2746 @@ spec:
     - cat
     singular: clusteranalysistemplate
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            args:
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                  valueFrom:
-                    properties:
-                      fieldRef:
-                        properties:
-                          fieldPath:
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            metrics:
-              items:
-                properties:
-                  consecutiveErrorLimit:
-                    format: int32
-                    type: integer
-                  count:
-                    format: int32
-                    type: integer
-                  failureCondition:
-                    type: string
-                  failureLimit:
-                    format: int32
-                    type: integer
-                  inconclusiveLimit:
-                    format: int32
-                    type: integer
-                  initialDelay:
-                    type: string
-                  interval:
-                    type: string
-                  name:
-                    type: string
-                  provider:
-                    properties:
-                      datadog:
-                        properties:
-                          interval:
-                            type: string
-                          query:
-                            type: string
-                        required:
-                        - query
-                        type: object
-                      job:
-                        properties:
-                          metadata:
-                            properties:
-                              annotations:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              labels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                          spec:
-                            properties:
-                              activeDeadlineSeconds:
-                                format: int64
-                                type: integer
-                              backoffLimit:
-                                format: int32
-                                type: integer
-                              completions:
-                                format: int32
-                                type: integer
-                              manualSelector:
-                                type: boolean
-                              parallelism:
-                                format: int32
-                                type: integer
-                              selector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              template:
-                                properties:
-                                  metadata:
-                                    properties:
-                                      annotations:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      labels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  spec:
-                                    properties:
-                                      activeDeadlineSeconds:
-                                        format: int64
-                                        type: integer
-                                      affinity:
-                                        properties:
-                                          nodeAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    preference:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    items:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    type: array
-                                                required:
-                                                - nodeSelectorTerms
-                                                type: object
-                                            type: object
-                                          podAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          podAntiAffinity:
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                items:
-                                                  properties:
-                                                    labelSelector:
-                                                      properties:
-                                                        matchExpressions:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              operator:
-                                                                type: string
-                                                              values:
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                        type: object
-                                      automountServiceAccountToken:
-                                        type: boolean
-                                      containers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      dnsConfig:
-                                        properties:
-                                          nameservers:
-                                            items:
-                                              type: string
-                                            type: array
-                                          options:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          searches:
-                                            items:
-                                              type: string
-                                            type: array
-                                        type: object
-                                      dnsPolicy:
-                                        type: string
-                                      enableServiceLinks:
-                                        type: boolean
-                                      ephemeralContainers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            targetContainerName:
-                                              type: string
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      hostAliases:
-                                        items:
-                                          properties:
-                                            hostnames:
-                                              items:
-                                                type: string
-                                              type: array
-                                            ip:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      hostIPC:
-                                        type: boolean
-                                      hostNetwork:
-                                        type: boolean
-                                      hostPID:
-                                        type: boolean
-                                      hostname:
-                                        type: string
-                                      imagePullSecrets:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      initContainers:
-                                        items:
-                                          properties:
-                                            args:
-                                              items:
-                                                type: string
-                                              type: array
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                            env:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                  valueFrom:
-                                                    properties:
-                                                      configMapKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                      fieldRef:
-                                                        properties:
-                                                          apiVersion:
-                                                            type: string
-                                                          fieldPath:
-                                                            type: string
-                                                        required:
-                                                        - fieldPath
-                                                        type: object
-                                                      resourceFieldRef:
-                                                        properties:
-                                                          containerName:
-                                                            type: string
-                                                          divisor:
-                                                            anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                            x-kubernetes-int-or-string: true
-                                                          resource:
-                                                            type: string
-                                                        required:
-                                                        - resource
-                                                        type: object
-                                                      secretKeyRef:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        required:
-                                                        - key
-                                                        type: object
-                                                    type: object
-                                                required:
-                                                - name
-                                                type: object
-                                              type: array
-                                            envFrom:
-                                              items:
-                                                properties:
-                                                  configMapRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                  prefix:
-                                                    type: string
-                                                  secretRef:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                    type: object
-                                                type: object
-                                              type: array
-                                            image:
-                                              type: string
-                                            imagePullPolicy:
-                                              type: string
-                                            lifecycle:
-                                              properties:
-                                                postStart:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                                preStop:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                  type: object
-                                              type: object
-                                            livenessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            name:
-                                              type: string
-                                            ports:
-                                              items:
-                                                properties:
-                                                  containerPort:
-                                                    format: int32
-                                                    type: integer
-                                                  hostIP:
-                                                    type: string
-                                                  hostPort:
-                                                    format: int32
-                                                    type: integer
-                                                  name:
-                                                    type: string
-                                                  protocol:
-                                                    type: string
-                                                required:
-                                                - containerPort
-                                                type: object
-                                              type: array
-                                            readinessProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            resources:
-                                              type: object
-                                            securityContext:
-                                              properties:
-                                                allowPrivilegeEscalation:
-                                                  type: boolean
-                                                capabilities:
-                                                  properties:
-                                                    add:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    drop:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                privileged:
-                                                  type: boolean
-                                                procMount:
-                                                  type: string
-                                                readOnlyRootFilesystem:
-                                                  type: boolean
-                                                runAsGroup:
-                                                  format: int64
-                                                  type: integer
-                                                runAsNonRoot:
-                                                  type: boolean
-                                                runAsUser:
-                                                  format: int64
-                                                  type: integer
-                                                seLinuxOptions:
-                                                  properties:
-                                                    level:
-                                                      type: string
-                                                    role:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                  type: object
-                                                windowsOptions:
-                                                  properties:
-                                                    gmsaCredentialSpec:
-                                                      type: string
-                                                    gmsaCredentialSpecName:
-                                                      type: string
-                                                    runAsUserName:
-                                                      type: string
-                                                  type: object
-                                              type: object
-                                            startupProbe:
-                                              properties:
-                                                exec:
-                                                  properties:
-                                                    command:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                failureThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                httpGet:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    httpHeaders:
-                                                      items:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          value:
-                                                            type: string
-                                                        required:
-                                                        - name
-                                                        - value
-                                                        type: object
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                    scheme:
-                                                      type: string
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                initialDelaySeconds:
-                                                  format: int32
-                                                  type: integer
-                                                periodSeconds:
-                                                  format: int32
-                                                  type: integer
-                                                successThreshold:
-                                                  format: int32
-                                                  type: integer
-                                                tcpSocket:
-                                                  properties:
-                                                    host:
-                                                      type: string
-                                                    port:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      x-kubernetes-int-or-string: true
-                                                  required:
-                                                  - port
-                                                  type: object
-                                                timeoutSeconds:
-                                                  format: int32
-                                                  type: integer
-                                              type: object
-                                            stdin:
-                                              type: boolean
-                                            stdinOnce:
-                                              type: boolean
-                                            terminationMessagePath:
-                                              type: string
-                                            terminationMessagePolicy:
-                                              type: string
-                                            tty:
-                                              type: boolean
-                                            volumeDevices:
-                                              items:
-                                                properties:
-                                                  devicePath:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                required:
-                                                - devicePath
-                                                - name
-                                                type: object
-                                              type: array
-                                            volumeMounts:
-                                              items:
-                                                properties:
-                                                  mountPath:
-                                                    type: string
-                                                  mountPropagation:
-                                                    type: string
-                                                  name:
-                                                    type: string
-                                                  readOnly:
-                                                    type: boolean
-                                                  subPath:
-                                                    type: string
-                                                  subPathExpr:
-                                                    type: string
-                                                required:
-                                                - mountPath
-                                                - name
-                                                type: object
-                                              type: array
-                                            workingDir:
-                                              type: string
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                      nodeName:
-                                        type: string
-                                      nodeSelector:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      overhead:
-                                        additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        type: object
-                                      preemptionPolicy:
-                                        type: string
-                                      priority:
-                                        format: int32
-                                        type: integer
-                                      priorityClassName:
-                                        type: string
-                                      readinessGates:
-                                        items:
-                                          properties:
-                                            conditionType:
-                                              type: string
-                                          required:
-                                          - conditionType
-                                          type: object
-                                        type: array
-                                      restartPolicy:
-                                        type: string
-                                      runtimeClassName:
-                                        type: string
-                                      schedulerName:
-                                        type: string
-                                      securityContext:
-                                        properties:
-                                          fsGroup:
-                                            format: int64
-                                            type: integer
-                                          fsGroupChangePolicy:
-                                            type: string
-                                          runAsGroup:
-                                            format: int64
-                                            type: integer
-                                          runAsNonRoot:
-                                            type: boolean
-                                          runAsUser:
-                                            format: int64
-                                            type: integer
-                                          seLinuxOptions:
-                                            properties:
-                                              level:
-                                                type: string
-                                              role:
-                                                type: string
-                                              type:
-                                                type: string
-                                              user:
-                                                type: string
-                                            type: object
-                                          supplementalGroups:
-                                            items:
-                                              format: int64
-                                              type: integer
-                                            type: array
-                                          sysctls:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                              required:
-                                              - name
-                                              - value
-                                              type: object
-                                            type: array
-                                          windowsOptions:
-                                            properties:
-                                              gmsaCredentialSpec:
-                                                type: string
-                                              gmsaCredentialSpecName:
-                                                type: string
-                                              runAsUserName:
-                                                type: string
-                                            type: object
-                                        type: object
-                                      serviceAccount:
-                                        type: string
-                                      serviceAccountName:
-                                        type: string
-                                      shareProcessNamespace:
-                                        type: boolean
-                                      subdomain:
-                                        type: string
-                                      terminationGracePeriodSeconds:
-                                        format: int64
-                                        type: integer
-                                      tolerations:
-                                        items:
-                                          properties:
-                                            effect:
-                                              type: string
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            tolerationSeconds:
-                                              format: int64
-                                              type: integer
-                                            value:
-                                              type: string
-                                          type: object
-                                        type: array
-                                      topologySpreadConstraints:
-                                        items:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            maxSkew:
-                                              format: int32
-                                              type: integer
-                                            topologyKey:
-                                              type: string
-                                            whenUnsatisfiable:
-                                              type: string
-                                          required:
-                                          - maxSkew
-                                          - topologyKey
-                                          - whenUnsatisfiable
-                                          type: object
-                                        type: array
-                                      volumes:
-                                        items:
-                                          properties:
-                                            awsElasticBlockStore:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                partition:
-                                                  format: int32
-                                                  type: integer
-                                                readOnly:
-                                                  type: boolean
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            azureDisk:
-                                              properties:
-                                                cachingMode:
-                                                  type: string
-                                                diskName:
-                                                  type: string
-                                                diskURI:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                kind:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - diskName
-                                              - diskURI
-                                              type: object
-                                            azureFile:
-                                              properties:
-                                                readOnly:
-                                                  type: boolean
-                                                secretName:
-                                                  type: string
-                                                shareName:
-                                                  type: string
-                                              required:
-                                              - secretName
-                                              - shareName
-                                              type: object
-                                            cephfs:
-                                              properties:
-                                                monitors:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretFile:
-                                                  type: string
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                user:
-                                                  type: string
-                                              required:
-                                              - monitors
-                                              type: object
-                                            cinder:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            csi:
-                                              properties:
-                                                driver:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                nodePublishSecretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                readOnly:
-                                                  type: boolean
-                                                volumeAttributes:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              required:
-                                              - driver
-                                              type: object
-                                            emptyDir:
-                                              properties:
-                                                medium:
-                                                  type: string
-                                                sizeLimit:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                              type: object
-                                            fc:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                lun:
-                                                  format: int32
-                                                  type: integer
-                                                readOnly:
-                                                  type: boolean
-                                                targetWWNs:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                wwids:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              type: object
-                                            flexVolume:
-                                              properties:
-                                                driver:
-                                                  type: string
-                                                fsType:
-                                                  type: string
-                                                options:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                              required:
-                                              - driver
-                                              type: object
-                                            flocker:
-                                              properties:
-                                                datasetName:
-                                                  type: string
-                                                datasetUUID:
-                                                  type: string
-                                              type: object
-                                            gcePersistentDisk:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                partition:
-                                                  format: int32
-                                                  type: integer
-                                                pdName:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - pdName
-                                              type: object
-                                            gitRepo:
-                                              properties:
-                                                directory:
-                                                  type: string
-                                                repository:
-                                                  type: string
-                                                revision:
-                                                  type: string
-                                              required:
-                                              - repository
-                                              type: object
-                                            glusterfs:
-                                              properties:
-                                                endpoints:
-                                                  type: string
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - endpoints
-                                              - path
-                                              type: object
-                                            hostPath:
-                                              properties:
-                                                path:
-                                                  type: string
-                                                type:
-                                                  type: string
-                                              required:
-                                              - path
-                                              type: object
-                                            iscsi:
-                                              properties:
-                                                chapAuthDiscovery:
-                                                  type: boolean
-                                                chapAuthSession:
-                                                  type: boolean
-                                                fsType:
-                                                  type: string
-                                                initiatorName:
-                                                  type: string
-                                                iqn:
-                                                  type: string
-                                                iscsiInterface:
-                                                  type: string
-                                                lun:
-                                                  format: int32
-                                                  type: integer
-                                                portals:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                targetPortal:
-                                                  type: string
-                                              required:
-                                              - iqn
-                                              - lun
-                                              - targetPortal
-                                              type: object
-                                            name:
-                                              type: string
-                                            nfs:
-                                              properties:
-                                                path:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                server:
-                                                  type: string
-                                              required:
-                                              - path
-                                              - server
-                                              type: object
-                                            persistentVolumeClaim:
-                                              properties:
-                                                claimName:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                              required:
-                                              - claimName
-                                              type: object
-                                            photonPersistentDisk:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                pdID:
-                                                  type: string
-                                              required:
-                                              - pdID
-                                              type: object
-                                            portworxVolume:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                volumeID:
-                                                  type: string
-                                              required:
-                                              - volumeID
-                                              type: object
-                                            projected:
-                                              properties:
-                                                defaultMode:
-                                                  format: int32
-                                                  type: integer
-                                                sources:
-                                                  items:
-                                                    properties:
-                                                      serviceAccountToken:
-                                                        properties:
-                                                          audience:
-                                                            type: string
-                                                          expirationSeconds:
-                                                            format: int64
-                                                            type: integer
-                                                          path:
-                                                            type: string
-                                                        required:
-                                                        - path
-                                                        type: object
-                                                    type: object
-                                                  type: array
-                                              required:
-                                              - sources
-                                              type: object
-                                            quobyte:
-                                              properties:
-                                                group:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                registry:
-                                                  type: string
-                                                tenant:
-                                                  type: string
-                                                user:
-                                                  type: string
-                                                volume:
-                                                  type: string
-                                              required:
-                                              - registry
-                                              - volume
-                                              type: object
-                                            rbd:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                image:
-                                                  type: string
-                                                keyring:
-                                                  type: string
-                                                monitors:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                pool:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                user:
-                                                  type: string
-                                              required:
-                                              - image
-                                              - monitors
-                                              type: object
-                                            scaleIO:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                gateway:
-                                                  type: string
-                                                protectionDomain:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                sslEnabled:
-                                                  type: boolean
-                                                storageMode:
-                                                  type: string
-                                                storagePool:
-                                                  type: string
-                                                system:
-                                                  type: string
-                                                volumeName:
-                                                  type: string
-                                              required:
-                                              - gateway
-                                              - secretRef
-                                              - system
-                                              type: object
-                                            storageos:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                  type: object
-                                                volumeName:
-                                                  type: string
-                                                volumeNamespace:
-                                                  type: string
-                                              type: object
-                                            vsphereVolume:
-                                              properties:
-                                                fsType:
-                                                  type: string
-                                                storagePolicyID:
-                                                  type: string
-                                                storagePolicyName:
-                                                  type: string
-                                                volumePath:
-                                                  type: string
-                                              required:
-                                              - volumePath
-                                              type: object
-                                          required:
-                                          - name
-                                          type: object
-                                        type: array
-                                    required:
-                                    - containers
-                                    type: object
-                                type: object
-                              ttlSecondsAfterFinished:
-                                format: int32
-                                type: integer
-                            required:
-                            - template
-                            type: object
-                        required:
-                        - spec
-                        type: object
-                      kayenta:
-                        properties:
-                          address:
-                            type: string
-                          application:
-                            type: string
-                          canaryConfigName:
-                            type: string
-                          configurationAccountName:
-                            type: string
-                          metricsAccountName:
-                            type: string
-                          scopes:
-                            items:
-                              properties:
-                                controlScope:
-                                  properties:
-                                    end:
-                                      type: string
-                                    region:
-                                      type: string
-                                    scope:
-                                      type: string
-                                    start:
-                                      type: string
-                                    step:
-                                      type: integer
-                                  required:
-                                  - end
-                                  - region
-                                  - scope
-                                  - start
-                                  - step
-                                  type: object
-                                experimentScope:
-                                  properties:
-                                    end:
-                                      type: string
-                                    region:
-                                      type: string
-                                    scope:
-                                      type: string
-                                    start:
-                                      type: string
-                                    step:
-                                      type: integer
-                                  required:
-                                  - end
-                                  - region
-                                  - scope
-                                  - start
-                                  - step
-                                  type: object
-                                name:
-                                  type: string
-                              required:
-                              - controlScope
-                              - experimentScope
-                              - name
-                              type: object
-                            type: array
-                          storageAccountName:
-                            type: string
-                          threshold:
-                            properties:
-                              marginal:
-                                type: integer
-                              pass:
-                                type: integer
-                            required:
-                            - marginal
-                            - pass
-                            type: object
-                        required:
-                        - address
-                        - application
-                        - canaryConfigName
-                        - configurationAccountName
-                        - metricsAccountName
-                        - scopes
-                        - storageAccountName
-                        - threshold
-                        type: object
-                      newRelic:
-                        properties:
-                          profile:
-                            type: string
-                          query:
-                            type: string
-                        required:
-                        - query
-                        type: object
-                      prometheus:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
-                        type: object
-                      wavefront:
-                        properties:
-                          address:
-                            type: string
-                          query:
-                            type: string
-                        type: object
-                      web:
-                        properties:
-                          headers:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - key
-                              - value
-                              type: object
-                            type: array
-                          insecure:
-                            type: boolean
-                          jsonPath:
-                            type: string
-                          timeoutSeconds:
-                            type: integer
-                          url:
-                            type: string
-                        required:
-                        - url
-                        type: object
-                    type: object
-                  successCondition:
-                    type: string
-                required:
-                - name
-                - provider
-                type: object
-              type: array
-          required:
-          - metrics
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      format: int32
+                      type: integer
+                    count:
+                      format: int32
+                      type: integer
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      format: int32
+                      type: integer
+                    inconclusiveLimit:
+                      format: int32
+                      type: integer
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        datadog:
+                          properties:
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                completions:
+                                  format: int32
+                                  type: integer
+                                manualSelector:
+                                  type: boolean
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              ip:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                        volumes:
+                                          items:
+                                            properties:
+                                              awsElasticBlockStore:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  partition:
+                                                    format: int32
+                                                    type: integer
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              azureDisk:
+                                                properties:
+                                                  cachingMode:
+                                                    type: string
+                                                  diskName:
+                                                    type: string
+                                                  diskURI:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - diskName
+                                                - diskURI
+                                                type: object
+                                              azureFile:
+                                                properties:
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretName:
+                                                    type: string
+                                                  shareName:
+                                                    type: string
+                                                required:
+                                                - secretName
+                                                - shareName
+                                                type: object
+                                              cephfs:
+                                                properties:
+                                                  monitors:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretFile:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  user:
+                                                    type: string
+                                                required:
+                                                - monitors
+                                                type: object
+                                              cinder:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              csi:
+                                                properties:
+                                                  driver:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  nodePublishSecretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeAttributes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - driver
+                                                type: object
+                                              emptyDir:
+                                                properties:
+                                                  medium:
+                                                    type: string
+                                                  sizeLimit:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                              fc:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  lun:
+                                                    format: int32
+                                                    type: integer
+                                                  readOnly:
+                                                    type: boolean
+                                                  targetWWNs:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  wwids:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              flexVolume:
+                                                properties:
+                                                  driver:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  options:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                required:
+                                                - driver
+                                                type: object
+                                              flocker:
+                                                properties:
+                                                  datasetName:
+                                                    type: string
+                                                  datasetUUID:
+                                                    type: string
+                                                type: object
+                                              gcePersistentDisk:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  partition:
+                                                    format: int32
+                                                    type: integer
+                                                  pdName:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - pdName
+                                                type: object
+                                              gitRepo:
+                                                properties:
+                                                  directory:
+                                                    type: string
+                                                  repository:
+                                                    type: string
+                                                  revision:
+                                                    type: string
+                                                required:
+                                                - repository
+                                                type: object
+                                              glusterfs:
+                                                properties:
+                                                  endpoints:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - endpoints
+                                                - path
+                                                type: object
+                                              hostPath:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              iscsi:
+                                                properties:
+                                                  chapAuthDiscovery:
+                                                    type: boolean
+                                                  chapAuthSession:
+                                                    type: boolean
+                                                  fsType:
+                                                    type: string
+                                                  initiatorName:
+                                                    type: string
+                                                  iqn:
+                                                    type: string
+                                                  iscsiInterface:
+                                                    type: string
+                                                  lun:
+                                                    format: int32
+                                                    type: integer
+                                                  portals:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  targetPortal:
+                                                    type: string
+                                                required:
+                                                - iqn
+                                                - lun
+                                                - targetPortal
+                                                type: object
+                                              name:
+                                                type: string
+                                              nfs:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  server:
+                                                    type: string
+                                                required:
+                                                - path
+                                                - server
+                                                type: object
+                                              persistentVolumeClaim:
+                                                properties:
+                                                  claimName:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - claimName
+                                                type: object
+                                              photonPersistentDisk:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  pdID:
+                                                    type: string
+                                                required:
+                                                - pdID
+                                                type: object
+                                              portworxVolume:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              projected:
+                                                properties:
+                                                  defaultMode:
+                                                    format: int32
+                                                    type: integer
+                                                  sources:
+                                                    items:
+                                                      properties:
+                                                        serviceAccountToken:
+                                                          properties:
+                                                            audience:
+                                                              type: string
+                                                            expirationSeconds:
+                                                              format: int64
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - sources
+                                                type: object
+                                              quobyte:
+                                                properties:
+                                                  group:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  registry:
+                                                    type: string
+                                                  tenant:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                  volume:
+                                                    type: string
+                                                required:
+                                                - registry
+                                                - volume
+                                                type: object
+                                              rbd:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  image:
+                                                    type: string
+                                                  keyring:
+                                                    type: string
+                                                  monitors:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  pool:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  user:
+                                                    type: string
+                                                required:
+                                                - image
+                                                - monitors
+                                                type: object
+                                              scaleIO:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  gateway:
+                                                    type: string
+                                                  protectionDomain:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  sslEnabled:
+                                                    type: boolean
+                                                  storageMode:
+                                                    type: string
+                                                  storagePool:
+                                                    type: string
+                                                  system:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - gateway
+                                                - secretRef
+                                                - system
+                                                type: object
+                                              storageos:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  volumeName:
+                                                    type: string
+                                                  volumeNamespace:
+                                                    type: string
+                                                type: object
+                                              vsphereVolume:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  storagePolicyID:
+                                                    type: string
+                                                  storagePolicyName:
+                                                    type: string
+                                                  volumePath:
+                                                    type: string
+                                                required:
+                                                - volumePath
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  type: integer
+                                pass:
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonPath:
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+            required:
+            - metrics
+            type: object
+        required:
+        - spec
+        type: object
 {{- end }}

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -6,11 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.0
   name: experiments.argoproj.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Experiment status
-    name: Status
-    type: string
   group: argoproj.io
   names:
     kind: Experiment
@@ -20,2665 +15,2669 @@ spec:
     - exp
     singular: experiment
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            analyses:
-              items:
-                properties:
-                  args:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        value:
-                          type: string
-                        valueFrom:
-                          properties:
-                            fieldRef:
-                              properties:
-                                fieldPath:
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            secretKeyRef:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  clusterScope:
-                    type: boolean
-                  name:
-                    type: string
-                  requiredForCompletion:
-                    type: boolean
-                  templateName:
-                    type: string
-                required:
-                - name
-                - templateName
-                type: object
-              type: array
-            duration:
-              type: string
-            progressDeadlineSeconds:
-              format: int32
-              type: integer
-            templates:
-              items:
-                properties:
-                  minReadySeconds:
-                    format: int32
-                    type: integer
-                  name:
-                    type: string
-                  replicas:
-                    format: int32
-                    type: integer
-                  selector:
-                    properties:
-                      matchExpressions:
-                        items:
-                          properties:
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            values:
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  template:
-                    properties:
-                      metadata:
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      spec:
-                        properties:
-                          activeDeadlineSeconds:
-                            format: int64
-                            type: integer
-                          affinity:
-                            properties:
-                              nodeAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        preference:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - preference
-                                      - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    properties:
-                                      nodeSelectorTerms:
-                                        items:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        type: array
-                                    required:
-                                    - nodeSelectorTerms
-                                    type: object
-                                type: object
-                              podAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        podAffinityTerm:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              type: string
-                                          required:
-                                          - topologyKey
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - podAffinityTerm
-                                      - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                              podAntiAffinity:
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        podAffinityTerm:
-                                          properties:
-                                            labelSelector:
-                                              properties:
-                                                matchExpressions:
-                                                  items:
-                                                    properties:
-                                                      key:
-                                                        type: string
-                                                      operator:
-                                                        type: string
-                                                      values:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              type: string
-                                          required:
-                                          - topologyKey
-                                          type: object
-                                        weight:
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - podAffinityTerm
-                                      - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    items:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                            type: object
-                          automountServiceAccountToken:
-                            type: boolean
-                          containers:
-                            items:
-                              properties:
-                                args:
-                                  items:
-                                    type: string
-                                  type: array
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                      valueFrom:
-                                        properties:
-                                          configMapKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                          secretKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                        type: object
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
-                                envFrom:
-                                  items:
-                                    properties:
-                                      configMapRef:
-                                        properties:
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      prefix:
-                                        type: string
-                                      secretRef:
-                                        properties:
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                    type: object
-                                  type: array
-                                image:
-                                  type: string
-                                imagePullPolicy:
-                                  type: string
-                                lifecycle:
-                                  properties:
-                                    postStart:
-                                      properties:
-                                        exec:
-                                          properties:
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          properties:
-                                            host:
-                                              type: string
-                                            httpHeaders:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          properties:
-                                            host:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                    preStop:
-                                      properties:
-                                        exec:
-                                          properties:
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          properties:
-                                            host:
-                                              type: string
-                                            httpHeaders:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          properties:
-                                            host:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                  type: object
-                                livenessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  type: string
-                                ports:
-                                  items:
-                                    properties:
-                                      containerPort:
-                                        format: int32
-                                        type: integer
-                                      hostIP:
-                                        type: string
-                                      hostPort:
-                                        format: int32
-                                        type: integer
-                                      name:
-                                        type: string
-                                      protocol:
-                                        type: string
-                                    required:
-                                    - containerPort
-                                    type: object
-                                  type: array
-                                readinessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  type: object
-                                securityContext:
-                                  properties:
-                                    allowPrivilegeEscalation:
-                                      type: boolean
-                                    capabilities:
-                                      properties:
-                                        add:
-                                          items:
-                                            type: string
-                                          type: array
-                                        drop:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    privileged:
-                                      type: boolean
-                                    procMount:
-                                      type: string
-                                    readOnlyRootFilesystem:
-                                      type: boolean
-                                    runAsGroup:
-                                      format: int64
-                                      type: integer
-                                    runAsNonRoot:
-                                      type: boolean
-                                    runAsUser:
-                                      format: int64
-                                      type: integer
-                                    seLinuxOptions:
-                                      properties:
-                                        level:
-                                          type: string
-                                        role:
-                                          type: string
-                                        type:
-                                          type: string
-                                        user:
-                                          type: string
-                                      type: object
-                                    windowsOptions:
-                                      properties:
-                                        gmsaCredentialSpec:
-                                          type: string
-                                        gmsaCredentialSpecName:
-                                          type: string
-                                        runAsUserName:
-                                          type: string
-                                      type: object
-                                  type: object
-                                startupProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                stdin:
-                                  type: boolean
-                                stdinOnce:
-                                  type: boolean
-                                terminationMessagePath:
-                                  type: string
-                                terminationMessagePolicy:
-                                  type: string
-                                tty:
-                                  type: boolean
-                                volumeDevices:
-                                  items:
-                                    properties:
-                                      devicePath:
-                                        type: string
-                                      name:
-                                        type: string
-                                    required:
-                                    - devicePath
-                                    - name
-                                    type: object
-                                  type: array
-                                volumeMounts:
-                                  items:
-                                    properties:
-                                      mountPath:
-                                        type: string
-                                      mountPropagation:
-                                        type: string
-                                      name:
-                                        type: string
-                                      readOnly:
-                                        type: boolean
-                                      subPath:
-                                        type: string
-                                      subPathExpr:
-                                        type: string
-                                    required:
-                                    - mountPath
-                                    - name
-                                    type: object
-                                  type: array
-                                workingDir:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          dnsConfig:
-                            properties:
-                              nameservers:
-                                items:
-                                  type: string
-                                type: array
-                              options:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  type: object
-                                type: array
-                              searches:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          dnsPolicy:
-                            type: string
-                          enableServiceLinks:
-                            type: boolean
-                          ephemeralContainers:
-                            items:
-                              properties:
-                                args:
-                                  items:
-                                    type: string
-                                  type: array
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                      valueFrom:
-                                        properties:
-                                          configMapKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                          secretKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                        type: object
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
-                                envFrom:
-                                  items:
-                                    properties:
-                                      configMapRef:
-                                        properties:
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      prefix:
-                                        type: string
-                                      secretRef:
-                                        properties:
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                    type: object
-                                  type: array
-                                image:
-                                  type: string
-                                imagePullPolicy:
-                                  type: string
-                                lifecycle:
-                                  properties:
-                                    postStart:
-                                      properties:
-                                        exec:
-                                          properties:
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          properties:
-                                            host:
-                                              type: string
-                                            httpHeaders:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          properties:
-                                            host:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                    preStop:
-                                      properties:
-                                        exec:
-                                          properties:
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          properties:
-                                            host:
-                                              type: string
-                                            httpHeaders:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          properties:
-                                            host:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                  type: object
-                                livenessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  type: string
-                                ports:
-                                  items:
-                                    properties:
-                                      containerPort:
-                                        format: int32
-                                        type: integer
-                                      hostIP:
-                                        type: string
-                                      hostPort:
-                                        format: int32
-                                        type: integer
-                                      name:
-                                        type: string
-                                      protocol:
-                                        type: string
-                                    required:
-                                    - containerPort
-                                    type: object
-                                  type: array
-                                readinessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  type: object
-                                securityContext:
-                                  properties:
-                                    allowPrivilegeEscalation:
-                                      type: boolean
-                                    capabilities:
-                                      properties:
-                                        add:
-                                          items:
-                                            type: string
-                                          type: array
-                                        drop:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    privileged:
-                                      type: boolean
-                                    procMount:
-                                      type: string
-                                    readOnlyRootFilesystem:
-                                      type: boolean
-                                    runAsGroup:
-                                      format: int64
-                                      type: integer
-                                    runAsNonRoot:
-                                      type: boolean
-                                    runAsUser:
-                                      format: int64
-                                      type: integer
-                                    seLinuxOptions:
-                                      properties:
-                                        level:
-                                          type: string
-                                        role:
-                                          type: string
-                                        type:
-                                          type: string
-                                        user:
-                                          type: string
-                                      type: object
-                                    windowsOptions:
-                                      properties:
-                                        gmsaCredentialSpec:
-                                          type: string
-                                        gmsaCredentialSpecName:
-                                          type: string
-                                        runAsUserName:
-                                          type: string
-                                      type: object
-                                  type: object
-                                startupProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                stdin:
-                                  type: boolean
-                                stdinOnce:
-                                  type: boolean
-                                targetContainerName:
-                                  type: string
-                                terminationMessagePath:
-                                  type: string
-                                terminationMessagePolicy:
-                                  type: string
-                                tty:
-                                  type: boolean
-                                volumeDevices:
-                                  items:
-                                    properties:
-                                      devicePath:
-                                        type: string
-                                      name:
-                                        type: string
-                                    required:
-                                    - devicePath
-                                    - name
-                                    type: object
-                                  type: array
-                                volumeMounts:
-                                  items:
-                                    properties:
-                                      mountPath:
-                                        type: string
-                                      mountPropagation:
-                                        type: string
-                                      name:
-                                        type: string
-                                      readOnly:
-                                        type: boolean
-                                      subPath:
-                                        type: string
-                                      subPathExpr:
-                                        type: string
-                                    required:
-                                    - mountPath
-                                    - name
-                                    type: object
-                                  type: array
-                                workingDir:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          hostAliases:
-                            items:
-                              properties:
-                                hostnames:
-                                  items:
-                                    type: string
-                                  type: array
-                                ip:
-                                  type: string
-                              type: object
-                            type: array
-                          hostIPC:
-                            type: boolean
-                          hostNetwork:
-                            type: boolean
-                          hostPID:
-                            type: boolean
-                          hostname:
-                            type: string
-                          imagePullSecrets:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            type: array
-                          initContainers:
-                            items:
-                              properties:
-                                args:
-                                  items:
-                                    type: string
-                                  type: array
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                      valueFrom:
-                                        properties:
-                                          configMapKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                          secretKeyRef:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                        type: object
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
-                                envFrom:
-                                  items:
-                                    properties:
-                                      configMapRef:
-                                        properties:
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      prefix:
-                                        type: string
-                                      secretRef:
-                                        properties:
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                    type: object
-                                  type: array
-                                image:
-                                  type: string
-                                imagePullPolicy:
-                                  type: string
-                                lifecycle:
-                                  properties:
-                                    postStart:
-                                      properties:
-                                        exec:
-                                          properties:
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          properties:
-                                            host:
-                                              type: string
-                                            httpHeaders:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          properties:
-                                            host:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                    preStop:
-                                      properties:
-                                        exec:
-                                          properties:
-                                            command:
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          properties:
-                                            host:
-                                              type: string
-                                            httpHeaders:
-                                              items:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                  value:
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          properties:
-                                            host:
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                  type: object
-                                livenessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  type: string
-                                ports:
-                                  items:
-                                    properties:
-                                      containerPort:
-                                        format: int32
-                                        type: integer
-                                      hostIP:
-                                        type: string
-                                      hostPort:
-                                        format: int32
-                                        type: integer
-                                      name:
-                                        type: string
-                                      protocol:
-                                        type: string
-                                    required:
-                                    - containerPort
-                                    type: object
-                                  type: array
-                                readinessProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  type: object
-                                securityContext:
-                                  properties:
-                                    allowPrivilegeEscalation:
-                                      type: boolean
-                                    capabilities:
-                                      properties:
-                                        add:
-                                          items:
-                                            type: string
-                                          type: array
-                                        drop:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    privileged:
-                                      type: boolean
-                                    procMount:
-                                      type: string
-                                    readOnlyRootFilesystem:
-                                      type: boolean
-                                    runAsGroup:
-                                      format: int64
-                                      type: integer
-                                    runAsNonRoot:
-                                      type: boolean
-                                    runAsUser:
-                                      format: int64
-                                      type: integer
-                                    seLinuxOptions:
-                                      properties:
-                                        level:
-                                          type: string
-                                        role:
-                                          type: string
-                                        type:
-                                          type: string
-                                        user:
-                                          type: string
-                                      type: object
-                                    windowsOptions:
-                                      properties:
-                                        gmsaCredentialSpec:
-                                          type: string
-                                        gmsaCredentialSpecName:
-                                          type: string
-                                        runAsUserName:
-                                          type: string
-                                      type: object
-                                  type: object
-                                startupProbe:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                stdin:
-                                  type: boolean
-                                stdinOnce:
-                                  type: boolean
-                                terminationMessagePath:
-                                  type: string
-                                terminationMessagePolicy:
-                                  type: string
-                                tty:
-                                  type: boolean
-                                volumeDevices:
-                                  items:
-                                    properties:
-                                      devicePath:
-                                        type: string
-                                      name:
-                                        type: string
-                                    required:
-                                    - devicePath
-                                    - name
-                                    type: object
-                                  type: array
-                                volumeMounts:
-                                  items:
-                                    properties:
-                                      mountPath:
-                                        type: string
-                                      mountPropagation:
-                                        type: string
-                                      name:
-                                        type: string
-                                      readOnly:
-                                        type: boolean
-                                      subPath:
-                                        type: string
-                                      subPathExpr:
-                                        type: string
-                                    required:
-                                    - mountPath
-                                    - name
-                                    type: object
-                                  type: array
-                                workingDir:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          nodeName:
-                            type: string
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          overhead:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          preemptionPolicy:
-                            type: string
-                          priority:
-                            format: int32
-                            type: integer
-                          priorityClassName:
-                            type: string
-                          readinessGates:
-                            items:
-                              properties:
-                                conditionType:
-                                  type: string
-                              required:
-                              - conditionType
-                              type: object
-                            type: array
-                          restartPolicy:
-                            type: string
-                          runtimeClassName:
-                            type: string
-                          schedulerName:
-                            type: string
-                          securityContext:
-                            properties:
-                              fsGroup:
-                                format: int64
-                                type: integer
-                              fsGroupChangePolicy:
-                                type: string
-                              runAsGroup:
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                type: boolean
-                              runAsUser:
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                properties:
-                                  level:
-                                    type: string
-                                  role:
-                                    type: string
-                                  type:
-                                    type: string
-                                  user:
-                                    type: string
-                                type: object
-                              supplementalGroups:
-                                items:
-                                  format: int64
-                                  type: integer
-                                type: array
-                              sysctls:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              windowsOptions:
-                                properties:
-                                  gmsaCredentialSpec:
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    type: string
-                                  runAsUserName:
-                                    type: string
-                                type: object
-                            type: object
-                          serviceAccount:
-                            type: string
-                          serviceAccountName:
-                            type: string
-                          shareProcessNamespace:
-                            type: boolean
-                          subdomain:
-                            type: string
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          tolerations:
-                            items:
-                              properties:
-                                effect:
-                                  type: string
-                                key:
-                                  type: string
-                                operator:
-                                  type: string
-                                tolerationSeconds:
-                                  format: int64
-                                  type: integer
-                                value:
-                                  type: string
-                              type: object
-                            type: array
-                          topologySpreadConstraints:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                maxSkew:
-                                  format: int32
-                                  type: integer
-                                topologyKey:
-                                  type: string
-                                whenUnsatisfiable:
-                                  type: string
-                              required:
-                              - maxSkew
-                              - topologyKey
-                              - whenUnsatisfiable
-                              type: object
-                            type: array
-                          volumes:
-                            items:
-                              properties:
-                                awsElasticBlockStore:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    partition:
-                                      format: int32
-                                      type: integer
-                                    readOnly:
-                                      type: boolean
-                                    volumeID:
-                                      type: string
-                                  required:
-                                  - volumeID
-                                  type: object
-                                azureDisk:
-                                  properties:
-                                    cachingMode:
-                                      type: string
-                                    diskName:
-                                      type: string
-                                    diskURI:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                  - diskName
-                                  - diskURI
-                                  type: object
-                                azureFile:
-                                  properties:
-                                    readOnly:
-                                      type: boolean
-                                    secretName:
-                                      type: string
-                                    shareName:
-                                      type: string
-                                  required:
-                                  - secretName
-                                  - shareName
-                                  type: object
-                                cephfs:
-                                  properties:
-                                    monitors:
-                                      items:
-                                        type: string
-                                      type: array
-                                    path:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretFile:
-                                      type: string
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    user:
-                                      type: string
-                                  required:
-                                  - monitors
-                                  type: object
-                                cinder:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    volumeID:
-                                      type: string
-                                  required:
-                                  - volumeID
-                                  type: object
-                                csi:
-                                  properties:
-                                    driver:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    nodePublishSecretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    readOnly:
-                                      type: boolean
-                                    volumeAttributes:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  required:
-                                  - driver
-                                  type: object
-                                emptyDir:
-                                  properties:
-                                    medium:
-                                      type: string
-                                    sizeLimit:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                  type: object
-                                fc:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    lun:
-                                      format: int32
-                                      type: integer
-                                    readOnly:
-                                      type: boolean
-                                    targetWWNs:
-                                      items:
-                                        type: string
-                                      type: array
-                                    wwids:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                flexVolume:
-                                  properties:
-                                    driver:
-                                      type: string
-                                    fsType:
-                                      type: string
-                                    options:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                  required:
-                                  - driver
-                                  type: object
-                                flocker:
-                                  properties:
-                                    datasetName:
-                                      type: string
-                                    datasetUUID:
-                                      type: string
-                                  type: object
-                                gcePersistentDisk:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    partition:
-                                      format: int32
-                                      type: integer
-                                    pdName:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                  - pdName
-                                  type: object
-                                gitRepo:
-                                  properties:
-                                    directory:
-                                      type: string
-                                    repository:
-                                      type: string
-                                    revision:
-                                      type: string
-                                  required:
-                                  - repository
-                                  type: object
-                                glusterfs:
-                                  properties:
-                                    endpoints:
-                                      type: string
-                                    path:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                  - endpoints
-                                  - path
-                                  type: object
-                                hostPath:
-                                  properties:
-                                    path:
-                                      type: string
-                                    type:
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                                iscsi:
-                                  properties:
-                                    chapAuthDiscovery:
-                                      type: boolean
-                                    chapAuthSession:
-                                      type: boolean
-                                    fsType:
-                                      type: string
-                                    initiatorName:
-                                      type: string
-                                    iqn:
-                                      type: string
-                                    iscsiInterface:
-                                      type: string
-                                    lun:
-                                      format: int32
-                                      type: integer
-                                    portals:
-                                      items:
-                                        type: string
-                                      type: array
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    targetPortal:
-                                      type: string
-                                  required:
-                                  - iqn
-                                  - lun
-                                  - targetPortal
-                                  type: object
-                                name:
-                                  type: string
-                                nfs:
-                                  properties:
-                                    path:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    server:
-                                      type: string
-                                  required:
-                                  - path
-                                  - server
-                                  type: object
-                                persistentVolumeClaim:
-                                  properties:
-                                    claimName:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                  required:
-                                  - claimName
-                                  type: object
-                                photonPersistentDisk:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    pdID:
-                                      type: string
-                                  required:
-                                  - pdID
-                                  type: object
-                                portworxVolume:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    volumeID:
-                                      type: string
-                                  required:
-                                  - volumeID
-                                  type: object
-                                projected:
-                                  properties:
-                                    defaultMode:
-                                      format: int32
-                                      type: integer
-                                    sources:
-                                      items:
-                                        properties:
-                                          serviceAccountToken:
-                                            properties:
-                                              audience:
-                                                type: string
-                                              expirationSeconds:
-                                                format: int64
-                                                type: integer
-                                              path:
-                                                type: string
-                                            required:
-                                            - path
-                                            type: object
-                                        type: object
-                                      type: array
-                                  required:
-                                  - sources
-                                  type: object
-                                quobyte:
-                                  properties:
-                                    group:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    registry:
-                                      type: string
-                                    tenant:
-                                      type: string
-                                    user:
-                                      type: string
-                                    volume:
-                                      type: string
-                                  required:
-                                  - registry
-                                  - volume
-                                  type: object
-                                rbd:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    image:
-                                      type: string
-                                    keyring:
-                                      type: string
-                                    monitors:
-                                      items:
-                                        type: string
-                                      type: array
-                                    pool:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    user:
-                                      type: string
-                                  required:
-                                  - image
-                                  - monitors
-                                  type: object
-                                scaleIO:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    gateway:
-                                      type: string
-                                    protectionDomain:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    sslEnabled:
-                                      type: boolean
-                                    storageMode:
-                                      type: string
-                                    storagePool:
-                                      type: string
-                                    system:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  required:
-                                  - gateway
-                                  - secretRef
-                                  - system
-                                  type: object
-                                storageos:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    readOnly:
-                                      type: boolean
-                                    secretRef:
-                                      properties:
-                                        name:
-                                          type: string
-                                      type: object
-                                    volumeName:
-                                      type: string
-                                    volumeNamespace:
-                                      type: string
-                                  type: object
-                                vsphereVolume:
-                                  properties:
-                                    fsType:
-                                      type: string
-                                    storagePolicyID:
-                                      type: string
-                                    storagePolicyName:
-                                      type: string
-                                    volumePath:
-                                      type: string
-                                  required:
-                                  - volumePath
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                        required:
-                        - containers
-                        type: object
-                    type: object
-                required:
-                - name
-                - selector
-                - template
-                type: object
-              type: array
-            terminate:
-              type: boolean
-          required:
-          - templates
-          type: object
-        status:
-          properties:
-            analysisRuns:
-              items:
-                properties:
-                  analysisRun:
-                    type: string
-                  message:
-                    type: string
-                  name:
-                    type: string
-                  phase:
-                    type: string
-                required:
-                - analysisRun
-                - name
-                - phase
-                type: object
-              type: array
-            availableAt:
-              format: date-time
-              type: string
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - lastTransitionTime
-                - lastUpdateTime
-                - message
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-            message:
-              type: string
-            phase:
-              type: string
-            templateStatuses:
-              items:
-                properties:
-                  availableReplicas:
-                    format: int32
-                    type: integer
-                  collisionCount:
-                    format: int32
-                    type: integer
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  name:
-                    type: string
-                  readyReplicas:
-                    format: int32
-                    type: integer
-                  replicas:
-                    format: int32
-                    type: integer
-                  status:
-                    type: string
-                  updatedReplicas:
-                    format: int32
-                    type: integer
-                required:
-                - availableReplicas
-                - name
-                - readyReplicas
-                - replicas
-                - updatedReplicas
-                type: object
-              type: array
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.phase
+      description: Experiment status
+      name: Status
+      type: string
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              analyses:
+                items:
+                  properties:
+                    args:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              fieldRef:
+                                properties:
+                                  fieldPath:
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    clusterScope:
+                      type: boolean
+                    name:
+                      type: string
+                    requiredForCompletion:
+                      type: boolean
+                    templateName:
+                      type: string
+                  required:
+                  - name
+                  - templateName
+                  type: object
+                type: array
+              duration:
+                type: string
+              progressDeadlineSeconds:
+                format: int32
+                type: integer
+              templates:
+                items:
+                  properties:
+                    minReadySeconds:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    replicas:
+                      format: int32
+                      type: integer
+                    selector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    template:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          properties:
+                            activeDeadlineSeconds:
+                              format: int64
+                              type: integer
+                            affinity:
+                              properties:
+                                nodeAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          preference:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      properties:
+                                        nodeSelectorTerms:
+                                          items:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              type: boolean
+                            containers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            dnsConfig:
+                              properties:
+                                nameservers:
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              type: string
+                            enableServiceLinks:
+                              type: boolean
+                            ephemeralContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  targetContainerName:
+                                    type: string
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            hostAliases:
+                              items:
+                                properties:
+                                  hostnames:
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              type: boolean
+                            hostNetwork:
+                              type: boolean
+                            hostPID:
+                              type: boolean
+                            hostname:
+                              type: string
+                            imagePullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            initContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    type: object
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            nodeName:
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            preemptionPolicy:
+                              type: string
+                            priority:
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              type: string
+                            readinessGates:
+                              items:
+                                properties:
+                                  conditionType:
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            restartPolicy:
+                              type: string
+                            runtimeClassName:
+                              type: string
+                            schedulerName:
+                              type: string
+                            securityContext:
+                              properties:
+                                fsGroup:
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  type: string
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                supplementalGroups:
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              type: string
+                            serviceAccountName:
+                              type: string
+                            shareProcessNamespace:
+                              type: boolean
+                            subdomain:
+                              type: string
+                            terminationGracePeriodSeconds:
+                              format: int64
+                              type: integer
+                            tolerations:
+                              items:
+                                properties:
+                                  effect:
+                                    type: string
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  tolerationSeconds:
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  maxSkew:
+                                    format: int32
+                                    type: integer
+                                  topologyKey:
+                                    type: string
+                                  whenUnsatisfiable:
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                            volumes:
+                              items:
+                                properties:
+                                  awsElasticBlockStore:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      partition:
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        type: boolean
+                                      volumeID:
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  azureDisk:
+                                    properties:
+                                      cachingMode:
+                                        type: string
+                                      diskName:
+                                        type: string
+                                      diskURI:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    required:
+                                    - diskName
+                                    - diskURI
+                                    type: object
+                                  azureFile:
+                                    properties:
+                                      readOnly:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                      shareName:
+                                        type: string
+                                    required:
+                                    - secretName
+                                    - shareName
+                                    type: object
+                                  cephfs:
+                                    properties:
+                                      monitors:
+                                        items:
+                                          type: string
+                                        type: array
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretFile:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      user:
+                                        type: string
+                                    required:
+                                    - monitors
+                                    type: object
+                                  cinder:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      volumeID:
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  csi:
+                                    properties:
+                                      driver:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      nodePublishSecretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      readOnly:
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  emptyDir:
+                                    properties:
+                                      medium:
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  fc:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      lun:
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        type: boolean
+                                      targetWWNs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      wwids:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  flexVolume:
+                                    properties:
+                                      driver:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  flocker:
+                                    properties:
+                                      datasetName:
+                                        type: string
+                                      datasetUUID:
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      partition:
+                                        format: int32
+                                        type: integer
+                                      pdName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    required:
+                                    - pdName
+                                    type: object
+                                  gitRepo:
+                                    properties:
+                                      directory:
+                                        type: string
+                                      repository:
+                                        type: string
+                                      revision:
+                                        type: string
+                                    required:
+                                    - repository
+                                    type: object
+                                  glusterfs:
+                                    properties:
+                                      endpoints:
+                                        type: string
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    required:
+                                    - endpoints
+                                    - path
+                                    type: object
+                                  hostPath:
+                                    properties:
+                                      path:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  iscsi:
+                                    properties:
+                                      chapAuthDiscovery:
+                                        type: boolean
+                                      chapAuthSession:
+                                        type: boolean
+                                      fsType:
+                                        type: string
+                                      initiatorName:
+                                        type: string
+                                      iqn:
+                                        type: string
+                                      iscsiInterface:
+                                        type: string
+                                      lun:
+                                        format: int32
+                                        type: integer
+                                      portals:
+                                        items:
+                                          type: string
+                                        type: array
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      targetPortal:
+                                        type: string
+                                    required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                    type: object
+                                  name:
+                                    type: string
+                                  nfs:
+                                    properties:
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      server:
+                                        type: string
+                                    required:
+                                    - path
+                                    - server
+                                    type: object
+                                  persistentVolumeClaim:
+                                    properties:
+                                      claimName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  photonPersistentDisk:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      pdID:
+                                        type: string
+                                    required:
+                                    - pdID
+                                    type: object
+                                  portworxVolume:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      volumeID:
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  projected:
+                                    properties:
+                                      defaultMode:
+                                        format: int32
+                                        type: integer
+                                      sources:
+                                        items:
+                                          properties:
+                                            serviceAccountToken:
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  format: int64
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                          type: object
+                                        type: array
+                                    required:
+                                    - sources
+                                    type: object
+                                  quobyte:
+                                    properties:
+                                      group:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      registry:
+                                        type: string
+                                      tenant:
+                                        type: string
+                                      user:
+                                        type: string
+                                      volume:
+                                        type: string
+                                    required:
+                                    - registry
+                                    - volume
+                                    type: object
+                                  rbd:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      image:
+                                        type: string
+                                      keyring:
+                                        type: string
+                                      monitors:
+                                        items:
+                                          type: string
+                                        type: array
+                                      pool:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      user:
+                                        type: string
+                                    required:
+                                    - image
+                                    - monitors
+                                    type: object
+                                  scaleIO:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      gateway:
+                                        type: string
+                                      protectionDomain:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      sslEnabled:
+                                        type: boolean
+                                      storageMode:
+                                        type: string
+                                      storagePool:
+                                        type: string
+                                      system:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                    type: object
+                                  storageos:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      volumeName:
+                                        type: string
+                                      volumeNamespace:
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      storagePolicyID:
+                                        type: string
+                                      storagePolicyName:
+                                        type: string
+                                      volumePath:
+                                        type: string
+                                    required:
+                                    - volumePath
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - selector
+                  - template
+                  type: object
+                type: array
+              terminate:
+                type: boolean
+            required:
+            - templates
+            type: object
+          status:
+            properties:
+              analysisRuns:
+                items:
+                  properties:
+                    analysisRun:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                  required:
+                  - analysisRun
+                  - name
+                  - phase
+                  type: object
+                type: array
+              availableAt:
+                format: date-time
+                type: string
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              phase:
+                type: string
+              templateStatuses:
+                items:
+                  properties:
+                    availableReplicas:
+                      format: int32
+                      type: integer
+                    collisionCount:
+                      format: int32
+                      type: integer
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    readyReplicas:
+                      format: int32
+                      type: integer
+                    replicas:
+                      format: int32
+                      type: integer
+                    status:
+                      type: string
+                    updatedReplicas:
+                      format: int32
+                      type: integer
+                  required:
+                  - availableReplicas
+                  - name
+                  - readyReplicas
+                  - replicas
+                  - updatedReplicas
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
 {{- end }}

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -6,23 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.4.0
   name: rollouts.argoproj.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.replicas
-    description: Number of desired pods
-    name: Desired
-    type: integer
-  - JSONPath: .status.replicas
-    description: Total number of non-terminated pods targeted by this rollout
-    name: Current
-    type: integer
-  - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
-    name: Up-to-date
-    type: integer
-  - JSONPath: .status.availableReplicas
-    description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
-    name: Available
-    type: integer
   group: argoproj.io
   names:
     kind: Rollout
@@ -32,377 +15,673 @@ spec:
     - ro
     singular: rollout
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.HPAReplicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            minReadySeconds:
-              format: int32
-              type: integer
-            paused:
-              type: boolean
-            progressDeadlineSeconds:
-              format: int32
-              type: integer
-            replicas:
-              format: int32
-              type: integer
-            restartAt:
-              format: date-time
-              type: string
-            revisionHistoryLimit:
-              format: int32
-              type: integer
-            selector:
-              properties:
-                matchExpressions:
-                  items:
-                    properties:
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      values:
-                        items:
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      description: Number of desired pods
+      name: Desired
+      type: integer
+    - jsonPath: .status.replicas
+      description: Total number of non-terminated pods targeted by this rollout
+      name: Current
+      type: integer
+    - jsonPath: .status.updatedReplicas
+      description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
+      name: Up-to-date
+      type: integer
+    - jsonPath: .status.availableReplicas
+      description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
+      name: Available
+      type: integer
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.HPAReplicas
+      status: {}
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              minReadySeconds:
+                format: int32
+                type: integer
+              paused:
+                type: boolean
+              progressDeadlineSeconds:
+                format: int32
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              restartAt:
+                format: date-time
+                type: string
+              revisionHistoryLimit:
+                format: int32
+                type: integer
+              selector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
                           type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
                     type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-              type: object
-            strategy:
-              properties:
-                blueGreen:
-                  properties:
-                    activeService:
-                      type: string
-                    antiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - weight
-                          type: object
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          type: object
-                      type: object
-                    autoPromotionEnabled:
-                      type: boolean
-                    autoPromotionSeconds:
-                      format: int32
-                      type: integer
-                    postPromotionAnalysis:
-                      properties:
-                        args:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                              valueFrom:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  podTemplateHashValue:
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        clusterScope:
-                          type: boolean
-                        templateName:
-                          type: string
-                        templates:
-                          items:
-                            properties:
-                              clusterScope:
-                                type: boolean
-                              templateName:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    prePromotionAnalysis:
-                      properties:
-                        args:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                              valueFrom:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  podTemplateHashValue:
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        clusterScope:
-                          type: boolean
-                        templateName:
-                          type: string
-                        templates:
-                          items:
-                            properties:
-                              clusterScope:
-                                type: boolean
-                              templateName:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    previewReplicaCount:
-                      format: int32
-                      type: integer
-                    previewService:
-                      type: string
-                    scaleDownDelayRevisionLimit:
-                      format: int32
-                      type: integer
-                    scaleDownDelaySeconds:
-                      format: int32
-                      type: integer
-                  required:
-                  - activeService
-                  type: object
-                canary:
-                  properties:
-                    analysis:
-                      properties:
-                        args:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                              valueFrom:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  podTemplateHashValue:
-                                    type: string
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        clusterScope:
-                          type: boolean
-                        startingStep:
-                          format: int32
-                          type: integer
-                        templateName:
-                          type: string
-                        templates:
-                          items:
-                            properties:
-                              clusterScope:
-                                type: boolean
-                              templateName:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    antiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - weight
-                          type: object
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          type: object
-                      type: object
-                    canaryMetadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    canaryService:
-                      type: string
-                    maxSurge:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    maxUnavailable:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    stableMetadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    stableService:
-                      type: string
-                    steps:
-                      items:
+                type: object
+              strategy:
+                properties:
+                  blueGreen:
+                    properties:
+                      activeService:
+                        type: string
+                      antiAffinity:
                         properties:
-                          analysis:
+                          preferredDuringSchedulingIgnoredDuringExecution:
                             properties:
-                              args:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                    valueFrom:
-                                      properties:
-                                        fieldRef:
-                                          properties:
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        podTemplateHashValue:
-                                          type: string
-                                      type: object
-                                  required:
-                                  - name
-                                  type: object
-                                type: array
-                              clusterScope:
-                                type: boolean
-                              templateName:
-                                type: string
-                              templates:
-                                items:
-                                  properties:
-                                    clusterScope:
-                                      type: boolean
-                                    templateName:
-                                      type: string
-                                  type: object
-                                type: array
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
                             type: object
-                          experiment:
-                            properties:
-                              analyses:
-                                items:
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                        type: object
+                      autoPromotionEnabled:
+                        type: boolean
+                      autoPromotionSeconds:
+                        format: int32
+                        type: integer
+                      postPromotionAnalysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
                                   properties:
-                                    args:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                          valueFrom:
-                                            properties:
-                                              fieldRef:
-                                                properties:
-                                                  fieldPath:
-                                                    type: string
-                                                required:
-                                                - fieldPath
-                                                type: object
-                                              podTemplateHashValue:
-                                                type: string
-                                            type: object
-                                        required:
-                                        - name
-                                        type: object
-                                      type: array
-                                    clusterScope:
-                                      type: boolean
-                                    name:
-                                      type: string
-                                    requiredForCompletion:
-                                      type: boolean
-                                    templateName:
-                                      type: string
-                                  required:
-                                  - name
-                                  - templateName
-                                  type: object
-                                type: array
-                              duration:
-                                type: string
-                              templates:
-                                items:
-                                  properties:
-                                    metadata:
+                                    fieldRef:
                                       properties:
-                                        annotations:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                        labels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
                                       type: object
-                                    name:
+                                    podTemplateHashValue:
                                       type: string
-                                    replicas:
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          clusterScope:
+                            type: boolean
+                          templateName:
+                            type: string
+                          templates:
+                            items:
+                              properties:
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      prePromotionAnalysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    podTemplateHashValue:
+                                      type: string
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          clusterScope:
+                            type: boolean
+                          templateName:
+                            type: string
+                          templates:
+                            items:
+                              properties:
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      previewReplicaCount:
+                        format: int32
+                        type: integer
+                      previewService:
+                        type: string
+                      scaleDownDelayRevisionLimit:
+                        format: int32
+                        type: integer
+                      scaleDownDelaySeconds:
+                        format: int32
+                        type: integer
+                    required:
+                    - activeService
+                    type: object
+                  canary:
+                    properties:
+                      analysis:
+                        properties:
+                          args:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    podTemplateHashValue:
+                                      type: string
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          clusterScope:
+                            type: boolean
+                          startingStep:
+                            format: int32
+                            type: integer
+                          templateName:
+                            type: string
+                          templates:
+                            items:
+                              properties:
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      antiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
+                            type: object
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                        type: object
+                      canaryMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      canaryService:
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      stableMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      stableService:
+                        type: string
+                      steps:
+                        items:
+                          properties:
+                            analysis:
+                              properties:
+                                args:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          podTemplateHashValue:
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                clusterScope:
+                                  type: boolean
+                                templateName:
+                                  type: string
+                                templates:
+                                  items:
+                                    properties:
+                                      clusterScope:
+                                        type: boolean
+                                      templateName:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            experiment:
+                              properties:
+                                analyses:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                podTemplateHashValue:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      clusterScope:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      requiredForCompletion:
+                                        type: boolean
+                                      templateName:
+                                        type: string
+                                    required:
+                                    - name
+                                    - templateName
+                                    type: object
+                                  type: array
+                                duration:
+                                  type: string
+                                templates:
+                                  items:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      name:
+                                        type: string
+                                      replicas:
+                                        format: int32
+                                        type: integer
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      specRef:
+                                        type: string
+                                    required:
+                                    - name
+                                    - specRef
+                                    type: object
+                                  type: array
+                              required:
+                              - templates
+                              type: object
+                            pause:
+                              properties:
+                                duration:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            setCanaryScale:
+                              properties:
+                                matchTrafficWeight:
+                                  type: boolean
+                                replicas:
+                                  format: int32
+                                  type: integer
+                                weight:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            setWeight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                      trafficRouting:
+                        properties:
+                          alb:
+                            properties:
+                              annotationPrefix:
+                                type: string
+                              ingress:
+                                type: string
+                              rootService:
+                                type: string
+                              servicePort:
+                                format: int32
+                                type: integer
+                            required:
+                            - ingress
+                            - servicePort
+                            type: object
+                          istio:
+                            properties:
+                              virtualService:
+                                properties:
+                                  name:
+                                    type: string
+                                  routes:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - name
+                                - routes
+                                type: object
+                            required:
+                            - virtualService
+                            type: object
+                          nginx:
+                            properties:
+                              additionalIngressAnnotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              annotationPrefix:
+                                type: string
+                              stableIngress:
+                                type: string
+                            required:
+                            - stableIngress
+                            type: object
+                          smi:
+                            properties:
+                              rootService:
+                                type: string
+                              trafficSplitName:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              template:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      activeDeadlineSeconds:
+                        format: int64
+                        type: integer
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
                                       format: int32
                                       type: integer
-                                    selector:
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
                                       properties:
                                         matchExpressions:
                                           items:
@@ -425,2723 +704,2443 @@ spec:
                                             type: string
                                           type: object
                                       type: object
-                                    specRef:
-                                      type: string
-                                  required:
-                                  - name
-                                  - specRef
-                                  type: object
-                                type: array
-                            required:
-                            - templates
-                            type: object
-                          pause:
-                            properties:
-                              duration:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            type: object
-                          setCanaryScale:
-                            properties:
-                              matchTrafficWeight:
-                                type: boolean
-                              replicas:
-                                format: int32
-                                type: integer
-                              weight:
-                                format: int32
-                                type: integer
-                            type: object
-                          setWeight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    trafficRouting:
-                      properties:
-                        alb:
-                          properties:
-                            annotationPrefix:
-                              type: string
-                            ingress:
-                              type: string
-                            rootService:
-                              type: string
-                            servicePort:
-                              format: int32
-                              type: integer
-                          required:
-                          - ingress
-                          - servicePort
-                          type: object
-                        istio:
-                          properties:
-                            virtualService:
-                              properties:
-                                name:
-                                  type: string
-                                routes:
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - name
-                              - routes
-                              type: object
-                          required:
-                          - virtualService
-                          type: object
-                        nginx:
-                          properties:
-                            additionalIngressAnnotations:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            annotationPrefix:
-                              type: string
-                            stableIngress:
-                              type: string
-                          required:
-                          - stableIngress
-                          type: object
-                        smi:
-                          properties:
-                            rootService:
-                              type: string
-                            trafficSplitName:
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-              type: object
-            template:
-              properties:
-                metadata:
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                spec:
-                  properties:
-                    activeDeadlineSeconds:
-                      format: int64
-                      type: integer
-                    affinity:
-                      properties:
-                        nodeAffinity:
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              items:
-                                properties:
-                                  preference:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - preference
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              properties:
-                                nodeSelectorTerms:
-                                  items:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                              - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              items:
-                                properties:
-                                  podAffinityTerm:
-                                    properties:
-                                      labelSelector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  weight:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - podAffinityTerm
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              items:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              items:
-                                properties:
-                                  podAffinityTerm:
-                                    properties:
-                                      labelSelector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  weight:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - podAffinityTerm
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              items:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    automountServiceAccountToken:
-                      type: boolean
-                    containers:
-                      items:
-                        properties:
-                          args:
-                            items:
-                              type: string
-                            type: array
-                          command:
-                            items:
-                              type: string
-                            type: array
-                          env:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                                valueFrom:
-                                  properties:
-                                    configMapKeyRef:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                    fieldRef:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        fieldPath:
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      properties:
-                                        containerName:
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                    secretKeyRef:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          envFrom:
-                            items:
-                              properties:
-                                configMapRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                prefix:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                              type: object
-                            type: array
-                          image:
-                            type: string
-                          imagePullPolicy:
-                            type: string
-                          lifecycle:
-                            properties:
-                              postStart:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                    - port
-                                    type: object
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                    - port
-                                    type: object
-                                type: object
-                              preStop:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                    - port
-                                    type: object
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                    - port
-                                    type: object
-                                type: object
-                            type: object
-                          livenessProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          name:
-                            type: string
-                          ports:
-                            items:
-                              properties:
-                                containerPort:
-                                  format: int32
-                                  type: integer
-                                hostIP:
-                                  type: string
-                                hostPort:
-                                  format: int32
-                                  type: integer
-                                name:
-                                  type: string
-                                protocol:
-                                  type: string
-                              required:
-                              - containerPort
-                              type: object
-                            type: array
-                          readinessProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          resources:
-                            type: object
-                          securityContext:
-                            properties:
-                              allowPrivilegeEscalation:
-                                type: boolean
-                              capabilities:
-                                properties:
-                                  add:
-                                    items:
-                                      type: string
-                                    type: array
-                                  drop:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              privileged:
-                                type: boolean
-                              procMount:
-                                type: string
-                              readOnlyRootFilesystem:
-                                type: boolean
-                              runAsGroup:
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                type: boolean
-                              runAsUser:
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                properties:
-                                  level:
-                                    type: string
-                                  role:
-                                    type: string
-                                  type:
-                                    type: string
-                                  user:
-                                    type: string
-                                type: object
-                              windowsOptions:
-                                properties:
-                                  gmsaCredentialSpec:
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    type: string
-                                  runAsUserName:
-                                    type: string
-                                type: object
-                            type: object
-                          startupProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          stdin:
-                            type: boolean
-                          stdinOnce:
-                            type: boolean
-                          terminationMessagePath:
-                            type: string
-                          terminationMessagePolicy:
-                            type: string
-                          tty:
-                            type: boolean
-                          volumeDevices:
-                            items:
-                              properties:
-                                devicePath:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - devicePath
-                              - name
-                              type: object
-                            type: array
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
-                          workingDir:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      type: array
-                    dnsConfig:
-                      properties:
-                        nameservers:
-                          items:
-                            type: string
-                          type: array
-                        options:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            type: object
-                          type: array
-                        searches:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    dnsPolicy:
-                      type: string
-                    enableServiceLinks:
-                      type: boolean
-                    ephemeralContainers:
-                      items:
-                        properties:
-                          args:
-                            items:
-                              type: string
-                            type: array
-                          command:
-                            items:
-                              type: string
-                            type: array
-                          env:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                                valueFrom:
-                                  properties:
-                                    configMapKeyRef:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                    fieldRef:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        fieldPath:
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      properties:
-                                        containerName:
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                    secretKeyRef:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          envFrom:
-                            items:
-                              properties:
-                                configMapRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                prefix:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                              type: object
-                            type: array
-                          image:
-                            type: string
-                          imagePullPolicy:
-                            type: string
-                          lifecycle:
-                            properties:
-                              postStart:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                    - port
-                                    type: object
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                    - port
-                                    type: object
-                                type: object
-                              preStop:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                    - port
-                                    type: object
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                    - port
-                                    type: object
-                                type: object
-                            type: object
-                          livenessProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          name:
-                            type: string
-                          ports:
-                            items:
-                              properties:
-                                containerPort:
-                                  format: int32
-                                  type: integer
-                                hostIP:
-                                  type: string
-                                hostPort:
-                                  format: int32
-                                  type: integer
-                                name:
-                                  type: string
-                                protocol:
-                                  type: string
-                              required:
-                              - containerPort
-                              type: object
-                            type: array
-                          readinessProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          resources:
-                            type: object
-                          securityContext:
-                            properties:
-                              allowPrivilegeEscalation:
-                                type: boolean
-                              capabilities:
-                                properties:
-                                  add:
-                                    items:
-                                      type: string
-                                    type: array
-                                  drop:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              privileged:
-                                type: boolean
-                              procMount:
-                                type: string
-                              readOnlyRootFilesystem:
-                                type: boolean
-                              runAsGroup:
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                type: boolean
-                              runAsUser:
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                properties:
-                                  level:
-                                    type: string
-                                  role:
-                                    type: string
-                                  type:
-                                    type: string
-                                  user:
-                                    type: string
-                                type: object
-                              windowsOptions:
-                                properties:
-                                  gmsaCredentialSpec:
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    type: string
-                                  runAsUserName:
-                                    type: string
-                                type: object
-                            type: object
-                          startupProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          stdin:
-                            type: boolean
-                          stdinOnce:
-                            type: boolean
-                          targetContainerName:
-                            type: string
-                          terminationMessagePath:
-                            type: string
-                          terminationMessagePolicy:
-                            type: string
-                          tty:
-                            type: boolean
-                          volumeDevices:
-                            items:
-                              properties:
-                                devicePath:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - devicePath
-                              - name
-                              type: object
-                            type: array
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
-                          workingDir:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      type: array
-                    hostAliases:
-                      items:
-                        properties:
-                          hostnames:
-                            items:
-                              type: string
-                            type: array
-                          ip:
-                            type: string
-                        type: object
-                      type: array
-                    hostIPC:
-                      type: boolean
-                    hostNetwork:
-                      type: boolean
-                    hostPID:
-                      type: boolean
-                    hostname:
-                      type: string
-                    imagePullSecrets:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                        type: object
-                      type: array
-                    initContainers:
-                      items:
-                        properties:
-                          args:
-                            items:
-                              type: string
-                            type: array
-                          command:
-                            items:
-                              type: string
-                            type: array
-                          env:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                                valueFrom:
-                                  properties:
-                                    configMapKeyRef:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                    fieldRef:
-                                      properties:
-                                        apiVersion:
-                                          type: string
-                                        fieldPath:
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      properties:
-                                        containerName:
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          type: string
-                                      required:
-                                      - resource
-                                      type: object
-                                    secretKeyRef:
-                                      properties:
-                                        key:
-                                          type: string
-                                        name:
-                                          type: string
-                                        optional:
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          envFrom:
-                            items:
-                              properties:
-                                configMapRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                prefix:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                              type: object
-                            type: array
-                          image:
-                            type: string
-                          imagePullPolicy:
-                            type: string
-                          lifecycle:
-                            properties:
-                              postStart:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                    - port
-                                    type: object
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                    - port
-                                    type: object
-                                type: object
-                              preStop:
-                                properties:
-                                  exec:
-                                    properties:
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  httpGet:
-                                    properties:
-                                      host:
-                                        type: string
-                                      httpHeaders:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                      path:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                      scheme:
-                                        type: string
-                                    required:
-                                    - port
-                                    type: object
-                                  tcpSocket:
-                                    properties:
-                                      host:
-                                        type: string
-                                      port:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                    - port
-                                    type: object
-                                type: object
-                            type: object
-                          livenessProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          name:
-                            type: string
-                          ports:
-                            items:
-                              properties:
-                                containerPort:
-                                  format: int32
-                                  type: integer
-                                hostIP:
-                                  type: string
-                                hostPort:
-                                  format: int32
-                                  type: integer
-                                name:
-                                  type: string
-                                protocol:
-                                  type: string
-                              required:
-                              - containerPort
-                              type: object
-                            type: array
-                          readinessProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          resources:
-                            type: object
-                          securityContext:
-                            properties:
-                              allowPrivilegeEscalation:
-                                type: boolean
-                              capabilities:
-                                properties:
-                                  add:
-                                    items:
-                                      type: string
-                                    type: array
-                                  drop:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              privileged:
-                                type: boolean
-                              procMount:
-                                type: string
-                              readOnlyRootFilesystem:
-                                type: boolean
-                              runAsGroup:
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                type: boolean
-                              runAsUser:
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                properties:
-                                  level:
-                                    type: string
-                                  role:
-                                    type: string
-                                  type:
-                                    type: string
-                                  user:
-                                    type: string
-                                type: object
-                              windowsOptions:
-                                properties:
-                                  gmsaCredentialSpec:
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    type: string
-                                  runAsUserName:
-                                    type: string
-                                type: object
-                            type: object
-                          startupProbe:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                format: int32
-                                type: integer
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              initialDelaySeconds:
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                              timeoutSeconds:
-                                format: int32
-                                type: integer
-                            type: object
-                          stdin:
-                            type: boolean
-                          stdinOnce:
-                            type: boolean
-                          terminationMessagePath:
-                            type: string
-                          terminationMessagePolicy:
-                            type: string
-                          tty:
-                            type: boolean
-                          volumeDevices:
-                            items:
-                              properties:
-                                devicePath:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - devicePath
-                              - name
-                              type: object
-                            type: array
-                          volumeMounts:
-                            items:
-                              properties:
-                                mountPath:
-                                  type: string
-                                mountPropagation:
-                                  type: string
-                                name:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                subPath:
-                                  type: string
-                                subPathExpr:
-                                  type: string
-                              required:
-                              - mountPath
-                              - name
-                              type: object
-                            type: array
-                          workingDir:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      type: array
-                    nodeName:
-                      type: string
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    overhead:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                    preemptionPolicy:
-                      type: string
-                    priority:
-                      format: int32
-                      type: integer
-                    priorityClassName:
-                      type: string
-                    readinessGates:
-                      items:
-                        properties:
-                          conditionType:
-                            type: string
-                        required:
-                        - conditionType
-                        type: object
-                      type: array
-                    restartPolicy:
-                      type: string
-                    runtimeClassName:
-                      type: string
-                    schedulerName:
-                      type: string
-                    securityContext:
-                      properties:
-                        fsGroup:
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          type: string
-                        runAsGroup:
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          type: boolean
-                        runAsUser:
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          properties:
-                            level:
-                              type: string
-                            role:
-                              type: string
-                            type:
-                              type: string
-                            user:
-                              type: string
-                          type: object
-                        supplementalGroups:
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          properties:
-                            gmsaCredentialSpec:
-                              type: string
-                            gmsaCredentialSpecName:
-                              type: string
-                            runAsUserName:
-                              type: string
-                          type: object
-                      type: object
-                    serviceAccount:
-                      type: string
-                    serviceAccountName:
-                      type: string
-                    shareProcessNamespace:
-                      type: boolean
-                    subdomain:
-                      type: string
-                    terminationGracePeriodSeconds:
-                      format: int64
-                      type: integer
-                    tolerations:
-                      items:
-                        properties:
-                          effect:
-                            type: string
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          tolerationSeconds:
-                            format: int64
-                            type: integer
-                          value:
-                            type: string
-                        type: object
-                      type: array
-                    topologySpreadConstraints:
-                      items:
-                        properties:
-                          labelSelector:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
+                                    namespaces:
                                       items:
                                         type: string
                                       type: array
+                                    topologyKey:
+                                      type: string
                                   required:
-                                  - key
-                                  - operator
+                                  - topologyKey
                                   type: object
                                 type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                type: object
                             type: object
-                          maxSkew:
-                            format: int32
-                            type: integer
-                          topologyKey:
-                            type: string
-                          whenUnsatisfiable:
-                            type: string
-                        required:
-                        - maxSkew
-                        - topologyKey
-                        - whenUnsatisfiable
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
                         type: object
-                      type: array
-                    volumes:
-                      items:
+                      automountServiceAccountToken:
+                        type: boolean
+                      containers:
+                        items:
+                          properties:
+                            args:
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dnsConfig:
                         properties:
-                          awsElasticBlockStore:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                            - volumeID
-                            type: object
-                          azureDisk:
-                            properties:
-                              cachingMode:
-                                type: string
-                              diskName:
-                                type: string
-                              diskURI:
-                                type: string
-                              fsType:
-                                type: string
-                              kind:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                            - diskName
-                            - diskURI
-                            type: object
-                          azureFile:
-                            properties:
-                              readOnly:
-                                type: boolean
-                              secretName:
-                                type: string
-                              shareName:
-                                type: string
-                            required:
-                            - secretName
-                            - shareName
-                            type: object
-                          cephfs:
-                            properties:
-                              monitors:
-                                items:
+                          nameservers:
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            items:
+                              properties:
+                                name:
                                   type: string
-                                type: array
-                              path:
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        type: string
+                      enableServiceLinks:
+                        type: boolean
+                      ephemeralContainers:
+                        items:
+                          properties:
+                            args:
+                              items:
                                 type: string
-                              readOnly:
-                                type: boolean
-                              secretFile:
+                              type: array
+                            command:
+                              items:
                                 type: string
-                              secretRef:
+                              type: array
+                            env:
+                              items:
                                 properties:
                                   name:
                                     type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
                                 type: object
-                              user:
+                              type: array
+                            envFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    type: string
+                                  protocol:
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            targetContainerName:
+                              type: string
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
+                                properties:
+                                  devicePath:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      hostAliases:
+                        items:
+                          properties:
+                            hostnames:
+                              items:
                                 type: string
-                            required:
-                            - monitors
-                            type: object
-                          cinder:
-                            properties:
-                              fsType:
+                              type: array
+                            ip:
+                              type: string
+                          type: object
+                        type: array
+                      hostIPC:
+                        type: boolean
+                      hostNetwork:
+                        type: boolean
+                      hostPID:
+                        type: boolean
+                      hostname:
+                        type: string
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      initContainers:
+                        items:
+                          properties:
+                            args:
+                              items:
                                 type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
+                              type: array
+                            command:
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              items:
                                 properties:
                                   name:
                                     type: string
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      configMapKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
                                 type: object
-                              volumeID:
-                                type: string
-                            required:
-                            - volumeID
-                            type: object
-                          csi:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              nodePublishSecretRef:
+                              type: array
+                            envFrom:
+                              items:
                                 properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              type: string
+                            imagePullPolicy:
+                              type: string
+                            lifecycle:
+                              properties:
+                                postStart:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              type: string
+                            ports:
+                              items:
+                                properties:
+                                  containerPort:
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    type: string
+                                  hostPort:
+                                    format: int32
+                                    type: integer
                                   name:
                                     type: string
+                                  protocol:
+                                    type: string
+                                required:
+                                - containerPort
                                 type: object
-                              readOnly:
-                                type: boolean
-                              volumeAttributes:
-                                additionalProperties:
+                              type: array
+                            readinessProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              type: object
+                            securityContext:
+                              properties:
+                                allowPrivilegeEscalation:
+                                  type: boolean
+                                capabilities:
+                                  properties:
+                                    add:
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  type: boolean
+                                procMount:
                                   type: string
-                                type: object
-                            required:
-                            - driver
-                            type: object
-                          emptyDir:
-                            properties:
-                              medium:
-                                type: string
-                              sizeLimit:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                            type: object
-                          fc:
-                            properties:
-                              fsType:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              readOnly:
-                                type: boolean
-                              targetWWNs:
-                                items:
-                                  type: string
-                                type: array
-                              wwids:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          flexVolume:
-                            properties:
-                              driver:
-                                type: string
-                              fsType:
-                                type: string
-                              options:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              readOnly:
-                                type: boolean
-                              secretRef:
+                                readOnlyRootFilesystem:
+                                  type: boolean
+                                runAsGroup:
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              type: boolean
+                            stdinOnce:
+                              type: boolean
+                            terminationMessagePath:
+                              type: string
+                            terminationMessagePolicy:
+                              type: string
+                            tty:
+                              type: boolean
+                            volumeDevices:
+                              items:
                                 properties:
+                                  devicePath:
+                                    type: string
                                   name:
                                     type: string
+                                required:
+                                - devicePath
+                                - name
                                 type: object
-                            required:
-                            - driver
-                            type: object
-                          flocker:
+                              type: array
+                            volumeMounts:
+                              items:
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      nodeName:
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      preemptionPolicy:
+                        type: string
+                      priority:
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        type: string
+                      readinessGates:
+                        items:
+                          properties:
+                            conditionType:
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        type: string
+                      runtimeClassName:
+                        type: string
+                      schedulerName:
+                        type: string
+                      securityContext:
+                        properties:
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            type: string
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
                             properties:
-                              datasetName:
+                              level:
                                 type: string
-                              datasetUUID:
-                                type: string
-                            type: object
-                          gcePersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              partition:
-                                format: int32
-                                type: integer
-                              pdName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                            - pdName
-                            type: object
-                          gitRepo:
-                            properties:
-                              directory:
-                                type: string
-                              repository:
-                                type: string
-                              revision:
-                                type: string
-                            required:
-                            - repository
-                            type: object
-                          glusterfs:
-                            properties:
-                              endpoints:
-                                type: string
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                            - endpoints
-                            - path
-                            type: object
-                          hostPath:
-                            properties:
-                              path:
+                              role:
                                 type: string
                               type:
                                 type: string
-                            required:
-                            - path
-                            type: object
-                          iscsi:
-                            properties:
-                              chapAuthDiscovery:
-                                type: boolean
-                              chapAuthSession:
-                                type: boolean
-                              fsType:
-                                type: string
-                              initiatorName:
-                                type: string
-                              iqn:
-                                type: string
-                              iscsiInterface:
-                                type: string
-                              lun:
-                                format: int32
-                                type: integer
-                              portals:
-                                items:
-                                  type: string
-                                type: array
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              targetPortal:
-                                type: string
-                            required:
-                            - iqn
-                            - lun
-                            - targetPortal
-                            type: object
-                          name:
-                            type: string
-                          nfs:
-                            properties:
-                              path:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              server:
-                                type: string
-                            required:
-                            - path
-                            - server
-                            type: object
-                          persistentVolumeClaim:
-                            properties:
-                              claimName:
-                                type: string
-                              readOnly:
-                                type: boolean
-                            required:
-                            - claimName
-                            type: object
-                          photonPersistentDisk:
-                            properties:
-                              fsType:
-                                type: string
-                              pdID:
-                                type: string
-                            required:
-                            - pdID
-                            type: object
-                          portworxVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              volumeID:
-                                type: string
-                            required:
-                            - volumeID
-                            type: object
-                          projected:
-                            properties:
-                              defaultMode:
-                                format: int32
-                                type: integer
-                              sources:
-                                items:
-                                  properties:
-                                    serviceAccountToken:
-                                      properties:
-                                        audience:
-                                          type: string
-                                        expirationSeconds:
-                                          format: int64
-                                          type: integer
-                                        path:
-                                          type: string
-                                      required:
-                                      - path
-                                      type: object
-                                  type: object
-                                type: array
-                            required:
-                            - sources
-                            type: object
-                          quobyte:
-                            properties:
-                              group:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              registry:
-                                type: string
-                              tenant:
-                                type: string
                               user:
                                 type: string
-                              volume:
-                                type: string
-                            required:
-                            - registry
-                            - volume
                             type: object
-                          rbd:
-                            properties:
-                              fsType:
-                                type: string
-                              image:
-                                type: string
-                              keyring:
-                                type: string
-                              monitors:
-                                items:
+                          supplementalGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            items:
+                              properties:
+                                name:
                                   type: string
-                                type: array
-                              pool:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              user:
-                                type: string
-                            required:
-                            - image
-                            - monitors
-                            type: object
-                          scaleIO:
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
                             properties:
-                              fsType:
+                              gmsaCredentialSpec:
                                 type: string
-                              gateway:
+                              gmsaCredentialSpecName:
                                 type: string
-                              protectionDomain:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              sslEnabled:
-                                type: boolean
-                              storageMode:
-                                type: string
-                              storagePool:
-                                type: string
-                              system:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                            - gateway
-                            - secretRef
-                            - system
-                            type: object
-                          storageos:
-                            properties:
-                              fsType:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                type: object
-                              volumeName:
-                                type: string
-                              volumeNamespace:
+                              runAsUserName:
                                 type: string
                             type: object
-                          vsphereVolume:
-                            properties:
-                              fsType:
-                                type: string
-                              storagePolicyID:
-                                type: string
-                              storagePolicyName:
-                                type: string
-                              volumePath:
-                                type: string
-                            required:
-                            - volumePath
-                            type: object
-                        required:
-                        - name
                         type: object
-                      type: array
-                  required:
-                  - containers
-                  type: object
-              type: object
-          required:
-          - selector
-          - template
-          type: object
-        status:
-          properties:
-            HPAReplicas:
-              format: int32
-              type: integer
-            abort:
-              type: boolean
-            abortedAt:
-              format: date-time
-              type: string
-            availableReplicas:
-              format: int32
-              type: integer
-            blueGreen:
-              properties:
-                activeSelector:
-                  type: string
-                postPromotionAnalysisRun:
-                  type: string
-                postPromotionAnalysisRunStatus:
-                  properties:
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    status:
-                      type: string
-                  required:
-                  - name
-                  - status
-                  type: object
-                prePromotionAnalysisRun:
-                  type: string
-                prePromotionAnalysisRunStatus:
-                  properties:
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    status:
-                      type: string
-                  required:
-                  - name
-                  - status
-                  type: object
-                previewSelector:
-                  type: string
-                previousActiveSelector:
-                  type: string
-                scaleDownDelayStartTime:
-                  format: date-time
-                  type: string
-                scaleUpPreviewCheckPoint:
-                  type: boolean
-              type: object
-            canary:
-              properties:
-                currentBackgroundAnalysisRun:
-                  type: string
-                currentBackgroundAnalysisRunStatus:
-                  properties:
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    status:
-                      type: string
-                  required:
-                  - name
-                  - status
-                  type: object
-                currentExperiment:
-                  type: string
-                currentStepAnalysisRun:
-                  type: string
-                currentStepAnalysisRunStatus:
-                  properties:
-                    message:
-                      type: string
-                    name:
-                      type: string
-                    status:
-                      type: string
-                  required:
-                  - name
-                  - status
-                  type: object
-              type: object
-            collisionCount:
-              format: int32
-              type: integer
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - lastTransitionTime
-                - lastUpdateTime
-                - message
-                - reason
-                - status
-                - type
+                      serviceAccount:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      shareProcessNamespace:
+                        type: boolean
+                      subdomain:
+                        type: string
+                      terminationGracePeriodSeconds:
+                        format: int64
+                        type: integer
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: string
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            tolerationSeconds:
+                              format: int64
+                              type: integer
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            maxSkew:
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              type: string
+                            whenUnsatisfiable:
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                      volumes:
+                        items:
+                          properties:
+                            awsElasticBlockStore:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              properties:
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            csi:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            emptyDir:
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            fc:
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              type: string
+                            nfs:
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  items:
+                                    properties:
+                                      serviceAccountToken:
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              required:
+                              - sources
+                              type: object
+                            quobyte:
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                user:
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            storageos:
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - containers
+                    type: object
                 type: object
-              type: array
-            controllerPause:
-              type: boolean
-            currentPodHash:
-              type: string
-            currentStepHash:
-              type: string
-            currentStepIndex:
-              format: int32
-              type: integer
-            observedGeneration:
-              type: string
-            pauseConditions:
-              items:
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            properties:
+              HPAReplicas:
+                format: int32
+                type: integer
+              abort:
+                type: boolean
+              abortedAt:
+                format: date-time
+                type: string
+              availableReplicas:
+                format: int32
+                type: integer
+              blueGreen:
                 properties:
-                  reason:
+                  activeSelector:
                     type: string
-                  startTime:
+                  postPromotionAnalysisRun:
+                    type: string
+                  postPromotionAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  prePromotionAnalysisRun:
+                    type: string
+                  prePromotionAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  previewSelector:
+                    type: string
+                  previousActiveSelector:
+                    type: string
+                  scaleDownDelayStartTime:
                     format: date-time
                     type: string
-                required:
-                - reason
-                - startTime
+                  scaleUpPreviewCheckPoint:
+                    type: boolean
                 type: object
-              type: array
-            promoteFull:
-              type: boolean
-            readyReplicas:
-              format: int32
-              type: integer
-            replicas:
-              format: int32
-              type: integer
-            restartedAt:
-              format: date-time
-              type: string
-            selector:
-              type: string
-            stableRS:
-              type: string
-            updatedReplicas:
-              format: int32
-              type: integer
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+              canary:
+                properties:
+                  currentBackgroundAnalysisRun:
+                    type: string
+                  currentBackgroundAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                  currentExperiment:
+                    type: string
+                  currentStepAnalysisRun:
+                    type: string
+                  currentStepAnalysisRunStatus:
+                    properties:
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                    - name
+                    - status
+                    type: object
+                type: object
+              collisionCount:
+                format: int32
+                type: integer
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              controllerPause:
+                type: boolean
+              currentPodHash:
+                type: string
+              currentStepHash:
+                type: string
+              currentStepIndex:
+                format: int32
+                type: integer
+              observedGeneration:
+                type: string
+              pauseConditions:
+                items:
+                  properties:
+                    reason:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                  required:
+                  - reason
+                  - startTime
+                  type: object
+                type: array
+              promoteFull:
+                type: boolean
+              readyReplicas:
+                format: int32
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              restartedAt:
+                format: date-time
+                type: string
+              selector:
+                type: string
+              stableRS:
+                type: string
+              updatedReplicas:
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
 {{- end }}


### PR DESCRIPTION
When trying to install the current version of argo-rollouts charts the error:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(CustomResourceDefinition.spec): unknown field "additionalPrinterColumns" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec, ValidationError(CustomResourceDefinition.spec): unknown field "subresources" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec, ValidationError(CustomResourceDefinition.spec): unknown field "validation" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec, ValidationError(CustomResourceDefinition.spec): unknown field "version" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec]
```

This is due to the format of the custom resource definition being updated from the apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1 versions (https://github.com/kubernetes/apiextensions-apiserver/commit/b7fdf760760c30827cd6e4539e372ad37451e6ac) 

This merge updates the argo-rollouts charts to new format

This might fix: https://github.com/argoproj/argo-helm/issues/581 

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
