### PR TITLE
fix(argo-rollouts): update cdr schema to current version

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.4.2
+version: 0.4.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -27,2812 +27,2937 @@ spec:
     subresources: {}
     schema:
       openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                args:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      value:
-                        type: string
-                      valueFrom:
-                        properties:
-                          fieldRef:
-                            properties:
-                              fieldPath:
-                                type: string
-                            required:
-                            - fieldPath
-                            type: object
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - key
-                            - name
-                            type: object
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-                metrics:
-                  items:
-                    properties:
-                      consecutiveErrorLimit:
-                        format: int32
-                        type: integer
-                      count:
-                        format: int32
-                        type: integer
-                      failureCondition:
-                        type: string
-                      failureLimit:
-                        format: int32
-                        type: integer
-                      inconclusiveLimit:
-                        format: int32
-                        type: integer
-                      initialDelay:
-                        type: string
-                      interval:
-                        type: string
-                      name:
-                        type: string
-                      provider:
-                        properties:
-                          datadog:
-                            properties:
-                              interval:
-                                type: string
-                              query:
-                                type: string
-                            required:
-                            - query
-                            type: object
-                          job:
-                            properties:
-                              metadata:
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              spec:
-                                properties:
-                                  activeDeadlineSeconds:
-                                    format: int64
-                                    type: integer
-                                  backoffLimit:
-                                    format: int32
-                                    type: integer
-                                  completions:
-                                    format: int32
-                                    type: integer
-                                  manualSelector:
-                                    type: boolean
-                                  parallelism:
-                                    format: int32
-                                    type: integer
-                                  selector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        datadog:
+                          properties:
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          required:
+                          - query
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                completions:
+                                  format: int32
+                                  type: integer
+                                manualSelector:
+                                  type: boolean
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
                                               type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
                                           type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  template:
-                                    properties:
-                                      metadata:
-                                        properties:
-                                          annotations:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                          labels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      spec:
-                                        properties:
-                                          activeDeadlineSeconds:
-                                            format: int64
-                                            type: integer
-                                          affinity:
-                                            properties:
-                                              nodeAffinity:
-                                                properties:
-                                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                                    items:
-                                                      properties:
-                                                        preference:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchFields:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                          type: object
-                                                        weight:
-                                                          format: int32
-                                                          type: integer
-                                                      required:
-                                                      - preference
-                                                      - weight
-                                                      type: object
-                                                    type: array
-                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
                                                     properties:
-                                                      nodeSelectorTerms:
-                                                        items:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchFields:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                          type: object
-                                                        type: array
-                                                    required:
-                                                    - nodeSelectorTerms
-                                                    type: object
-                                                type: object
-                                              podAffinity:
-                                                properties:
-                                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                                    items:
-                                                      properties:
-                                                        podAffinityTerm:
-                                                          properties:
-                                                            labelSelector:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
                                                               properties:
-                                                                matchExpressions:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
                                                                   items:
-                                                                    properties:
-                                                                      key:
-                                                                        type: string
-                                                                      operator:
-                                                                        type: string
-                                                                      values:
-                                                                        items:
-                                                                          type: string
-                                                                        type: array
-                                                                    required:
-                                                                    - key
-                                                                    - operator
-                                                                    type: object
+                                                                    type: string
                                                                   type: array
-                                                                matchLabels:
-                                                                  additionalProperties:
-                                                                    type: string
-                                                                  type: object
+                                                              required:
+                                                              - key
+                                                              - operator
                                                               type: object
-                                                            namespaces:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                            topologyKey:
-                                                              type: string
-                                                          required:
-                                                          - topologyKey
-                                                          type: object
-                                                        weight:
-                                                          format: int32
-                                                          type: integer
-                                                      required:
-                                                      - podAffinityTerm
-                                                      - weight
-                                                      type: object
-                                                    type: array
-                                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                                    items:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    type: array
-                                                type: object
-                                              podAntiAffinity:
-                                                properties:
-                                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                                    items:
-                                                      properties:
-                                                        podAffinityTerm:
-                                                          properties:
-                                                            labelSelector:
+                                                            type: array
+                                                          matchFields:
+                                                            items:
                                                               properties:
-                                                                matchExpressions:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
                                                                   items:
-                                                                    properties:
-                                                                      key:
-                                                                        type: string
-                                                                      operator:
-                                                                        type: string
-                                                                      values:
-                                                                        items:
-                                                                          type: string
-                                                                        type: array
-                                                                    required:
-                                                                    - key
-                                                                    - operator
-                                                                    type: object
+                                                                    type: string
                                                                   type: array
-                                                                matchLabels:
-                                                                  additionalProperties:
-                                                                    type: string
-                                                                  type: object
+                                                              required:
+                                                              - key
+                                                              - operator
                                                               type: object
-                                                            namespaces:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                            topologyKey:
-                                                              type: string
-                                                          required:
-                                                          - topologyKey
-                                                          type: object
-                                                        weight:
-                                                          format: int32
-                                                          type: integer
-                                                      required:
-                                                      - podAffinityTerm
-                                                      - weight
-                                                      type: object
-                                                    type: array
-                                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                                    items:
-                                                      properties:
-                                                        labelSelector:
-                                                          properties:
-                                                            matchExpressions:
-                                                              items:
-                                                                properties:
-                                                                  key:
-                                                                    type: string
-                                                                  operator:
-                                                                    type: string
-                                                                  values:
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    type: array
-                                                type: object
-                                            type: object
-                                          automountServiceAccountToken:
-                                            type: boolean
-                                          containers:
-                                            items:
-                                              properties:
-                                                args:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                env:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                      valueFrom:
-                                                        properties:
-                                                          configMapKeyRef:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              name:
-                                                                type: string
-                                                              optional:
-                                                                type: boolean
-                                                            required:
-                                                            - key
-                                                            type: object
-                                                          fieldRef:
-                                                            properties:
-                                                              apiVersion:
-                                                                type: string
-                                                              fieldPath:
-                                                                type: string
-                                                            required:
-                                                            - fieldPath
-                                                            type: object
-                                                          resourceFieldRef:
-                                                            properties:
-                                                              containerName:
-                                                                type: string
-                                                              divisor:
-                                                                anyOf:
-                                                                - type: integer
-                                                                - type: string
-                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                                x-kubernetes-int-or-string: true
-                                                              resource:
-                                                                type: string
-                                                            required:
-                                                            - resource
-                                                            type: object
-                                                          secretKeyRef:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              name:
-                                                                type: string
-                                                              optional:
-                                                                type: boolean
-                                                            required:
-                                                            - key
-                                                            type: object
+                                                            type: array
                                                         type: object
