### PR TITLE
fix(argo-events): spec.versions.schema Required for argo-events crds

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.2.3
+version: 1.2.4
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/crds/eventbus-crd.yml
+++ b/charts/argo-events/crds/eventbus-crd.yml
@@ -18,5 +18,23 @@ spec:
       served: true
       storage: true
       schema:
-          openAPIV3Schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
               type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+          - metadata
+          - spec
+          type: object
+      subresources:
+        status: {}

--- a/charts/argo-events/crds/eventbus-crd.yml
+++ b/charts/argo-events/crds/eventbus-crd.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -16,3 +17,6 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      schema:
+          openAPIV3Schema:
+              type: object

--- a/charts/argo-events/crds/eventsource-crd.yml
+++ b/charts/argo-events/crds/eventsource-crd.yml
@@ -18,5 +18,23 @@ spec:
       served: true
       storage: true
       schema:
-          openAPIV3Schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
               type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+          - metadata
+          - spec
+          type: object
+      subresources:
+        status: {}

--- a/charts/argo-events/crds/eventsource-crd.yml
+++ b/charts/argo-events/crds/eventsource-crd.yml
@@ -17,5 +17,6 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-
-
+      schema:
+          openAPIV3Schema:
+              type: object

--- a/charts/argo-events/crds/sensor-crd.yml
+++ b/charts/argo-events/crds/sensor-crd.yml
@@ -17,4 +17,6 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-
+      schema:
+          openAPIV3Schema:
+              type: object

--- a/charts/argo-events/crds/sensor-crd.yml
+++ b/charts/argo-events/crds/sensor-crd.yml
@@ -18,5 +18,23 @@ spec:
       served: true
       storage: true
       schema:
-          openAPIV3Schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
               type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+          - metadata
+          - spec
+          type: object
+      subresources:
+        status: {}

--- a/charts/argo-events/templates/eventbus-crd.yaml
+++ b/charts/argo-events/templates/eventbus-crd.yaml
@@ -20,4 +20,25 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+          - metadata
+          - spec
+          type: object
+      subresources:
+        status: {}
 {{- end }}

--- a/charts/argo-events/templates/eventsource-crd.yaml
+++ b/charts/argo-events/templates/eventsource-crd.yaml
@@ -20,4 +20,25 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+          - metadata
+          - spec
+          type: object
+      subresources:
+        status: {}
 {{- end }}

--- a/charts/argo-events/templates/sensor-crd.yaml
+++ b/charts/argo-events/templates/sensor-crd.yaml
@@ -21,4 +21,25 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          required:
+          - metadata
+          - spec
+          type: object
+      subresources:
+        status: {}
 {{- end }}


### PR DESCRIPTION
This is to fix the issue which I raised here: https://github.com/argoproj/argo-helm/issues/599

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
