### PR TITLE
fix(argo-cd): only exclude *.tgz in the top-level chart dir

### DIFF
--- a/charts/argo-cd/.helmignore
+++ b/charts/argo-cd/.helmignore
@@ -1,2 +1,2 @@
-*.tgz
+/*.tgz
 output

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 2.17.4
+version: 2.17.5
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:


### PR DESCRIPTION
This should fix #585:
```bash
$ helm dependency update
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://dandydeveloper.github.io/charts/" chart repository
(..)
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading redis-ha from repo https://dandydeveloper.github.io/charts/
Deleting outdated charts

$ helm template .
Error: found in Chart.yaml, but missing in charts/ directory: redis-ha
```

Ref:
- https://github.com/argoproj/argo-helm/issues/585
- https://helm.sh/docs/chart_template_guide/helm_ignore_file/

Is there a reason why you deleted this file completely two years ago, @jdeprin / @alexec? (https://github.com/argoproj/argo-helm/pull/129)

Checklist:

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed the DCO and the build is green.
* [X] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