-                                                    required:
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                envFrom:
-                                                  items:
-                                                    properties:
-                                                      configMapRef:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        type: object
-                                                      prefix:
-                                                        type: string
-                                                      secretRef:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        type: object
-                                                    type: object
-                                                  type: array
-                                                image:
-                                                  type: string
-                                                imagePullPolicy:
-                                                  type: string
-                                                lifecycle:
-                                                  properties:
-                                                    postStart:
-                                                      properties:
-                                                        exec:
-                                                          properties:
-                                                            command:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          type: object
-                                                        httpGet:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            httpHeaders:
-                                                              items:
-                                                                properties:
-                                                                  name:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                                required:
-                                                                - name
-                                                                - value
-                                                                type: object
-                                                              type: array
-                                                            path:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                            scheme:
-                                                              type: string
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                        tcpSocket:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                      type: object
-                                                    preStop:
-                                                      properties:
-                                                        exec:
-                                                          properties:
-                                                            command:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          type: object
-                                                        httpGet:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            httpHeaders:
-                                                              items:
-                                                                properties:
-                                                                  name:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                                required:
-                                                                - name
-                                                                - value
-                                                                type: object
-                                                              type: array
-                                                            path:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                            scheme:
-                                                              type: string
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                        tcpSocket:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                      type: object
-                                                  type: object
-                                                livenessProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                name:
-                                                  type: string
-                                                ports:
-                                                  items:
-                                                    properties:
-                                                      containerPort:
+                                                      weight:
                                                         format: int32
                                                         type: integer
-                                                      hostIP:
-                                                        type: string
-                                                      hostPort:
-                                                        format: int32
-                                                        type: integer
-                                                      name:
-                                                        type: string
-                                                      protocol:
-                                                        type: string
                                                     required:
-                                                    - containerPort
+                                                    - preference
+                                                    - weight
                                                     type: object
                                                   type: array
