### PR TITLE
fix (argocd-notifications): Slack notification service is disabled in values.

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.1.1
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.1.2
+version: 1.1.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -60,8 +60,8 @@ extraEnv: []
 notifiers:
 # For more information: https://argocd-notifications.readthedocs.io/en/stable/services/overview/
 
-  service.slack: |
-    token: $slack-token
+  # service.slack: |
+  #   token: $slack-token
 
 podAnnotations: {}
 


### PR DESCRIPTION
Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
