### PR TITLE
fix(argo): Fix argo-server webhook permission

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.7
+version: 0.16.8
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -75,6 +75,8 @@ rules:
   - events
   verbs:
   - watch
+  - create
+  - patch
 {{- if .Values.controller.persistence }}
 - apiGroups:
   - ""


### PR DESCRIPTION
argo-server permission has been fixed in https://github.com/argoproj/argo-workflows/pull/3929, not yet reflected in here.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