-                                                readinessProbe:
+                                                requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                resources:
-                                                  type: object
-                                                securityContext:
-                                                  properties:
-                                                    allowPrivilegeEscalation:
-                                                      type: boolean
-                                                    capabilities:
-                                                      properties:
-                                                        add:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        drop:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    privileged:
-                                                      type: boolean
-                                                    procMount:
-                                                      type: string
-                                                    readOnlyRootFilesystem:
-                                                      type: boolean
-                                                    runAsGroup:
-                                                      format: int64
-                                                      type: integer
-                                                    runAsNonRoot:
-                                                      type: boolean
-                                                    runAsUser:
-                                                      format: int64
-                                                      type: integer
-                                                    seLinuxOptions:
-                                                      properties:
-                                                        level:
-                                                          type: string
-                                                        role:
-                                                          type: string
-                                                        type:
-                                                          type: string
-                                                        user:
-                                                          type: string
-                                                      type: object
-                                                    windowsOptions:
-                                                      properties:
-                                                        gmsaCredentialSpec:
-                                                          type: string
-                                                        gmsaCredentialSpecName:
-                                                          type: string
-                                                        runAsUserName:
-                                                          type: string
-                                                      type: object
-                                                  type: object
-                                                startupProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                stdin:
-                                                  type: boolean
-                                                stdinOnce:
-                                                  type: boolean
-                                                terminationMessagePath:
-                                                  type: string
-                                                terminationMessagePolicy:
-                                                  type: string
-                                                tty:
-                                                  type: boolean
-                                                volumeDevices:
-                                                  items:
-                                                    properties:
-                                                      devicePath:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                    required:
-                                                    - devicePath
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                volumeMounts:
-                                                  items:
-                                                    properties:
-                                                      mountPath:
-                                                        type: string
-                                                      mountPropagation:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      readOnly:
-                                                        type: boolean
-                                                      subPath:
-                                                        type: string
-                                                      subPathExpr:
-                                                        type: string
-                                                    required:
-                                                    - mountPath
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                workingDir:
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                          dnsConfig:
-                                            properties:
-                                              nameservers:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              options:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  type: object
-                                                type: array
-                                              searches:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          dnsPolicy:
-                                            type: string
-                                          enableServiceLinks:
-                                            type: boolean
-                                          ephemeralContainers:
-                                            items:
-                                              properties:
-                                                args:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                env:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                      valueFrom:
-                                                        properties:
-                                                          configMapKeyRef:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              name:
-                                                                type: string
-                                                              optional:
-                                                                type: boolean
-                                                            required:
-                                                            - key
-                                                            type: object
-                                                          fieldRef:
-                                                            properties:
-                                                              apiVersion:
-                                                                type: string
-                                                              fieldPath:
-                                                                type: string
-                                                            required:
-                                                            - fieldPath
-                                                            type: object
-                                                          resourceFieldRef:
-                                                            properties:
-                                                              containerName:
-                                                                type: string
-                                                              divisor:
-                                                                anyOf:
-                                                                - type: integer
-                                                                - type: string
-                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                                x-kubernetes-int-or-string: true
-                                                              resource:
-                                                                type: string
-                                                            required:
-                                                            - resource
-                                                            type: object
-                                                          secretKeyRef:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              name:
-                                                                type: string
-                                                              optional:
-                                                                type: boolean
-                                                            required:
-                                                            - key
-                                                            type: object
-                                                        type: object
-                                                    required:
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                envFrom:
-                                                  items:
-                                                    properties:
-                                                      configMapRef:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        type: object
-                                                      prefix:
-                                                        type: string
-                                                      secretRef:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        type: object
-                                                    type: object
-                                                  type: array
-                                                image:
-                                                  type: string
-                                                imagePullPolicy:
-                                                  type: string
-                                                lifecycle:
-                                                  properties:
-                                                    postStart:
-                                                      properties:
-                                                        exec:
-                                                          properties:
-                                                            command:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          type: object
-                                                        httpGet:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            httpHeaders:
-                                                              items:
-                                                                properties:
-                                                                  name:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                                required:
-                                                                - name
-                                                                - value
-                                                                type: object
-                                                              type: array
-                                                            path:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                            scheme:
-                                                              type: string
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                        tcpSocket:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                      type: object
-                                                    preStop:
-                                                      properties:
-                                                        exec:
-                                                          properties:
-                                                            command:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          type: object
-                                                        httpGet:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            httpHeaders:
-                                                              items:
-                                                                properties:
-                                                                  name:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                                required:
-                                                                - name
-                                                                - value
-                                                                type: object
-                                                              type: array
-                                                            path:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                            scheme:
-                                                              type: string
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                        tcpSocket:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                      type: object
-                                                  type: object
-                                                livenessProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                name:
-                                                  type: string
-                                                ports:
-                                                  items:
-                                                    properties:
-                                                      containerPort:
-                                                        format: int32
-                                                        type: integer
-                                                      hostIP:
-                                                        type: string
-                                                      hostPort:
-                                                        format: int32
-                                                        type: integer
-                                                      name:
-                                                        type: string
-                                                      protocol:
-                                                        type: string
-                                                    required:
-                                                    - containerPort
-                                                    type: object
-                                                  type: array
-                                                readinessProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                resources:
-                                                  type: object
-                                                securityContext:
-                                                  properties:
-                                                    allowPrivilegeEscalation:
-                                                      type: boolean
-                                                    capabilities:
-                                                      properties:
-                                                        add:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        drop:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    privileged:
-                                                      type: boolean
-                                                    procMount:
-                                                      type: string
-                                                    readOnlyRootFilesystem:
-                                                      type: boolean
-                                                    runAsGroup:
-                                                      format: int64
-                                                      type: integer
-                                                    runAsNonRoot:
-                                                      type: boolean
-                                                    runAsUser:
-                                                      format: int64
-                                                      type: integer
-                                                    seLinuxOptions:
-                                                      properties:
-                                                        level:
-                                                          type: string
-                                                        role:
-                                                          type: string
-                                                        type:
-                                                          type: string
-                                                        user:
-                                                          type: string
-                                                      type: object
-                                                    windowsOptions:
-                                                      properties:
-                                                        gmsaCredentialSpec:
-                                                          type: string
-                                                        gmsaCredentialSpecName:
-                                                          type: string
-                                                        runAsUserName:
-                                                          type: string
-                                                      type: object
-                                                  type: object
-                                                startupProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                stdin:
-                                                  type: boolean
-                                                stdinOnce:
-                                                  type: boolean
-                                                targetContainerName:
-                                                  type: string
-                                                terminationMessagePath:
-                                                  type: string
-                                                terminationMessagePolicy:
-                                                  type: string
-                                                tty:
-                                                  type: boolean
-                                                volumeDevices:
-                                                  items:
-                                                    properties:
-                                                      devicePath:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                    required:
-                                                    - devicePath
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                volumeMounts:
-                                                  items:
-                                                    properties:
-                                                      mountPath:
-                                                        type: string
-                                                      mountPropagation:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      readOnly:
-                                                        type: boolean
-                                                      subPath:
-                                                        type: string
-                                                      subPathExpr:
-                                                        type: string
-                                                    required:
-                                                    - mountPath
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                workingDir:
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                          hostAliases:
-                                            items:
-                                              properties:
-                                                hostnames:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                ip:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          hostIPC:
-                                            type: boolean
-                                          hostNetwork:
-                                            type: boolean
-                                          hostPID:
-                                            type: boolean
-                                          hostname:
-                                            type: string
-                                          imagePullSecrets:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          initContainers:
-                                            items:
-                                              properties:
-                                                args:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                command:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                env:
-                                                  items:
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      value:
-                                                        type: string
-                                                      valueFrom:
-                                                        properties:
-                                                          configMapKeyRef:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              name:
-                                                                type: string
-                                                              optional:
-                                                                type: boolean
-                                                            required:
-                                                            - key
-                                                            type: object
-                                                          fieldRef:
-                                                            properties:
-                                                              apiVersion:
-                                                                type: string
-                                                              fieldPath:
-                                                                type: string
-                                                            required:
-                                                            - fieldPath
-                                                            type: object
-                                                          resourceFieldRef:
-                                                            properties:
-                                                              containerName:
-                                                                type: string
-                                                              divisor:
-                                                                anyOf:
-                                                                - type: integer
-                                                                - type: string
-                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                                x-kubernetes-int-or-string: true
-                                                              resource:
-                                                                type: string
-                                                            required:
-                                                            - resource
-                                                            type: object
-                                                          secretKeyRef:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              name:
-                                                                type: string
-                                                              optional:
-                                                                type: boolean
-                                                            required:
-                                                            - key
-                                                            type: object
-                                                        type: object
-                                                    required:
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                envFrom:
-                                                  items:
-                                                    properties:
-                                                      configMapRef:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        type: object
-                                                      prefix:
-                                                        type: string
-                                                      secretRef:
-                                                        properties:
-                                                          name:
-                                                            type: string
-                                                          optional:
-                                                            type: boolean
-                                                        type: object
-                                                    type: object
-                                                  type: array
-                                                image:
-                                                  type: string
-                                                imagePullPolicy:
-                                                  type: string
-                                                lifecycle:
-                                                  properties:
-                                                    postStart:
-                                                      properties:
-                                                        exec:
-                                                          properties:
-                                                            command:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          type: object
-                                                        httpGet:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            httpHeaders:
-                                                              items:
-                                                                properties:
-                                                                  name:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                                required:
-                                                                - name
-                                                                - value
-                                                                type: object
-                                                              type: array
-                                                            path:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                            scheme:
-                                                              type: string
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                        tcpSocket:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                      type: object
-                                                    preStop:
-                                                      properties:
-                                                        exec:
-                                                          properties:
-                                                            command:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          type: object
-                                                        httpGet:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            httpHeaders:
-                                                              items:
-                                                                properties:
-                                                                  name:
-                                                                    type: string
-                                                                  value:
-                                                                    type: string
-                                                                required:
-                                                                - name
-                                                                - value
-                                                                type: object
-                                                              type: array
-                                                            path:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                            scheme:
-                                                              type: string
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                        tcpSocket:
-                                                          properties:
-                                                            host:
-                                                              type: string
-                                                            port:
-                                                              anyOf:
-                                                              - type: integer
-                                                              - type: string
-                                                              x-kubernetes-int-or-string: true
-                                                          required:
-                                                          - port
-                                                          type: object
-                                                      type: object
-                                                  type: object
-                                                livenessProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                name:
-                                                  type: string
-                                                ports:
-                                                  items:
-                                                    properties:
-                                                      containerPort:
-                                                        format: int32
-                                                        type: integer
-                                                      hostIP:
-                                                        type: string
-                                                      hostPort:
-                                                        format: int32
-                                                        type: integer
-                                                      name:
-                                                        type: string
-                                                      protocol:
-                                                        type: string
-                                                    required:
-                                                    - containerPort
-                                                    type: object
-                                                  type: array
-                                                readinessProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                resources:
-                                                  type: object
-                                                securityContext:
-                                                  properties:
-                                                    allowPrivilegeEscalation:
-                                                      type: boolean
-                                                    capabilities:
-                                                      properties:
-                                                        add:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        drop:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    privileged:
-                                                      type: boolean
-                                                    procMount:
-                                                      type: string
-                                                    readOnlyRootFilesystem:
-                                                      type: boolean
-                                                    runAsGroup:
-                                                      format: int64
-                                                      type: integer
-                                                    runAsNonRoot:
-                                                      type: boolean
-                                                    runAsUser:
-                                                      format: int64
-                                                      type: integer
-                                                    seLinuxOptions:
-                                                      properties:
-                                                        level:
-                                                          type: string
-                                                        role:
-                                                          type: string
-                                                        type:
-                                                          type: string
-                                                        user:
-                                                          type: string
-                                                      type: object
-                                                    windowsOptions:
-                                                      properties:
-                                                        gmsaCredentialSpec:
-                                                          type: string
-                                                        gmsaCredentialSpecName:
-                                                          type: string
-                                                        runAsUserName:
-                                                          type: string
-                                                      type: object
-                                                  type: object
-                                                startupProbe:
-                                                  properties:
-                                                    exec:
-                                                      properties:
-                                                        command:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      type: object
-                                                    failureThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    httpGet:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        httpHeaders:
-                                                          items:
-                                                            properties:
-                                                              name:
-                                                                type: string
-                                                              value:
-                                                                type: string
-                                                            required:
-                                                            - name
-                                                            - value
-                                                            type: object
-                                                          type: array
-                                                        path:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                        scheme:
-                                                          type: string
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    initialDelaySeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    periodSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                    successThreshold:
-                                                      format: int32
-                                                      type: integer
-                                                    tcpSocket:
-                                                      properties:
-                                                        host:
-                                                          type: string
-                                                        port:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          x-kubernetes-int-or-string: true
-                                                      required:
-                                                      - port
-                                                      type: object
-                                                    timeoutSeconds:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
-                                                stdin:
-                                                  type: boolean
-                                                stdinOnce:
-                                                  type: boolean
-                                                terminationMessagePath:
-                                                  type: string
-                                                terminationMessagePolicy:
-                                                  type: string
-                                                tty:
-                                                  type: boolean
-                                                volumeDevices:
-                                                  items:
-                                                    properties:
-                                                      devicePath:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                    required:
-                                                    - devicePath
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                volumeMounts:
-                                                  items:
-                                                    properties:
-                                                      mountPath:
-                                                        type: string
-                                                      mountPropagation:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                      readOnly:
-                                                        type: boolean
-                                                      subPath:
-                                                        type: string
-                                                      subPathExpr:
-                                                        type: string
-                                                    required:
-                                                    - mountPath
-                                                    - name
-                                                    type: object
-                                                  type: array
-                                                workingDir:
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                            type: array
-                                          nodeName:
-                                            type: string
-                                          nodeSelector:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                          overhead:
-                                            additionalProperties:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          preemptionPolicy:
-                                            type: string
-                                          priority:
-                                            format: int32
-                                            type: integer
-                                          priorityClassName:
-                                            type: string
-                                          readinessGates:
-                                            items:
-                                              properties:
-                                                conditionType:
-                                                  type: string
-                                              required:
-                                              - conditionType
-                                              type: object
-                                            type: array
-                                          restartPolicy:
-                                            type: string
-                                          runtimeClassName:
-                                            type: string
-                                          schedulerName:
-                                            type: string
-                                          securityContext:
-                                            properties:
-                                              fsGroup:
-                                                format: int64
-                                                type: integer
-                                              fsGroupChangePolicy:
-                                                type: string
-                                              runAsGroup:
-                                                format: int64
-                                                type: integer
-                                              runAsNonRoot:
-                                                type: boolean
-                                              runAsUser:
-                                                format: int64
-                                                type: integer
-                                              seLinuxOptions:
-                                                properties:
-                                                  level:
-                                                    type: string
-                                                  role:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                  user:
-                                                    type: string
-                                                type: object
-                                              supplementalGroups:
-                                                items:
-                                                  format: int64
-                                                  type: integer
-                                                type: array
-                                              sysctls:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  - value
-                                                  type: object
-                                                type: array
-                                              windowsOptions:
-                                                properties:
-                                                  gmsaCredentialSpec:
-                                                    type: string
-                                                  gmsaCredentialSpecName:
-                                                    type: string
-                                                  runAsUserName:
-                                                    type: string
-                                                type: object
-                                            type: object
-                                          serviceAccount:
-                                            type: string
-                                          serviceAccountName:
-                                            type: string
-                                          shareProcessNamespace:
-                                            type: boolean
-                                          subdomain:
-                                            type: string
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          tolerations:
-                                            items:
-                                              properties:
-                                                effect:
-                                                  type: string
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                tolerationSeconds:
-                                                  format: int64
-                                                  type: integer
-                                                value:
-                                                  type: string
-                                              type: object
-                                            type: array
-                                          topologySpreadConstraints:
-                                            items:
-                                              properties:
-                                                labelSelector:
-                                                  properties:
-                                                    matchExpressions:
+                                                    nodeSelectorTerms:
                                                       items:
                                                         properties:
