### PR TITLE
add crds dir to .helmignore

### DIFF
--- a/charts/argo-events/.helmignore
+++ b/charts/argo-events/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# Custom Resource Definitions for manual creation only
+crds/

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.2.3
+version: 1.2.4
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo/.helmignore
+++ b/charts/argo/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# Custom Resource Definitions for manual creation only
+crds/

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.5
+version: 0.16.6
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:


### PR DESCRIPTION
The CRDs in the `./crds` directory were still being created even when the `installCRD` value was set to false. This is now fixed in the `argo` and `argo-events` charts.

I also found another bug while I testing for this change, which was a missing `apiVersion` line in the `argo/templates/workflow-aggregate-roles.yaml` template.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
