### PR TITLE
make chart support env vars correctly.

### DIFF
--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -66,7 +66,10 @@ spec:
         {{- end }}
         {{- if .Values.server.env }}
         env:
-{{- toYaml .Values.server.env | nindent 8 }}
+        {{- range $key, $value := .Values.server.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
         {{- end }}
         volumeMounts:
         {{- if .Values.server.volumeMounts }}


### PR DESCRIPTION
I cannot see how server.env ever worked - so hard to make something backwards compatible here AFAIK ?
I COULD perhaps look if its an array - and IF so.. "do the old thing" ?
fixes #662 

Checklist:
* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