-                                                          key:
-                                                            type: string
-                                                          operator:
-                                                            type: string
-                                                          values:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
                                                             items:
                                                               type: string
                                                             type: array
+                                                          topologyKey:
+                                                            type: string
                                                         required:
-                                                        - key
-                                                        - operator
+                                                        - topologyKey
                                                         type: object
-                                                      type: array
-                                                    matchLabels:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                  type: object
-                                                maxSkew:
-                                                  format: int32
-                                                  type: integer
-                                                topologyKey:
-                                                  type: string
-                                                whenUnsatisfiable:
-                                                  type: string
-                                              required:
-                                              - maxSkew
-                                              - topologyKey
-                                              - whenUnsatisfiable
-                                              type: object
-                                            type: array
-                                          volumes:
-                                            items:
-                                              properties:
-                                                awsElasticBlockStore:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    partition:
-                                                      format: int32
-                                                      type: integer
-                                                    readOnly:
-                                                      type: boolean
-                                                    volumeID:
-                                                      type: string
-                                                  required:
-                                                  - volumeID
-                                                  type: object
-                                                azureDisk:
-                                                  properties:
-                                                    cachingMode:
-                                                      type: string
-                                                    diskName:
-                                                      type: string
-                                                    diskURI:
-                                                      type: string
-                                                    fsType:
-                                                      type: string
-                                                    kind:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                  required:
-                                                  - diskName
-                                                  - diskURI
-                                                  type: object
-                                                azureFile:
-                                                  properties:
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretName:
-                                                      type: string
-                                                    shareName:
-                                                      type: string
-                                                  required:
-                                                  - secretName
-                                                  - shareName
-                                                  type: object
-                                                cephfs:
-                                                  properties:
-                                                    monitors:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    path:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretFile:
-                                                      type: string
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    user:
-                                                      type: string
-                                                  required:
-                                                  - monitors
-                                                  type: object
-                                                cinder:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    volumeID:
-                                                      type: string
-                                                  required:
-                                                  - volumeID
-                                                  type: object
-                                                csi:
-                                                  properties:
-                                                    driver:
-                                                      type: string
-                                                    fsType:
-                                                      type: string
-                                                    nodePublishSecretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    readOnly:
-                                                      type: boolean
-                                                    volumeAttributes:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                  required:
-                                                  - driver
-                                                  type: object
-                                                emptyDir:
-                                                  properties:
-                                                    medium:
-                                                      type: string
-                                                    sizeLimit:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                  type: object
-                                                fc:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    lun:
-                                                      format: int32
-                                                      type: integer
-                                                    readOnly:
-                                                      type: boolean
-                                                    targetWWNs:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    wwids:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  type: object
-                                                flexVolume:
-                                                  properties:
-                                                    driver:
-                                                      type: string
-                                                    fsType:
-                                                      type: string
-                                                    options:
-                                                      additionalProperties:
-                                                        type: string
-                                                      type: object
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                  required:
-                                                  - driver
-                                                  type: object
-                                                flocker:
-                                                  properties:
-                                                    datasetName:
-                                                      type: string
-                                                    datasetUUID:
-                                                      type: string
-                                                  type: object
-                                                gcePersistentDisk:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    partition:
-                                                      format: int32
-                                                      type: integer
-                                                    pdName:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                  required:
-                                                  - pdName
-                                                  type: object
-                                                gitRepo:
-                                                  properties:
-                                                    directory:
-                                                      type: string
-                                                    repository:
-                                                      type: string
-                                                    revision:
-                                                      type: string
-                                                  required:
-                                                  - repository
-                                                  type: object
-                                                glusterfs:
-                                                  properties:
-                                                    endpoints:
-                                                      type: string
-                                                    path:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                  required:
-                                                  - endpoints
-                                                  - path
-                                                  type: object
-                                                hostPath:
-                                                  properties:
-                                                    path:
-                                                      type: string
-                                                    type:
-                                                      type: string
-                                                  required:
-                                                  - path
-                                                  type: object
-                                                iscsi:
-                                                  properties:
-                                                    chapAuthDiscovery:
-                                                      type: boolean
-                                                    chapAuthSession:
-                                                      type: boolean
-                                                    fsType:
-                                                      type: string
-                                                    initiatorName:
-                                                      type: string
-                                                    iqn:
-                                                      type: string
-                                                    iscsiInterface:
-                                                      type: string
-                                                    lun:
-                                                      format: int32
-                                                      type: integer
-                                                    portals:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    targetPortal:
-                                                      type: string
-                                                  required:
-                                                  - iqn
-                                                  - lun
-                                                  - targetPortal
-                                                  type: object
-                                                name:
-                                                  type: string
-                                                nfs:
-                                                  properties:
-                                                    path:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    server:
-                                                      type: string
-                                                  required:
-                                                  - path
-                                                  - server
-                                                  type: object
-                                                persistentVolumeClaim:
-                                                  properties:
-                                                    claimName:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                  required:
-                                                  - claimName
-                                                  type: object
-                                                photonPersistentDisk:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    pdID:
-                                                      type: string
-                                                  required:
-                                                  - pdID
-                                                  type: object
-                                                portworxVolume:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    volumeID:
-                                                      type: string
-                                                  required:
-                                                  - volumeID
-                                                  type: object
-                                                projected:
-                                                  properties:
-                                                    defaultMode:
-                                                      format: int32
-                                                      type: integer
-                                                    sources:
-                                                      items:
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
                                                         properties:
