### PR TITLE
feat(argo-cd): prepare (dex) for readOnlyRootFilesystem

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.16.1
+version: 2.17.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -86,10 +86,12 @@ spec:
           containerPort: {{ .Values.dex.containerPortMetrics }}
           protocol: TCP
         {{- end }}
-{{- if .Values.dex.volumeMounts }}
         volumeMounts:
-{{- toYaml .Values.dex.volumeMounts | nindent 10 }}
-{{- end }}
+        - mountPath: /tmp
+          name: tmp-dir
+        {{- if .Values.dex.volumeMounts }}
+        {{- toYaml .Values.dex.volumeMounts | nindent 8 }}
+        {{- end }}
         resources:
 {{- toYaml .Values.dex.resources | nindent 10 }}
     {{- if .Values.dex.nodeSelector }}
@@ -105,10 +107,12 @@ spec:
 {{- toYaml .Values.dex.affinity | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "argo-cd.dexServiceAccountName" . }}
-{{- if .Values.dex.volumes }}
       volumes:
-{{- toYaml .Values.dex.volumes | nindent 8}}
-{{- end }}
+      - emptyDir: {}
+        name: tmp-dir
+      {{- if .Values.dex.volumes }}
+      {{- toYaml .Values.dex.volumes | nindent 6 }}
+      {{- end }}
 {{- if .Values.dex.priorityClassName }}
       priorityClassName: {{ .Values.dex.priorityClassName }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -75,6 +75,7 @@ controller:
     # capabilities:
     #   drop:
     #     - all
+    # readOnlyRootFilesystem: true
 
   ## Configures the controller port
   containerPort: 8082
@@ -254,6 +255,7 @@ dex:
     # capabilities:
     #   drop:
     #     - all
+    # readOnlyRootFilesystem: true
 
   resources: {}
   #  limits:
@@ -303,6 +305,7 @@ redis:
     # capabilities:
     #   drop:
     #     - all
+    # readOnlyRootFilesystem: true
 
   ## Redis Pod specific security context
   securityContext:
@@ -426,6 +429,7 @@ server:
     # capabilities:
     #   drop:
     #     - all
+    # readOnlyRootFilesystem: true
 
   resources: {}
   #  limits:
@@ -786,6 +790,7 @@ repoServer:
     # capabilities:
     #   drop:
     #     - all
+    # readOnlyRootFilesystem: true
 
   resources: {}
   #  limits:


### PR DESCRIPTION
While working on #619 and @davidkarlsen and @yann-soubeyrand commented that it would be nice, when all components use read-only root file systems. Until yesterday I didn't use dex at all for argo and therefore I missed this change here.
Dex also needs to write to `/tmp`:

```log
level=fatal msg="open /tmp/dex.yaml: read-only file system"
```
This also relates to this idea here: https://github.com/argoproj/argo-cd/issues/3648

Checklist:

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
