### PR TITLE
fix(argo-cd): Changed jwtTokensByRole type of AppProject CRD status field.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.14.7
+version: 2.14.8
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/crds/crd-project.yaml
+++ b/charts/argo-cd/crds/crd-project.yaml
@@ -243,7 +243,7 @@ spec:
                         description: ID of the token
                         type: string
                     type: object
-                  type: array
+                  type: object
                 description: JWT Tokens issued for each of the roles in the project
                 type: object
             type: object


### PR DESCRIPTION
This fixes #584, introduced by #582, where the type of jwtTokensByRole.additionalProperties in status field should be **object** instead of **array**, causing updates of roles to fail.

Checklist:

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
