### PR TITLE
feat(argo workflow): can configure ingress default path

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.7
+version: 0.17.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -2,6 +2,8 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := printf "%s-%s" .Release.Name .Values.server.name -}}
 {{- $servicePort := .Values.server.servicePort -}}
+{{- $paths := .Values.server.ingress.paths -}}
+{{- $extraPaths := .Values.server.ingress.extraPaths -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
@@ -23,24 +25,37 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- range .Values.server.ingress.hosts }}
-    - host: {{ . }}
+  {{- if .Values.server.ingress.hosts }}
+  {{- range $host := .Values.server.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          {{- if $.Values.server.ingress.paths }}
-          {{- range $.Values.server.ingress.paths }}
-          - backend:
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .servicePort }}
-          {{- end }}
-          {{- end }}
-          - backend:
+  {{- if $extraPaths }}
+  {{- toYaml $extraPaths | nindent 10 }}
+  {{- end }}
+  {{- range $p := $paths }}
+          - path: {{ $p }}
+            backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-    {{- end -}}
+  {{- end -}}
+  {{- end -}}
+  {{- else }}
+    - http:
+        paths:
+  {{- if $extraPaths }}
+  {{- toYaml $extraPaths | nindent 10 }}
+  {{- end }}
+  {{- range $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:
-{{ toYaml .Values.server.ingress.tls | indent 4 }}
+{{- toYaml .Values.server.ingress.tls | nindent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -219,7 +219,6 @@ server:
   ##
   ingress:
     enabled: false
-
     ## Annotations to be added to the web ingress.
     ##
     # annotations:
@@ -234,13 +233,16 @@ server:
     ## Hostnames.
     ## Must be provided if Ingress is enabled.
     ##
-    # hosts:
-    #   - argo.domain.com
-
+    hosts: []
+      # - argocd.example.com
+    paths:
+      - /
     ## Additional Paths for each host
-    # paths:
-    #   - serviceName: "ssl-redirect"
-    #     servicePort: "use-annotation"
+    extraPaths: []
+      # - path: /*
+      #   backend:
+      #     serviceName: ssl-redirect
+      #     servicePort: use-annotation
 
     ## TLS configuration.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
This implements #640 , based on what already exist for other argo charts (e.g. argo-cd)

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [x] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.
