### PR TITLE
fix(argo-cd): appproject crd status tokens items

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.17.1
+version: 2.17.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/crds/crd-project.yaml
+++ b/charts/argo-cd/crds/crd-project.yaml
@@ -228,23 +228,28 @@ spec:
             description: Status of the AppProject
             properties:
               jwtTokensByRole:
-                additionalProperties:
-                  description: List of JWTToken objects for a given role
-                  items:
-                    description: Holds the issuedAt and expiresAt values of the token
-                    properties:
-                      exp:
-                        description: The expiresAt value of a token
-                        type: string
-                      iat:
-                        description: The issuedAt value of a token
-                        type: string
-                      id:
-                        description: ID of the token
-                        type: string
-                    type: object
-                  type: array
                 description: JWT Tokens issued for each of the roles in the project
+                additionalProperties:
+                  properties:
+                    items: 
+                      description: List of JWT Tokens issued for the role
+                      items: 
+                        description: Holds the issuedAt and expiresAt values of the token
+                        properties:
+                          exp:
+                            description: The expiresAt value of a token
+                            format: int64
+                            type: integer
+                          iat:
+                            description: The issuedAt value of a token
+                            format: int64
+                            type: integer
+                          id:
+                            description: ID of the token
+                            type: string
+                        type: object
+                      type: array
+                  type: object
                 type: object
             type: object
         required:


### PR DESCRIPTION
When creating a tokens, the respective metadata is not being keeped on the respective AppProject, this is happening due to the AppProject CRD not defining correctly the status.jwtTokensByRole object. This MR fixes it.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
