### PR TITLE
adopt wework clusters

### DIFF
--- a/charts/argo-cd/.helmignore
+++ b/charts/argo-cd/.helmignore
@@ -1,2 +1,3 @@
-*.tgz
+*.swp
 output
+

--- a/charts/argo-cd/crds/crd-application.yaml
+++ b/charts/argo-cd/crds/crd-application.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/charts/argo-cd/crds/crd-project.yaml
+++ b/charts/argo-cd/crds/crd-project.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:

--- a/charts/argo-cd/requirements.lock
+++ b/charts/argo-cd/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
-  repository: https://dandydeveloper.github.io/charts/
+  repository: acr://wework-chart.cn-shanghai.cr.aliyuncs.com/wework/argo
   version: 4.10.1
-digest: sha256:e1e0526ad009ecc065df937b48c4e0e5877e5194242c7888b1dc4467775f2663
-generated: "2020-12-14T14:00:30.830130403+01:00"
+digest: sha256:03fee5b240534c3033b61bfd349fdec8d83b94545de373b1be800f833f9a622f
+generated: "2021-02-23T14:41:18.630567+08:00"

--- a/charts/argo-cd/requirements.yaml
+++ b/charts/argo-cd/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: redis-ha
   version: 4.10.1
-  repository: https://dandydeveloper.github.io/charts/
+  repository: acr://wework-chart.cn-shanghai.cr.aliyuncs.com/wework/argo
   condition: redis-ha.enabled


### PR DESCRIPTION
the following are the changes that this PR means to be:

- `v1.14.8-aliyun.1` doesn't support `apiextensions.k8s.io/v1`
- Moving these Helm charts to Alicloud:
  ```shell
  helm dependency update
  helm push ./ alicloud-repo
  ```