-                                                          serviceAccountToken:
-                                                            properties:
-                                                              audience:
-                                                                type: string
-                                                              expirationSeconds:
-                                                                format: int64
-                                                                type: integer
-                                                              path:
-                                                                type: string
-                                                            required:
-                                                            - path
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             type: object
                                                         type: object
-                                                      type: array
-                                                  required:
-                                                  - sources
-                                                  type: object
-                                                quobyte:
-                                                  properties:
-                                                    group:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    registry:
-                                                      type: string
-                                                    tenant:
-                                                      type: string
-                                                    user:
-                                                      type: string
-                                                    volume:
-                                                      type: string
-                                                  required:
-                                                  - registry
-                                                  - volume
-                                                  type: object
-                                                rbd:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    image:
-                                                      type: string
-                                                    keyring:
-                                                      type: string
-                                                    monitors:
-                                                      items:
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
                                                         type: string
-                                                      type: array
-                                                    pool:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    user:
-                                                      type: string
-                                                  required:
-                                                  - image
-                                                  - monitors
-                                                  type: object
-                                                scaleIO:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    gateway:
-                                                      type: string
-                                                    protectionDomain:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    sslEnabled:
-                                                      type: boolean
-                                                    storageMode:
-                                                      type: string
-                                                    storagePool:
-                                                      type: string
-                                                    system:
-                                                      type: string
-                                                    volumeName:
-                                                      type: string
-                                                  required:
-                                                  - gateway
-                                                  - secretRef
-                                                  - system
-                                                  type: object
-                                                storageos:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    readOnly:
-                                                      type: boolean
-                                                    secretRef:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                      type: object
-                                                    volumeName:
-                                                      type: string
-                                                    volumeNamespace:
-                                                      type: string
-                                                  type: object
-                                                vsphereVolume:
-                                                  properties:
-                                                    fsType:
-                                                      type: string
-                                                    storagePolicyID:
-                                                      type: string
-                                                    storagePolicyName:
-                                                      type: string
-                                                    volumePath:
-                                                      type: string
-                                                  required:
-                                                  - volumePath
-                                                  type: object
-                                              required:
-                                              - name
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
                                               type: object
