### PR TITLE
chore: Update PR template to include notes on DCO

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,13 @@
+Note on DCO:
+
+If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
+
 Checklist:
 
 * [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
 * [ ] Any new values are backwards compatible and/or have sensible default.
 * [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
-* [ ] I have signed the CLA and the build is green.
-* [ ] I will test my changes again once merged to master and published.
+* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
+* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).
 
 Changes are automatically published when merged to `master`. They are not published on branches.


### PR DESCRIPTION
As I opened several PRs in the past, I wondered what CLA stands for. As described in the [project news](https://github.com/argoproj/argoproj#news), Argo Project has moved from the CLA to the DCO and this might be a leftover from that time:

> ## News
> 
> Argo Project is moving from CLA to DCO as a simpler way to track contributions.
> Argo Project has moved from the CLA to the DCO.
> * https://github.com/apps/dco/
> 
> Please start signing off your contributions by doing ONE of the following:
> Please signoff your contributions by doing ONE of the following:
> * Use `git commit -s ...` with each commit to add the signoff or
> * Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message.
> 
> The email address must match your primary GitHub email. You do NOT need cryptographic (e.g. gpg) signing.
> * Use `git commit -s --amend ...` to add a signoff to the latest commit, if you forgot.

Ref.:
- https://github.com/argoproj/argoproj/pull/24
- https://github.com/argoproj/argo-cd/pull/4966

Checklist:

* [X] ~I have updated the chart version in `Chart.yaml` following Semantic Versioning.~
* [X] ~Any new values are backwards compatible and/or have sensible default.~
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have **signed the CLA** and the **build is green**.
* [X] ~I will test my changes again once merged to master and published.~

Changes are automatically published when merged to `master`. They are not published on branches.
