### PR TITLE
fix(argo): @vladlosev Restores aggregated roles to be ClusterRoles.

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.4
+version: 0.16.5
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.createAggregateRoles }}
-apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: Role
-{{ else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   annotations:
     helm.sh/hook: pre-install
@@ -30,11 +25,7 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: Role
-{{ else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   annotations:
     helm.sh/hook: pre-install
@@ -65,11 +56,7 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: Role
-{{ else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   annotations:
     helm.sh/hook: pre-install


### PR DESCRIPTION
The aggregateable roles need to be `ClusterRoles`, per the Kubernetes [docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