-                                            type: array
-                                        required:
-                                        - containers
-                                        type: object
-                                    type: object
-                                  ttlSecondsAfterFinished:
-                                    format: int32
-                                    type: integer
-                                required:
-                                - template
-                                type: object
-                            required:
-                            - spec
-                            type: object
-                          kayenta:
-                            properties:
-                              address:
-                                type: string
-                              application:
-                                type: string
-                              canaryConfigName:
-                                type: string
-                              configurationAccountName:
-                                type: string
-                              metricsAccountName:
-                                type: string
-                              scopes:
-                                items:
-                                  properties:
-                                    controlScope:
-                                      properties:
-                                        end:
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        dnsPolicy:
                                           type: string
-                                        region:
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              ip:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostname:
                                           type: string
-                                        scope:
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resources:
+                                                type: object
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        nodeName:
                                           type: string
-                                        start:
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
                                           type: string
-                                        step:
+                                        priority:
+                                          format: int32
                                           type: integer
-                                      required:
-                                      - end
-                                      - region
-                                      - scope
-                                      - start
-                                      - step
-                                      type: object
-                                    experimentScope:
-                                      properties:
-                                        end:
+                                        priorityClassName:
                                           type: string
-                                        region:
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                        restartPolicy:
                                           type: string
-                                        scope:
+                                        runtimeClassName:
                                           type: string
-                                        start:
+                                        schedulerName:
                                           type: string
-                                        step:
+                                        securityContext:
+                                          properties:
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
                                           type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                        volumes:
+                                          items:
+                                            properties:
+                                              awsElasticBlockStore:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  partition:
+                                                    format: int32
+                                                    type: integer
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              azureDisk:
+                                                properties:
+                                                  cachingMode:
+                                                    type: string
+                                                  diskName:
+                                                    type: string
+                                                  diskURI:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - diskName
+                                                - diskURI
+                                                type: object
+                                              azureFile:
+                                                properties:
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretName:
+                                                    type: string
+                                                  shareName:
+                                                    type: string
+                                                required:
+                                                - secretName
+                                                - shareName
+                                                type: object
+                                              cephfs:
+                                                properties:
+                                                  monitors:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretFile:
+                                                    type: string
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  user:
+                                                    type: string
+                                                required:
+                                                - monitors
+                                                type: object
+                                              cinder:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              csi:
+                                                properties:
+                                                  driver:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  nodePublishSecretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeAttributes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - driver
+                                                type: object
+                                              emptyDir:
+                                                properties:
+                                                  medium:
+                                                    type: string
+                                                  sizeLimit:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                              ephemeral:
+                                                properties:
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeClaimTemplate:
+                                                    properties:
+                                                      metadata:
+                                                        type: object
+                                                      spec:
+                                                        properties:
+                                                          accessModes:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          dataSource:
+                                                            properties:
+                                                              apiGroup:
+                                                                type: string
+                                                              kind:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                            required:
+                                                            - kind
+                                                            - name
+                                                            type: object
+                                                          resources:
+                                                            properties:
+                                                              limits:
+                                                                additionalProperties:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                type: object
+                                                              requests:
+                                                                additionalProperties:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                type: object
+                                                            type: object
+                                                          selector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          storageClassName:
+                                                            type: string
+                                                          volumeMode:
+                                                            type: string
+                                                          volumeName:
+                                                            type: string
+                                                        type: object
+                                                    required:
+                                                    - spec
+                                                    type: object
+                                                type: object
+                                              fc:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  lun:
+                                                    format: int32
+                                                    type: integer
+                                                  readOnly:
+                                                    type: boolean
+                                                  targetWWNs:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  wwids:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              flexVolume:
+                                                properties:
+                                                  driver:
+                                                    type: string
+                                                  fsType:
+                                                    type: string
+                                                  options:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                required:
+                                                - driver
+                                                type: object
+                                              flocker:
+                                                properties:
+                                                  datasetName:
+                                                    type: string
+                                                  datasetUUID:
+                                                    type: string
+                                                type: object
+                                              gcePersistentDisk:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  partition:
+                                                    format: int32
+                                                    type: integer
+                                                  pdName:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - pdName
+                                                type: object
+                                              gitRepo:
+                                                properties:
+                                                  directory:
+                                                    type: string
+                                                  repository:
+                                                    type: string
+                                                  revision:
+                                                    type: string
+                                                required:
+                                                - repository
+                                                type: object
+                                              glusterfs:
+                                                properties:
+                                                  endpoints:
+                                                    type: string
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - endpoints
+                                                - path
+                                                type: object
+                                              hostPath:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              iscsi:
+                                                properties:
+                                                  chapAuthDiscovery:
+                                                    type: boolean
+                                                  chapAuthSession:
+                                                    type: boolean
+                                                  fsType:
+                                                    type: string
+                                                  initiatorName:
+                                                    type: string
+                                                  iqn:
+                                                    type: string
+                                                  iscsiInterface:
+                                                    type: string
+                                                  lun:
+                                                    format: int32
+                                                    type: integer
+                                                  portals:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  targetPortal:
+                                                    type: string
+                                                required:
+                                                - iqn
+                                                - lun
+                                                - targetPortal
+                                                type: object
+                                              name:
+                                                type: string
+                                              nfs:
+                                                properties:
+                                                  path:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  server:
+                                                    type: string
+                                                required:
+                                                - path
+                                                - server
+                                                type: object
+                                              persistentVolumeClaim:
+                                                properties:
+                                                  claimName:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                required:
+                                                - claimName
+                                                type: object
+                                              photonPersistentDisk:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  pdID:
+                                                    type: string
+                                                required:
+                                                - pdID
+                                                type: object
+                                              portworxVolume:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeID:
+                                                    type: string
+                                                required:
+                                                - volumeID
+                                                type: object
+                                              projected:
+                                                properties:
+                                                  defaultMode:
+                                                    format: int32
+                                                    type: integer
+                                                  sources:
+                                                    items:
+                                                      properties:
+                                                        serviceAccountToken:
+                                                          properties:
+                                                            audience:
+                                                              type: string
+                                                            expirationSeconds:
+                                                              format: int64
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - sources
+                                                type: object
+                                              quobyte:
+                                                properties:
+                                                  group:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  registry:
+                                                    type: string
+                                                  tenant:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                  volume:
+                                                    type: string
+                                                required:
+                                                - registry
+                                                - volume
+                                                type: object
+                                              rbd:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  image:
+                                                    type: string
+                                                  keyring:
+                                                    type: string
+                                                  monitors:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  pool:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  user:
+                                                    type: string
+                                                required:
+                                                - image
+                                                - monitors
+                                                type: object
+                                              scaleIO:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  gateway:
+                                                    type: string
+                                                  protectionDomain:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  sslEnabled:
+                                                    type: boolean
+                                                  storageMode:
+                                                    type: string
+                                                  storagePool:
+                                                    type: string
+                                                  system:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - gateway
+                                                - secretRef
+                                                - system
+                                                type: object
+                                              storageos:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  secretRef:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  volumeName:
+                                                    type: string
+                                                  volumeNamespace:
+                                                    type: string
+                                                type: object
+                                              vsphereVolume:
+                                                properties:
+                                                  fsType:
+                                                    type: string
+                                                  storagePolicyID:
+                                                    type: string
+                                                  storagePolicyName:
+                                                    type: string
+                                                  volumePath:
+                                                    type: string
+                                                required:
+                                                - volumePath
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
                                       required:
