### PR TITLE
feat(argo-cd): Add ability to handle cluster credentials

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.17.4
+version: 2.18.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -76,7 +76,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | global.hostAliases | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]` |
 | nameOverride | Provide a name in place of `argocd` | `"argocd"` |
 | installCRDs | Install CRDs if you are using Helm2. | `true` |
-| configs.clusterCredentials | [External Cluster Credentials](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters)| `[]` (See [values.yaml](values.yaml)) |
+| configs.clusterCredentials | Provide one or multiple [external cluster credentials](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters) | `[]` (See [values.yaml](values.yaml)) |
 | configs.knownHostsAnnotations | Known Hosts configmap annotations | `{}` |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
 | configs.secret.annotations | Annotations for argocd-secret | `{}` |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -76,6 +76,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | global.hostAliases | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]` |
 | nameOverride | Provide a name in place of `argocd` | `"argocd"` |
 | installCRDs | Install CRDs if you are using Helm2. | `true` |
+| configs.clusterCredentials | [External Cluster Credentials](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters)| `[]` (See [values.yaml](values.yaml)) |
 | configs.knownHostsAnnotations | Known Hosts configmap annotations | `{}` |
 | configs.knownHosts.data.ssh_known_hosts | Known Hosts | See [values.yaml](values.yaml) |
 | configs.secret.annotations | Annotations for argocd-secret | `{}` |

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -1,0 +1,23 @@
+{{- range .Values.configs.clusterCredentials }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "argo-cd.name" $ }}-cluster-{{ .name }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
+    argocd.argoproj.io/secret-type: cluster
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  name: {{ required "A valid .Values.configs.clusterCredentials[].name entry is required!" .name }}
+  server: {{ required "A valid .Values.configs.clusterCredentials[].server entry is required!" .server }}
+  {{- with .namespaces }}
+  namespaces: {{ . }}
+  {{- end }}
+  config: |
+    {{- required "A valid .Values.configs.clusterCredentials[].config entry is required!" .config | toPrettyJson | nindent 4 }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
-data:
+stringData:
   name: {{ required "A valid .Values.configs.clusterCredentials[].name entry is required!" .name }}
   server: {{ required "A valid .Values.configs.clusterCredentials[].server entry is required!" .server }}
   {{- with .namespaces }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -872,6 +872,29 @@ repoServer:
 
 ## Argo Configs
 configs:
+  ## External Cluster Credentials
+  ## reference:
+  ## - https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters
+  ## - https://argoproj.github.io/argo-cd/operator-manual/security/#external-cluster-credentials
+  clusterCredentials: []
+    # - name: mycluster
+    #   server: https://mycluster.com
+    #   annotations: {}
+    #   config:
+    #     bearerToken: "<authentication token>"
+    #     tlsClientConfig:
+    #       insecure: false
+    #       caData: "<base64 encoded certificate>"
+    # - name: mycluster2
+    #   server: https://mycluster2.com
+    #   annotations: {}
+    #   namespaces: namespace1,namespace2
+    #   config:
+    #     bearerToken: "<authentication token>"
+    #     tlsClientConfig:
+    #       insecure: false
+    #       caData: "<base64 encoded certificate>"
+
   knownHostsAnnotations: {}
   knownHosts:
     data:


### PR DESCRIPTION
I thought it would be a good idea to implement _External Cluster Credentials/Clusters_ from [Declarative Setup](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#clusters)


I was not sure, where to put the config in the values. (Also opened an issue here: https://github.com/argoproj/argo-helm/issues/631)

Checklist:

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the DCO and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
