### PR TITLE
fix(argo-cd): One occurrence of label templating was missing

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.17.3
+version: 2.17.4
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Selector labels
 {{- define "argo-cd.selectorLabels" -}}
 {{- if .name -}}
 app.kubernetes.io/name: {{ include "argo-cd.name" .context }}-{{ .name }}
-{{- end }}
+{{ end -}}
 app.kubernetes.io/instance: {{ .context.Release.Name }}
 {{- if .component }}
 app.kubernetes.io/component: {{ .component }}

--- a/charts/argo-cd/templates/redis/service.yaml
+++ b/charts/argo-cd/templates/redis/service.yaml
@@ -11,5 +11,5 @@ spec:
   - port: {{ .Values.redis.servicePort }}
     targetPort: {{ .Values.redis.servicePort }}
   selector:
-    app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.redis.name }}
+    {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.redis.name) | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Found a missing usage of the label templating function introduced in #627.

While here I also noticed, that the whitespace trimming could be improved with this:
```diff
--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Selector labels
 {{- define "argo-cd.selectorLabels" -}}
 {{- if .name -}}
 app.kubernetes.io/name: {{ include "argo-cd.name" .context }}-{{ .name }}
-{{- end }}
+{{ end -}}
 app.kubernetes.io/instance: {{ .context.Release.Name }}
 {{- if .component }}
 app.kubernetes.io/component: {{ .component }}
```
This is especially useful, when using the function without defining the `name` parameter. This resulted in an additional empty newline.

Checklist:

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
