### PR TITLE
fix(argo): Restore cluster template role binding to be ClusterRoleBinding.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.2
+version: 0.16.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-crb.yaml
+++ b/charts/argo/templates/workflow-controller-crb.yaml
@@ -31,20 +31,12 @@ subjects:
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: RoleBinding
-{{ else }}
 kind: ClusterRoleBinding
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.singleNamespace }}
-  kind: Role
-  {{ else }}
   kind: ClusterRole
-  {{- end }}
   name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
#530 changed the `cluster-template` `ClusterRoleBinding`s into namespace-scoped `RoleBinding`s when `singleNamespace` is set in values. That change is incorrect as the `cluster-template` role grants permissions on cluster-scoped objects, and binding it with a namespace scoped `RoleBinding` will _not_ grant the subjects the expected permissions. This binding has to be `ClusterRoleBinding`.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
