### PR TITLE
Missing ClusterRole apiVersion in aggregate roles

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.5
+version: 0.16.6
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:


### PR DESCRIPTION
Missing `apiVersion` for ClusterRole in aggregate roles causes deployment to fail in k8s >= v1.19.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
