### PR TITLE
fix(argo): add extraArgs to controller deployment

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.7
+version: 0.16.8
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.6
+version: 0.16.7
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/workflow-controller-deployment.yaml
+++ b/charts/argo/templates/workflow-controller-deployment.yaml
@@ -55,6 +55,9 @@ spec:
           - "--pod-workers"
           - {{ . | quote }}
           {{- end }}
+          {{- if .Values.controller.extraArgs }}
+          {{- toYaml .Values.controller.extraArgs | nindent 10 }}
+          {{- end }}
           env:
           - name: ARGO_NAMESPACE
             valueFrom:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -118,6 +118,8 @@ controller:
   # The list of environment variable definitions to be added to the controller
   # manages container verbatim.
   extraEnv: []
+  # Extra arguments to be added to the controller
+  extraArgs: []
   replicas: 1
   pdb:
     enabled: false


### PR DESCRIPTION
Hi,

this PR add support of extraArgs to controller deployment, for cases like this: https://github.com/argoproj/argo-workflows/blob/master/docs/managed-namespace.md (`--managed-namespace` flag)

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
