### PR TITLE
fix(argo): Restore server cluster-template to be a ClusterRoleBinding.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.3
+version: 0.16.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -111,11 +111,7 @@ rules:
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-{{ .Values.server.name }}-cluster-template
 rules:

--- a/charts/argo/templates/server-crb.yaml
+++ b/charts/argo/templates/server-crb.yaml
@@ -26,11 +26,7 @@ metadata:
   name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.singleNamespace }}
-  kind: Role
-  {{ else }}
   kind: ClusterRole
-  {{- end }}
   name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
 subjects:
 - kind: ServiceAccount

--- a/charts/argo/templates/server-crb.yaml
+++ b/charts/argo/templates/server-crb.yaml
@@ -21,11 +21,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: RoleBinding
-{{ else }}
 kind: ClusterRoleBinding
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
 roleRef:

--- a/charts/argo/templates/workflow-controller-cluster-roles.yaml
+++ b/charts/argo/templates/workflow-controller-cluster-roles.yaml
@@ -131,11 +131,7 @@ rules:
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
 rules:


### PR DESCRIPTION
This is a followup on #593, as the server role binding needs to be cluster scope as well. Thanks to @stefansedich for the catch.

Signed-off-by: Vlad Losev <vladimir.losev@sage.com>

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
