### PR TITLE
fix(argo-cd): Upgrade redis-ha to v4.10.4

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.14.8
+version: 2.14.9
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -333,7 +333,7 @@ through `xxx.extraArgs`
 | redis.securityContext | Redis Pod Security Context | See [values.yaml](values.yaml) |
 | redis.servicePort | Redis service port | `6379` |
 | redis.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
-| redis-ha | Configures [Redis HA subchart](https://github.com/helm/charts/tree/master/stable/redis-ha) The properties below have been changed from the subchart defaults | |
+| redis-ha | Configures [Redis HA subchart](https://github.com/DandyDeveloper/charts/tree/master/charts/redis-ha) The properties below have been changed from the subchart defaults | |
 | redis-ha.enabled | Enables the Redis HA subchart and disables the custom Redis single node deployment| `false` |
 | redis-ha.exporter.enabled | If `true`, the prometheus exporter sidecar is enabled | `true` |
 | redis-ha.persistentVolume.enabled | Configures persistency on Redis nodes | `false`

--- a/charts/argo-cd/requirements.lock
+++ b/charts/argo-cd/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.10.1
-digest: sha256:e1e0526ad009ecc065df937b48c4e0e5877e5194242c7888b1dc4467775f2663
-generated: "2020-12-14T14:00:30.830130403+01:00"
+  version: 4.10.4
+digest: sha256:e36321520ffd6f91962b0bcfeae947a86983d6b6d273eb616f08425e2b8ab9c2
+generated: "2021-03-03T10:13:21.0955491+01:00"

--- a/charts/argo-cd/requirements.yaml
+++ b/charts/argo-cd/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: redis-ha
-  version: 4.10.1
+  version: 4.10.4
   repository: https://dandydeveloper.github.io/charts/
   condition: redis-ha.enabled


### PR DESCRIPTION
This upgrades the redis-ha helm chart to v4.10.4 from v4.10.1.

Changelog: https://github.com/DandyDeveloper/charts/compare/9a334385...a83e96da

The main reason is to fix the kubernetes probes for redis.

We have been hit by an issue similar to https://github.com/bitnami/charts/issues/2441 where the liveness/readiness probes leave lots of zombie processes behind that eventually starve the system from threads and PIDs.
The timeout that wraps the redis-cli call is always left as defunc even though the probes actually succeed.

redis-ha v4.10.4 totally removed the timeout, while everything still works as expected.

The timeout was introduced in https://github.com/helm/charts/pull/11355 as a workaround for https://github.com/kubernetes/kubernetes/pull/58925 which has been fixed a long time ago.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