-                                      - end
-                                      - region
-                                      - scope
-                                      - start
-                                      - step
+                                      - containers
                                       type: object
-                                    name:
-                                      type: string
-                                  required:
-                                  - controlScope
-                                  - experimentScope
-                                  - name
                                   type: object
-                                type: array
-                              storageAccountName:
-                                type: string
-                              threshold:
-                                properties:
-                                  marginal:
-                                    type: integer
-                                  pass:
-                                    type: integer
-                                required:
-                                - marginal
-                                - pass
-                                type: object
-                            required:
-                            - address
-                            - application
-                            - canaryConfigName
-                            - configurationAccountName
-                            - metricsAccountName
-                            - scopes
-                            - storageAccountName
-                            - threshold
-                            type: object
-                          newRelic:
-                            properties:
-                              profile:
-                                type: string
-                              query:
-                                type: string
-                            required:
-                            - query
-                            type: object
-                          prometheus:
-                            properties:
-                              address:
-                                type: string
-                              query:
-                                type: string
-                            type: object
-                          wavefront:
-                            properties:
-                              address:
-                                type: string
-                              query:
-                                type: string
-                            type: object
-                          web:
-                            properties:
-                              headers:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - key
-                                  - value
-                                  type: object
-                                type: array
-                              insecure:
-                                type: boolean
-                              jsonPath:
-                                type: string
-                              timeoutSeconds:
-                                type: integer
-                              url:
-                                type: string
-                            required:
-                            - url
-                            type: object
-                        type: object
-                      successCondition:
-                        type: string
-                    required:
-                    - name
-                    - provider
-                    type: object
-                  type: array
-                terminate:
-                  type: boolean
-              required:
-              - metrics
-              type: object
-            status:
-              properties:
-                message:
-                  type: string
-                metricResults:
-                  items:
-                    properties:
-                      consecutiveError:
-                        format: int32
-                        type: integer
-                      count:
-                        format: int32
-                        type: integer
-                      error:
-                        format: int32
-                        type: integer
-                      failed:
-                        format: int32
-                        type: integer
-                      inconclusive:
-                        format: int32
-                        type: integer
-                      measurements:
-                        items:
-                          properties:
-                            finishedAt:
-                              format: date-time
-                              type: string
-                            message:
-                              type: string
-                            metadata:
-                              additionalProperties:
-                                type: string
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
                               type: object
-                            phase:
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
                               type: string
-                            resumeAt:
-                              format: date-time
+                            application:
                               type: string
-                            startedAt:
-                              format: date-time
+                            canaryConfigName:
                               type: string
-                            value:
+                            configurationAccountName:
+                              type: string
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        type: integer
+                                    required:
+                                    - end
+                                    - region
+                                    - scope
+                                    - start
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  type: integer
+                                pass:
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
                               type: string
                           required:
-                          - phase
+                          - query
                           type: object
-                        type: array
-                      message:
-                        type: string
-                      name:
-                        type: string
-                      phase:
-                        type: string
-                      successful:
-                        format: int32
-                        type: integer
-                    required:
-                    - name
-                    - phase
-                    type: object
-                  type: array
-                phase:
-                  type: string
-                startedAt:
-                  format: date-time
-                  type: string
-              required:
-              - phase
-              type: object
-          required:
-          - spec
-          type: object
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonPath:
+                              type: string
+                            timeoutSeconds:
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+              terminate:
+                type: boolean
+            required:
+            - metrics
+            type: object
+          status:
+            properties:
+              message:
+                type: string
+              metricResults:
+                items:
+                  properties:
+                    consecutiveError:
+                      format: int32
+                      type: integer
+                    count:
+                      format: int32
+                      type: integer
+                    error:
+                      format: int32
+                      type: integer
+                    failed:
+                      format: int32
+                      type: integer
+                    inconclusive:
+                      format: int32
+                      type: integer
+                    measurements:
+                      items:
+                        properties:
+                          finishedAt:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          phase:
+                            type: string
+                          resumeAt:
+                            format: date-time
+                            type: string
+                          startedAt:
+                            format: date-time
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - phase
+                        type: object
+                      type: array
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                    successful:
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+              phase:
+                type: string
+              startedAt:
+                format: date-time
+                type: string
+            required:
+            - phase
+            type: object
+        required:
+        - spec
+        type: object
 {{- end }}

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -65,19 +65,27 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     count:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     failureCondition:
                       type: string
                     failureLimit:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     inconclusiveLimit:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     initialDelay:
                       type: string
                     interval:
@@ -821,6 +829,15 @@ spec:
                                                       user:
                                                         type: string
                                                     type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   windowsOptions:
                                                     properties:
                                                       gmsaCredentialSpec:
@@ -1359,6 +1376,15 @@ spec:
                                                         type: string
                                                       user:
                                                         type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
                                                     type: object
                                                   windowsOptions:
                                                     properties:
@@ -1903,6 +1929,15 @@ spec:
                                                       user:
                                                         type: string
                                                     type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   windowsOptions:
                                                     properties:
                                                       gmsaCredentialSpec:
@@ -2088,6 +2123,15 @@ spec:
                                                 user:
                                                   type: string
                                               type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             supplementalGroups:
                                               items:
                                                 format: int64
@@ -2119,6 +2163,8 @@ spec:
                                           type: string
                                         serviceAccountName:
                                           type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
                                         shareProcessNamespace:
                                           type: boolean
                                         subdomain:
