### PR TITLE
fix(argo-events): Revert crd api version to v1beta1

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.2.3
+version: 1.2.4
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/crds/eventbus-crd.yml
+++ b/charts/argo-events/crds/eventbus-crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventbus.argoproj.io

--- a/charts/argo-events/crds/eventsource-crd.yml
+++ b/charts/argo-events/crds/eventsource-crd.yml
@@ -1,5 +1,4 @@
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io

--- a/charts/argo-events/crds/sensor-crd.yml
+++ b/charts/argo-events/crds/sensor-crd.yml
@@ -1,5 +1,4 @@
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

CRD version should be not changed to `v1` in the release of `v1.2.x`, the CRD definition doesn't work with `v1`, and the helm chart is actually not working currently.

It should be changed with release `v1.3.x`.

Checklist:

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