@@ -2296,6 +2342,85 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
+                                                type: object
+                                              ephemeral:
+                                                properties:
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeClaimTemplate:
+                                                    properties:
+                                                      metadata:
+                                                        type: object
+                                                      spec:
+                                                        properties:
+                                                          accessModes:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          dataSource:
+                                                            properties:
+                                                              apiGroup:
+                                                                type: string
+                                                              kind:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                            required:
+                                                            - kind
+                                                            - name
+                                                            type: object
+                                                          resources:
+                                                            properties:
+                                                              limits:
+                                                                additionalProperties:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                type: object
+                                                              requests:
+                                                                additionalProperties:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                type: object
+                                                            type: object
+                                                          selector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          storageClassName:
+                                                            type: string
+                                                          volumeMode:
+                                                            type: string
+                                                          volumeName:
+                                                            type: string
+                                                        type: object
+                                                    required:
+                                                    - spec
+                                                    type: object
                                                 type: object
                                               fc:
                                                 properties:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -65,19 +65,27 @@ spec:
                 items:
                   properties:
                     consecutiveErrorLimit:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     count:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     failureCondition:
                       type: string
                     failureLimit:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     inconclusiveLimit:
-                      format: int32
-                      type: integer
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
                     initialDelay:
                       type: string
                     interval:
@@ -821,6 +829,15 @@ spec:
                                                       user:
                                                         type: string
                                                     type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   windowsOptions:
                                                     properties:
                                                       gmsaCredentialSpec:
@@ -1359,6 +1376,15 @@ spec:
                                                         type: string
                                                       user:
                                                         type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
                                                     type: object
                                                   windowsOptions:
                                                     properties:
@@ -1903,6 +1929,15 @@ spec:
                                                       user:
                                                         type: string
                                                     type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   windowsOptions:
                                                     properties:
                                                       gmsaCredentialSpec:
@@ -2088,6 +2123,15 @@ spec:
                                                 user:
                                                   type: string
                                               type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             supplementalGroups:
                                               items:
                                                 format: int64
@@ -2119,6 +2163,8 @@ spec:
                                           type: string
                                         serviceAccountName:
                                           type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
                                         shareProcessNamespace:
                                           type: boolean
                                         subdomain:
@@ -2296,6 +2342,85 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
+                                                type: object
+                                              ephemeral:
+                                                properties:
+                                                  readOnly:
+                                                    type: boolean
+                                                  volumeClaimTemplate:
+                                                    properties:
+                                                      metadata:
+                                                        type: object
+                                                      spec:
+                                                        properties:
+                                                          accessModes:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                          dataSource:
+                                                            properties:
+                                                              apiGroup:
+                                                                type: string
+                                                              kind:
+                                                                type: string
+                                                              name:
+                                                                type: string
+                                                            required:
+                                                            - kind
+                                                            - name
+                                                            type: object
+                                                          resources:
+                                                            properties:
+                                                              limits:
+                                                                additionalProperties:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                type: object
+                                                              requests:
+                                                                additionalProperties:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                type: object
+                                                            type: object
+                                                          selector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                          storageClassName:
+                                                            type: string
+                                                          volumeMode:
+                                                            type: string
+                                                          volumeName:
+                                                            type: string
+                                                        type: object
+                                                    required:
+                                                    - spec
+                                                    type: object
                                                 type: object
                                               fc:
                                                 properties:

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -97,6 +97,17 @@ spec:
                 properties:
                   blueGreen:
                     properties:
+                      activeMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
                       activeService:
                         type: string
                       antiAffinity:
@@ -117,6 +128,11 @@ spec:
                       autoPromotionSeconds:
                         format: int32
                         type: integer
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
                       postPromotionAnalysis:
                         properties:
                           args:
@@ -194,6 +210,17 @@ spec:
                                   type: string
                               type: object
                             type: array
+                        type: object
+                      previewMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
                         type: object
                       previewReplicaCount:
                         format: int32
@@ -482,6 +509,19 @@ spec:
                             type: object
                           istio:
                             properties:
+                              destinationRule:
+                                properties:
+                                  canarySubsetName:
+                                    type: string
+                                  name:
+                                    type: string
+                                  stableSubsetName:
+                                    type: string
+                                required:
+                                - canarySubsetName
+                                - name
+                                - stableSubsetName
+                                type: object
                               virtualService:
                                 properties:
                                   name:
@@ -1194,6 +1234,15 @@ spec:
                                     user:
                                       type: string
                                   type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 windowsOptions:
                                   properties:
                                     gmsaCredentialSpec:
@@ -1732,6 +1781,15 @@ spec:
                                       type: string
                                     user:
                                       type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
                                   type: object
                                 windowsOptions:
                                   properties:
@@ -2276,6 +2334,15 @@ spec:
                                     user:
                                       type: string
                                   type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 windowsOptions:
                                   properties:
                                     gmsaCredentialSpec:
@@ -2461,6 +2528,15 @@ spec:
                               user:
                                 type: string
                             type: object
+                          seccompProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
                           supplementalGroups:
                             items:
                               format: int64
@@ -2492,6 +2568,8 @@ spec:
                         type: string
                       serviceAccountName:
                         type: string
+                      setHostnameAsFQDN:
+                        type: boolean
                       shareProcessNamespace:
                         type: boolean
                       subdomain:
@@ -2639,6 +2717,31 @@ spec:
                               required:
                               - volumeID
                               type: object
+                            configMap:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
                             csi:
                               properties:
                                 driver:
@@ -2659,6 +2762,44 @@ spec:
                               required:
                               - driver
                               type: object
+                            downwardAPI:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            type: string
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
                             emptyDir:
                               properties:
                                 medium:
@@ -2669,6 +2810,85 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                volumeClaimTemplate:
+                                  properties:
+                                    metadata:
+                                      type: object
+                                    spec:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
                               type: object
                             fc:
                               properties:
@@ -2847,6 +3067,85 @@ spec:
                                 sources:
                                   items:
                                     properties:
+                                      configMap:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      type: string
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        properties:
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
                                       serviceAccountToken:
                                         properties:
                                           audience:
@@ -2938,6 +3237,31 @@ spec:
                               - gateway
                               - secretRef
                               - system
+                              type: object
+                            secret:
+                              properties:
+                                defaultMode:
+                                  format: int32
+                                  type: integer
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
                               type: object
                             storageos:
                               properties:


### PR DESCRIPTION
This Pull request updates the cdr schemas to the current version. It also adds back properties removed from the manifest in https://github.com/argoproj/argo-rollouts/pull/114/files since the validation fails if they are missing on the current API extensions version.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
