### PR TITLE
feat(argo-workflows): added new argo-workflows chart and deprecated argo chart

### DIFF
--- a/charts/argo-workflows/.helmignore
+++ b/charts/argo-workflows/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Argo Workflows
 type: application
 version: 0.1.0
 appVersion: "v3.0.1"
-icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
+icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
   - https://github.com/argoproj/argo-workflows

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
 version: 0.1.0
-appVersion: "v3.0.1"
+appVersion: "v3.0.2"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,6 +3,7 @@ name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
 version: 0.1.0
+appVersion: "v3.0.1"
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,18 +1,14 @@
 apiVersion: v2
-appVersion: v2.12.5
+name: argo-workflows
 description: A Helm chart for Argo Workflows
-name: argo
-version: 0.16.10
+type: application
+version: 0.1.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
+sources:
+  - https://github.com/argoproj/argo-workflows
 maintainers:
   - name: alexec
   - name: alexmt
   - name: jessesuen
   - name: benjaminws
-dependencies:
-- name: minio
-  version: 8.0.9
-  repository: https://helm.min.io/
-  condition: minio.install
-deprecated: true

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -38,7 +38,6 @@ Fields to note:
      registry: quay.io
      repository: argoproj/argocli
      tag: v3.0.1
-     pullPolicy: IfNotPresent
    ```
 
    this also makes it easier for automatic update tooling (eg. renovate bot) to detect and update images.

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -44,3 +44,5 @@ Fields to note:
 
 1. switched to quay.io as the default registry for all images
 1. removed any included usage of Minio
+1. aligned the configuration of serviceAccounts with the argo-cd chart, ie: what used to be `server.createServiceAccount` is now `server.serviceAccount.create`
+1. moved the previously known as `telemetryServicePort` inside the `telemetryConfig` as `telemetryConfig.servicePort` - same for `metricsConfig`

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -1,0 +1,47 @@
+# Argo Workflows Chart
+
+This is a **community maintained** chart. It is used to set up argo and it's needed dependencies through one command. This is used in conjunction with [helm](https://github.com/kubernetes/helm).
+
+If you want your deployment of this helm chart to most closely match the [argo CLI](https://github.com/argoproj/argo-workflows), you should deploy it in the `kube-system` namespace.
+
+## Pre-Requisites
+
+This chart uses an install hook to configure the CRD definition. Installation of CRDs is a somewhat privileged process in itself and in RBAC enabled clusters the `default` service account for namespaces does not typically have the ability to do create these.
+
+A few options are:
+
+- Manually create a ServiceAccount in the Namespace which your release will be deployed w/ appropriate bindings to perform this action and set the `init.serviceAccount` attribute
+- Augment the `default` ServiceAccount permissions in the Namespace in which your Release is deployed to have the appropriate permissions
+
+## Usage Notes
+
+This chart defaults to setting the `controller.instanceID.enabled` to `false` now, which means the deployed controller will act upon any workflow deployed to the cluster. If you would like to limit the behavior and deploy multiple workflow controllers, please use the `controller.instanceID.enabled` attribute along with one of it's configuration options to set the `instanceID` of the workflow controller to be properly scoped for your needs.
+
+## Values
+
+The `values.yaml` contains items used to tweak a deployment of this chart.
+Fields to note:
+
+- `controller.instanceID.enabled`: If set to true, the Argo Controller will **ONLY** monitor Workflow submissions with a `--instanceid` attribute
+- `controller.instanceID.useReleaseName`: If set to true then chart set controller instance id to release name
+- `controller.instanceID.explicitID`: Allows customization of an instance id for the workflow controller to monitor
+- `controller.workflowNamespaces`: This is a list of namespaces where workflows will be ran
+
+## Breaking changes from the deprecated `argo` chart
+
+1. the `installCRD` value has been removed. CRDs are now only installed from the conventional crds/ directory
+1. the CRDs were updated to `apiextensions.k8s.io/v1`
+1. the container image registry/project/tag format was changed to be more in line with the more common
+
+   ```yaml
+   image:
+     registry: quay.io
+     repository: argoproj/argocli
+     tag: v3.0.1
+     pullPolicy: IfNotPresent
+   ```
+
+   this also makes it easier for automatic update tooling (eg. renovate bot) to detect and update images.
+
+1. switched to quay.io as the default registry for all images
+1. removed any included usage of Minio

--- a/charts/argo-workflows/ci/enable-ingress-values.yaml
+++ b/charts/argo-workflows/ci/enable-ingress-values.yaml
@@ -1,0 +1,5 @@
+server:
+  ingress:
+    enabled: true
+    hosts:
+      - argo-workflows.127.0.0.1.xip.io

--- a/charts/argo-workflows/ci/enable-metrics-values.yaml
+++ b/charts/argo-workflows/ci/enable-metrics-values.yaml
@@ -1,0 +1,5 @@
+controller:
+  serviceMonitor:
+    enabled: true
+  metricsConfig:
+    enabled: true

--- a/charts/argo-workflows/ci/enable-metrics-values.yaml
+++ b/charts/argo-workflows/ci/enable-metrics-values.yaml
@@ -3,3 +3,5 @@ controller:
     enabled: true
   metricsConfig:
     enabled: true
+  telemetryConfig:
+    enabled: true

--- a/charts/argo-workflows/ci/enable-rbac-values.yaml
+++ b/charts/argo-workflows/ci/enable-rbac-values.yaml
@@ -1,0 +1,5 @@
+workflow:
+  serviceAccount:
+    create: true # Specifies whether a service account should be created
+  rbac:
+    create: true # adds Role and RoleBinding for the above specified service account to be able to run workflows

--- a/charts/argo-workflows/crds/argoproj.io_clusterworkflowtemplates.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_clusterworkflowtemplates.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterworkflowtemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ClusterWorkflowTemplate
+    listKind: ClusterWorkflowTemplateList
+    plural: clusterworkflowtemplates
+    shortNames:
+    - clusterwftmpl
+    - cwft
+    singular: clusterworkflowtemplate
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/charts/argo-workflows/crds/argoproj.io_cronworkflows.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_cronworkflows.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cronworkflows.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: CronWorkflow
+    listKind: CronWorkflowList
+    plural: cronworkflows
+    shortNames:
+    - cwf
+    - cronwf
+    singular: cronworkflow
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/charts/argo-workflows/crds/argoproj.io_workfloweventbindings.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_workfloweventbindings.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workfloweventbindings.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowEventBinding
+    listKind: WorkflowEventBindingList
+    plural: workfloweventbindings
+    shortNames:
+    - wfeb
+    singular: workfloweventbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/charts/argo-workflows/crds/argoproj.io_workflows.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_workflows.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflows.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    singular: workflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status of the workflow
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: When the workflow was started
+      format: date-time
+      jsonPath: .status.startedAt
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/charts/argo-workflows/crds/argoproj.io_workflowtemplates.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_workflowtemplates.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowtemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowTemplate
+    listKind: WorkflowTemplateList
+    plural: workflowtemplates
+    shortNames:
+    - wftmpl
+    singular: workflowtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/charts/argo-workflows/templates/NOTES.txt
+++ b/charts/argo-workflows/templates/NOTES.txt
@@ -4,4 +4,4 @@ kubectl --namespace {{ .Release.Namespace }} get services -o wide | grep {{ .Rel
 
 2. Submit the hello-world workflow by running:
 
-argo submit https://raw.githubusercontent.com/argoproj/argo/master/examples/hello-world.yaml --watch
+argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/hello-world.yaml --watch

--- a/charts/argo-workflows/templates/NOTES.txt
+++ b/charts/argo-workflows/templates/NOTES.txt
@@ -1,0 +1,7 @@
+1. Get Argo Server external IP/domain by running:
+
+kubectl --namespace {{ .Release.Namespace }} get services -o wide | grep {{ .Release.Name }}-{{ .Values.server.name }}
+
+2. Submit the hello-world workflow by running:
+
+argo submit https://raw.githubusercontent.com/argoproj/argo/master/examples/hello-world.yaml --watch

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -94,3 +94,21 @@ Return the appropriate apiVersion for ingress
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate service layout for ingress
+*/}}
+{{- define "argo-workflows.ingress.service" -}}
+{{- if semverCompare "<1.19-0" .kubeVersion -}}
+- backend:
+    serviceName: {{ .serviceName }}
+    servicePort: {{ .servicePort }}
+{{- else -}}
+- backend:
+    service:
+      name: {{ .serviceName }}
+      port: 
+        number: {{ .servicePort }}
+  pathType: ImplementationSpecific
+{{- end -}}
+{{- end -}}

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -86,29 +86,11 @@ Create the name of the controller service account to use
 Return the appropriate apiVersion for ingress
 */}}
 {{- define "argo-workflows.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate service layout for ingress
-*/}}
-{{- define "argo-workflows.ingress.service" -}}
-{{- if semverCompare "<1.19-0" .kubeVersion -}}
-- backend:
-    serviceName: {{ .serviceName }}
-    servicePort: {{ .servicePort }}
-{{- else -}}
-- backend:
-    service:
-      name: {{ .serviceName }}
-      port:
-        number: {{ .servicePort }}
-  pathType: ImplementationSpecific
 {{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -1,16 +1,96 @@
 {{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create argo workflows server name and version as used by the chart label.
+*/}}
+{{- define "argo-workflows.server.fullname" -}}
+{{- printf "%s-%s" (include "argo-workflows.fullname" .) .Values.server.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create controller name and version as used by the chart label.
+*/}}
+{{- define "argo-workflows.controller.fullname" -}}
+{{- printf "%s-%s" (include "argo-workflows.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "argo-workflows.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "argo-workflows.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argo-workflows.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "argo-workflows.labels" -}}
+helm.sh/chart: {{ include "argo-workflows.chart" .context }}
+{{ include "argo-workflows.selectorLabels" (dict "context" .context "component" .component "name" .name) }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+app.kubernetes.io/part-of: argo-workflows
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "argo-workflows.selectorLabels" -}}
+{{- if .name -}}
+app.kubernetes.io/name: {{ include "argo-workflows.name" .context }}-{{ .name }}
+{{ end -}}
+app.kubernetes.io/instance: {{ .context.Release.Name }}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the server service account to use
+*/}}
+{{- define "argo-workflows.serverServiceAccountName" -}}
+{{- if .Values.server.createServiceAccount -}}
+    {{ default (include "argo-workflows.fullname" .) .Values.server.serviceAccount }}
+{{- else -}}
+    {{ default "default" .Values.server.serviceAccount }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "argo-workflows.controllerServiceAccountName" -}}
+{{- if .Values.controller.createServiceAccount -}}
+    {{ default (include "argo-workflows.fullname" .) .Values.controller.serviceAccount }}
+{{- else -}}
+    {{ default "default" .Values.controller.serviceAccount }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress
+*/}}
+{{- define "argo-cd.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -85,7 +85,7 @@ Create the name of the controller service account to use
 {{/*
 Return the appropriate apiVersion for ingress
 */}}
-{{- define "argo-cd.ingress.apiVersion" -}}
+{{- define "argo-workflows.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -64,10 +64,10 @@ app.kubernetes.io/component: {{ .component }}
 Create the name of the server service account to use
 */}}
 {{- define "argo-workflows.serverServiceAccountName" -}}
-{{- if .Values.server.createServiceAccount -}}
-    {{ default (include "argo-workflows.fullname" .) .Values.server.serviceAccount }}
+{{- if .Values.server.serviceAccount.create -}}
+    {{ default (include "argo-workflows.fullname" .) .Values.server.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.server.serviceAccount }}
+    {{ default "default" .Values.server.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -75,10 +75,10 @@ Create the name of the server service account to use
 Create the name of the controller service account to use
 */}}
 {{- define "argo-workflows.controllerServiceAccountName" -}}
-{{- if .Values.controller.createServiceAccount -}}
-    {{ default (include "argo-workflows.fullname" .) .Values.controller.serviceAccount }}
+{{- if .Values.controller.serviceAccount.create -}}
+    {{ default (include "argo-workflows.fullname" .) .Values.controller.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.controller.serviceAccount }}
+    {{ default "default" .Values.controller.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -107,7 +107,7 @@ Return the appropriate service layout for ingress
 - backend:
     service:
       name: {{ .serviceName }}
-      port: 
+      port:
         number: {{ .servicePort }}
   pathType: ImplementationSpecific
 {{- end -}}

--- a/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.createAggregateRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+  name: argo-aggregate-to-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  - cronworkflows
+  - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+  name: argo-aggregate-to-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  - cronworkflows
+  - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+  name: argo-aggregate-to-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  - cronworkflows
+  - cronworkflows/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
-  name: argo-aggregate-to-view
+  name: argo-workflows-aggregate-to-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
@@ -33,7 +33,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
-  name: argo-aggregate-to-edit
+  name: argo-workflows-aggregate-to-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
@@ -66,7 +66,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-delete-policy: before-hook-creation
-  name: argo-aggregate-to-admin
+  name: argo-workflows-aggregate-to-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -1,0 +1,146 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.singleNamespace }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - cronworkflows
+  - cronworkflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "policy"
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - delete
+{{- if .Values.controller.persistence }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  {{- if .Values.controller.persistence.postgresql }}
+  - {{ .Values.controller.persistence.postgresql.userNameSecret.name }}
+  - {{ .Values.controller.persistence.postgresql.passwordSecret.name }}
+  {{- end}}
+  {{- if .Values.controller.persistence.mysql }}
+  - {{ .Values.controller.persistence.mysql.userNameSecret.name }}
+  - {{ .Values.controller.persistence.mysql.passwordSecret.name }}
+  {{- end}}
+  verbs:
+  - get
+{{- end}}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - workflow-controller
+  - workflow-controller-lease
+  verbs:
+  - get
+  - watch
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -5,7 +5,9 @@ kind: Role
 kind: ClusterRole
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ template "argo-workflows.controller.fullname" . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -1,11 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-configmap
+  name: {{ template "argo-workflows.controller.fullname" . }}-configmap
   labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" "cm") | nindent 4 }}
 data:
   config: |
     {{- if .Values.controller.instanceID.enabled }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}-configmap
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config: |
+    {{- if .Values.controller.instanceID.enabled }}
+    {{- if .Values.controller.instanceID.useReleaseName }}
+    instanceID: {{ .Release.Name }}
+    {{- else }}
+    instanceID: {{ .Values.controller.instanceID.explicitID }}
+    {{- end }}
+    {{- end }}
+    containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
+    {{- if .Values.controller.parallelism }}
+    parallelism: {{ .Values.controller.parallelism }}
+    {{- end }}
+    {{- if or .Values.executor.resources .Values.executor.env .Values.executor.securityContext}}
+    executor:
+      {{- with .Values.executor.resources }}
+      resources: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executor.env }}
+      env: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executor.securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.useDefaultArtifactRepo }}
+    artifactRepository:
+      {{- if .Values.artifactRepository.archiveLogs }}
+      archiveLogs: {{ .Values.artifactRepository.archiveLogs }}
+      {{- end }}
+      {{- if .Values.artifactRepository.gcs }}
+      gcs:
+{{ toYaml .Values.artifactRepository.gcs | indent 8}}
+      {{- else }}
+      s3:
+        {{- if .Values.useStaticCredentials }}
+        accessKeySecret:
+          key: {{ .Values.artifactRepository.s3.accessKeySecret.key }}
+          name: {{ .Values.artifactRepository.s3.accessKeySecret.name }}
+        secretKeySecret:
+          key: {{ .Values.artifactRepository.s3.secretKeySecret.key }}
+          name: {{ .Values.artifactRepository.s3.secretKeySecret.name }}
+        {{- end }}
+        bucket: {{ .Values.artifactRepository.s3.bucket }}
+        endpoint: {{ .Values.artifactRepository.s3.endpoint }}
+        insecure: {{ .Values.artifactRepository.s3.insecure }}
+        {{- if .Values.artifactRepository.s3.keyFormat }}
+        keyFormat: {{ .Values.artifactRepository.s3.keyFormat | quote }}
+        {{- end }}
+        {{- if .Values.artifactRepository.s3.region }}
+        region: {{ .Values.artifactRepository.s3.region }}
+        {{- end }}
+        {{- if .Values.artifactRepository.s3.roleARN }}
+        roleARN: {{ .Values.artifactRepository.s3.roleARN }}
+        {{- end }}
+        {{- if .Values.artifactRepository.s3.useSDKCreds }}
+        useSDKCreds: {{ .Values.artifactRepository.s3.useSDKCreds }}
+        {{- end }}
+      {{- end }}
+    {{- end}}
+    {{- if .Values.controller.metricsConfig.enabled }}
+    metricsConfig:
+{{ toYaml .Values.controller.metricsConfig | indent 6}}{{- end }}
+    {{- if .Values.controller.telemetryConfig.enabled }}
+    telemetryConfig:
+{{ toYaml .Values.controller.telemetryConfig | indent 6}}{{- end }}
+    {{- if .Values.controller.persistence }}
+    persistence:
+{{ toYaml .Values.controller.persistence | indent 6 }}{{- end }}
+    {{- if .Values.controller.workflowDefaults }}
+    workflowDefaults:
+{{ toYaml .Values.controller.workflowDefaults | indent 6 }}{{- end }}
+    {{- with .Values.server.sso }}
+    sso: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.controller.workflowRestrictions }}
+    workflowRestrictions: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.controller.links }}
+    links: {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.singleNamespace }}
+kind: RoleBinding
+{{ else }}
+kind: ClusterRoleBinding
+{{- end }}
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.singleNamespace }}
+  kind: Role
+  {{ else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount }}
+    namespace: {{ .Release.Namespace }}
+{{- if .Values.controller.workflowNamespaces }}
+{{- $uiServiceAccount := .Values.controller.serviceAccount }}
+{{- $namespace := .Release.Namespace }}
+{{- range $key := .Values.controller.workflowNamespaces }}
+  {{- if not (eq $key $namespace) }}
+  - kind: ServiceAccount
+    name: {{ $uiServiceAccount }}
+    namespace: {{ $key }}
+  {{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -5,7 +5,9 @@ kind: RoleBinding
 kind: ClusterRoleBinding
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ template "argo-workflows.controller.fullname" . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.singleNamespace }}
@@ -13,7 +15,7 @@ roleRef:
   {{ else }}
   kind: ClusterRole
   {{- end }}
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ template "argo-workflows.controller.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount }}
@@ -33,11 +35,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+  name: {{ template "argo-workflows.controller.fullname" . }}-cluster-template
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}-cluster-template
+  name: {{ template "argo-workflows.controller.fullname" . }}-cluster-template
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controller.serviceAccount }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -18,10 +18,10 @@ roleRef:
   name: {{ template "argo-workflows.controller.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.controller.serviceAccount }}
+    name: {{ template "argo-workflows.controllerServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- if .Values.controller.workflowNamespaces }}
-{{- $uiServiceAccount := .Values.controller.serviceAccount }}
+{{- $uiServiceAccount := (include "argo-workflows.controllerServiceAccountName" .) }}
 {{- $namespace := .Release.Namespace }}
 {{- range $key := .Values.controller.workflowNamespaces }}
   {{- if not (eq $key $namespace) }}
@@ -44,5 +44,5 @@ roleRef:
   name: {{ template "argo-workflows.controller.fullname" . }}-cluster-template
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.controller.serviceAccount }}
+    name: {{ template "argo-workflows.controllerServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.controller.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name}}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.controller.pdb.minAvailable }}
+  minAvailable: {{ .Values.controller.pdb.minAvailable }}
+  {{- else if .Values.controller.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.controller.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: 0
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
@@ -2,12 +2,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}
+  name: {{ template "argo-workflows.controller.fullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 spec:
   {{- if .Values.controller.pdb.minAvailable }}
   minAvailable: {{ .Values.controller.pdb.minAvailable }}
@@ -18,6 +15,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.controller.name}}
-      release: {{ .Release.Name }}
+      {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -15,8 +15,8 @@ spec:
       labels:
         {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
         app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.controller.image.tag | quote }}
-        {{- if .Values.controller.podLabels }}
-        {{ toYaml .Values.controller.podLabels | nindent 8}}
+        {{- with.Values.controller.podLabels }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.controller.podAnnotations }}
       annotations:

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -32,14 +32,14 @@ spec:
       {{- end }}
       containers:
         - name: controller
-          image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: [ "workflow-controller" ]
           args:
           - "--configmap"
           - "{{ .Release.Name }}-{{ .Values.controller.name}}-configmap"
           - "--executor-image"
-          - "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}"
+          - "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag | default .Chart.AppVersion }}"
           - "--loglevel"
           - "{{ .Values.controller.logging.level }}"
           - "--gloglevel"

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -99,6 +99,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.controller.priorityClassName }}
-      priorityClassName: {{ .Values.controller.priorityClassName }}
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -76,23 +76,15 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
-          {{- if .Values.controller.metricsConfig.enabled }}
           ports:
             - name: metrics
-              containerPort: {{- .Values.controller.metricsConfig.port }}
+              containerPort: {{ .Values.controller.metricsConfig.port }}
           livenessProbe:
             httpGet:
               port: metrics
-              path: {{- .Values.controller.metricsConfig.path }}
+              path: {{ .Values.controller.metricsConfig.path }}
             initialDelaySeconds: 30
             periodSeconds: 30
-          readinessProbe:
-            httpGet:
-              port: metrics
-              path: {{- .Values.controller.metricsConfig.path }}
-            initialDelaySeconds: 30
-            periodSeconds: 30
-          {{- end }}
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -53,8 +53,8 @@ spec:
           - "--pod-workers"
           - {{ . | quote }}
           {{- end }}
-          {{- if .Values.controller.extraArgs }}
-          {{- toYaml .Values.controller.extraArgs | nindent 10 }}
+          {{- with .Values.controller.extraArgs }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -24,9 +24,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "argo-workflows.controllerServiceAccountName" . }}
-      {{- if .Values.controller.podSecurityContext }}
+      {{- with .Values.controller.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: controller

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -18,9 +18,10 @@ spec:
         {{- if .Values.controller.podLabels }}
         {{ toYaml .Values.controller.podLabels | nindent 8}}
         {{- end }}
-      {{- if .Values.controller.podAnnotations }}
+      {{- with .Values.controller.podAnnotations }}
       annotations:
-{{ toYaml .Values.controller.podAnnotations | indent 8}}{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "argo-workflows.controllerServiceAccountName" . }}
       {{- if .Values.controller.podSecurityContext }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name}}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-{{ .Values.controller.name}}
+        release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+        {{ toYaml .Values.controller.podLabels | nindent 8}}
+        {{- end }}
+      {{- if .Values.controller.podAnnotations }}
+      annotations:
+{{ toYaml .Values.controller.podAnnotations | indent 8}}{{- end }}
+    spec:
+      serviceAccountName: {{ .Values.controller.serviceAccount | quote }}
+      {{- if .Values.controller.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: controller
+          image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          command: [ "workflow-controller" ]
+          args:
+          - "--configmap"
+          - "{{ .Release.Name }}-{{ .Values.controller.name}}-configmap"
+          - "--executor-image"
+          - "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}"
+          - "--loglevel"
+          - "{{ .Values.controller.logging.level }}"
+          - "--gloglevel"
+          - "{{ .Values.controller.logging.globallevel }}"
+          {{- if .Values.singleNamespace }}
+          - "--namespaced"
+          {{- end }}
+          {{- with .Values.controller.workflowWorkers }}
+          - "--workflow-workers"
+          - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.controller.podWorkers }}
+          - "--pod-workers"
+          - {{ . | quote }}
+          {{- end }}
+          {{- if .Values.controller.extraArgs }}
+          {{- toYaml .Values.controller.extraArgs | nindent 10 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.controller.securityContext | nindent 12 }}
+          env:
+            - name: ARGO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          {{- with .Values.controller.extraEnv }}
+            {{ toYaml . | nindent 10 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          {{- if .Values.controller.metricsConfig.enabled }}
+          ports:
+            - name: metrics
+              containerPort: {{- .Values.controller.metricsConfig.port }}
+          livenessProbe:
+            httpGet:
+              port: metrics
+              path: {{- .Values.controller.metricsConfig.path }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              port: metrics
+              path: {{- .Values.controller.metricsConfig.path }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          {{- end }}
+      {{- with .Values.images.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+      {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -1,23 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name}}
+  name: {{ template "argo-workflows.controller.fullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
+    app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.controller.image.tag | quote }}
 spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.controller.name}}
-      release: {{ .Release.Name }}
+      {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-{{ .Values.controller.name}}
-        release: {{ .Release.Name }}
+        {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.controller.image.tag | quote }}
         {{- if .Values.controller.podLabels }}
         {{ toYaml .Values.controller.podLabels | nindent 8}}
         {{- end }}
@@ -25,7 +22,7 @@ spec:
       annotations:
 {{ toYaml .Values.controller.podAnnotations | indent 8}}{{- end }}
     spec:
-      serviceAccountName: {{ .Values.controller.serviceAccount | quote }}
+      serviceAccountName: {{ template "argo-workflows.controllerServiceAccountName" . }}
       {{- if .Values.controller.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
@@ -37,7 +34,7 @@ spec:
           command: [ "workflow-controller" ]
           args:
           - "--configmap"
-          - "{{ .Release.Name }}-{{ .Values.controller.name}}-configmap"
+          - "{{ template "argo-workflows.controller.fullname" . }}-configmap"
           - "--executor-image"
           - "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag | default .Chart.AppVersion }}"
           - "--loglevel"

--- a/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.controller.serviceAccount }}
+  annotations:
+{{ toYaml .Values.controller.serviceAccountAnnotations | indent 4 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.controller.serviceAccount }}
+  name: {{ template "argo-workflows.controllerServiceAccountName" . }}
   annotations:
 {{ toYaml .Values.controller.serviceAccountAnnotations | indent 4 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.controllerServiceAccountName" . }}
+  {{ with .Values.controller.serviceAccountAnnotations }}
   annotations:
-{{ toYaml .Values.controller.serviceAccountAnnotations | indent 4 }}
+    {{- toYaml .| nindent 4 }}
+  {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.controllerServiceAccountName" . }}
-  {{ with .Values.controller.serviceAccountAnnotations }}
+  {{ with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml .| nindent 4 }}
   {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -1,0 +1,38 @@
+{{- if or .Values.controller.metricsConfig.enabled .Values.controller.telemetryConfig.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.controller.serviceLabels }}
+    {{ toYaml .Values.controller.serviceLabels | nindent 4}}
+    {{- end }}
+  {{- if .Values.controller.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.controller.serviceAnnotations | indent 4}}{{- end }}
+spec:
+  ports:
+  {{- if .Values.controller.metricsConfig.enabled }}
+  - name: {{ .Values.controller.metricsServicePortName }}
+    port: {{ .Values.controller.metricsServicePort }}
+    protocol: TCP
+    targetPort: {{ .Values.controller.metricsConfig.port }}
+  {{- end }}
+  {{- if .Values.controller.telemetryConfig.enabled }}
+  - name: {{ .Values.controller.telemetryServicePortName }}
+    port: {{ .Values.controller.telemetryServicePort }}
+    protocol: TCP
+    targetPort: {{ .Values.controller.telemetryConfig.port }}
+  {{- end }}
+  selector:
+    app: {{ .Release.Name }}-{{ .Values.controller.name }}
+  sessionAffinity: None
+  type: {{ .Values.controller.serviceType }}
+  {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.loadBalancerSourceRanges | indent 4 }}{{- end }}
+{{- end -}}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -16,14 +16,14 @@ metadata:
 spec:
   ports:
   {{- if .Values.controller.metricsConfig.enabled }}
-  - name: {{ .Values.controller.metricsServicePortName }}
-    port: {{ .Values.controller.metricsServicePort }}
+  - name: {{ .Values.controller.metricsConfig.servicePortName }}
+    port: {{ .Values.controller.metricsConfig.servicePort }}
     protocol: TCP
     targetPort: {{ .Values.controller.metricsConfig.port }}
   {{- end }}
   {{- if .Values.controller.telemetryConfig.enabled }}
-  - name: {{ .Values.controller.telemetryServicePortName }}
-    port: {{ .Values.controller.telemetryServicePort }}
+  - name: {{ .Values.controller.telemetryConfig.servicePortName }}
+    port: {{ .Values.controller.telemetryConfig.servicePort }}
     protocol: TCP
     targetPort: {{ .Values.controller.telemetryConfig.port }}
   {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -9,9 +9,10 @@ metadata:
     {{- if .Values.controller.serviceLabels }}
     {{ toYaml .Values.controller.serviceLabels | nindent 4}}
     {{- end }}
-  {{- if .Values.controller.serviceAnnotations }}
+  {{- with .Values.controller.serviceAnnotations }}
   annotations:
-{{ toYaml .Values.controller.serviceAnnotations | indent 4}}{{- end }}
+    {{- toYaml . | nindent 4}}
+  {{- end }}
 spec:
   ports:
   {{- if .Values.controller.metricsConfig.enabled }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.controller.image.tag | quote }}
-    {{- if .Values.controller.serviceLabels }}
-    {{ toYaml .Values.controller.serviceLabels | nindent 4}}
+    {{- with .Values.controller.serviceLabels }}
+      {{ toYaml . | nindent 4 }}
     {{- end }}
   {{- with .Values.controller.serviceAnnotations }}
   annotations:
@@ -33,5 +33,6 @@ spec:
   type: {{ .Values.controller.serviceType }}
   {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.controller.loadBalancerSourceRanges | indent 4 }}{{- end }}
+    {{- toYaml .Values.controller.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -2,12 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ template "argo-workflows.controller.fullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
+    app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.controller.image.tag | quote }}
     {{- if .Values.controller.serviceLabels }}
     {{ toYaml .Values.controller.serviceLabels | nindent 4}}
     {{- end }}
@@ -29,7 +27,7 @@ spec:
     targetPort: {{ .Values.controller.telemetryConfig.port }}
   {{- end }}
   selector:
-    app: {{ .Release.Name }}-{{ .Values.controller.name }}
+    {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 4 }}
   sessionAffinity: None
   type: {{ .Values.controller.serviceType }}
   {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and (or .Values.controller.metricsConfig.enabled .Values.controller.telemetryConfig.enabled) .Values.controller.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.controller.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.controller.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.controller.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  {{- if .Values.controller.metricsConfig.enabled }}
+    - port: metrics
+      path: {{ .Values.controller.metricsConfig.path }}
+      interval: 30s
+  {{- end }}
+  {{- if .Values.controller.telemetryConfig.enabled }}
+    - port: telemetry
+      path: {{ .Values.controller.telemetryConfig.path }}
+      interval: 30s
+  {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.controller.name}}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -5,19 +5,19 @@ metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    {{- if .Values.controller.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.controller.serviceMonitor.additionalLabels | indent 4 }}
+    {{- with .Values.controller.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
-  {{- if .Values.controller.metricsConfig.enabled }}
+  {{- with .Values.controller.metricsConfig.enabled }}
     - port: metrics
-      path: {{ .Values.controller.metricsConfig.path }}
+      path: {{ . }}
       interval: 30s
   {{- end }}
-  {{- if .Values.controller.telemetryConfig.enabled }}
+  {{- with .Values.controller.telemetryConfig.enabled }}
     - port: telemetry
-      path: {{ .Values.controller.telemetryConfig.path }}
+      path: {{ . }}
       interval: 30s
   {{- end }}
   namespaceSelector:

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -2,12 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.controller.name }}
+  name: {{ template "argo-workflows.controller.fullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.controller.name}}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     {{- if .Values.controller.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.controller.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
@@ -28,6 +25,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.controller.name}}
-      release: {{ .Release.Name }}
+      {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -10,14 +10,14 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  {{- with .Values.controller.metricsConfig.enabled }}
+  {{- if .Values.controller.metricsConfig.enabled }}
     - port: metrics
-      path: {{ . }}
+      path: {{ .Values.controller.metricsConfig.path }}
       interval: 30s
   {{- end }}
-  {{- with .Values.controller.telemetryConfig.enabled }}
+  {{- if .Values.controller.telemetryConfig.enabled }}
     - port: telemetry
-      path: {{ . }}
+      path: {{ .Values.controller.telemetryConfig.path }}
       interval: 30s
   {{- end }}
   namespaceSelector:

--- a/charts/argo-workflows/templates/controller/workflow-rb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-rb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.workflow.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-workflow
+{{- if .Values.workflow.namespace }}
+  namespace: {{ .Values.workflow.namespace }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-workflow
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.workflow.serviceAccount.name }}
+  {{- if .Values.workflow.namespace }}
+  namespace: {{ .Values.workflow.namespace }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-rb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-rb.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-workflow
+  name: {{ template "argo-workflows.fullname" . }}-workflow
 {{- if .Values.workflow.namespace }}
   namespace: {{ .Values.workflow.namespace }}
 {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-workflow
+  name: {{ template "argo-workflows.fullname" . }}-workflow
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.workflow.serviceAccount.name }}

--- a/charts/argo-workflows/templates/controller/workflow-rb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-rb.yaml
@@ -3,9 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "argo-workflows.fullname" . }}-workflow
-{{- if .Values.workflow.namespace }}
-  namespace: {{ .Values.workflow.namespace }}
-{{- end }}
+  {{- with .Values.workflow.namespace }}
+  namespace: {{ . }} 
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,7 +13,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.workflow.serviceAccount.name }}
-  {{- if .Values.workflow.namespace }}
-  namespace: {{ .Values.workflow.namespace }}
+  {{- with .Values.workflow.namespace }}
+  namespace: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.workflow.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-workflow
+  {{- if .Values.workflow.namespace }}
+  namespace: {{ .Values.workflow.namespace }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - watch
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-workflow
+  name: {{ template "argo-workflows.fullname" . }}-workflow
   {{- if .Values.workflow.namespace }}
   namespace: {{ .Values.workflow.namespace }}
   {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -3,8 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "argo-workflows.fullname" . }}-workflow
-  {{- if .Values.workflow.namespace }}
-  namespace: {{ .Values.workflow.namespace }}
+  {{- with .Values.workflow.namespace }}
+  namespace: {{ . }}
   {{- end }}
 rules:
 - apiGroups:

--- a/charts/argo-workflows/templates/controller/workflow-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-sa.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.workflow.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.workflow.serviceAccount.name }}
+  {{- if .Values.workflow.namespace }}
+  namespace: {{ .Values.workflow.namespace }}
+  {{- end }}
+  {{- with .Values.workflow.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-sa.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.workflow.serviceAccount.name }}
-  {{- if .Values.workflow.namespace }}
-  namespace: {{ .Values.workflow.namespace }}
+  {{- with .Values.workflow.namespace }}
+  namespace: {{ . }}
   {{- end }}
   {{- with .Values.workflow.serviceAccount.annotations }}
   annotations:

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -1,0 +1,134 @@
+{{- if .Values.server.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.singleNamespace }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+{{- if .Values.server.sso }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - sso
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+{{- end}}
+{{- if .Values.server.sso }}
+  {{- if .Values.server.sso.rbac }}
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  {{- end }}
+{{- end }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+{{- if .Values.server.sso }}
+  {{- if .Values.server.sso.rbac }}
+    {{- with .Values.server.sso.rbac.secretWhitelist }}
+  resourceNames: {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - watch
+  - create
+  - patch
+{{- if .Values.controller.persistence }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  {{- with .Values.controller.persistence.postgresql }}
+  - {{ .userNameSecret.name }}
+  - {{ .passwordSecret.name }}
+  {{- end}}
+  {{- with .Values.controller.persistence.mysql }}
+  - {{ .userNameSecret.name }}
+  - {{ .passwordSecret.name }}
+  {{- end}}
+  verbs:
+  - get
+{{- end}}
+- apiGroups:
+    - argoproj.io
+  resources:
+    - eventsources
+    - sensors
+    - workflows
+    - workfloweventbindings
+    - workflowtemplates
+    - cronworkflows
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - patch
+    - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name }}-cluster-template
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if .Values.server.clusterWorkflowTemplates.enableEditing }}
+  - create
+  - update
+  - patch
+  - delete
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.server.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
+  {{- if .Values.singleNamespace }}
 kind: Role
-{{- else }}
+  {{- else }}
 kind: ClusterRole
-{{- end }}
+  {{- end }}
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
   labels:
@@ -30,7 +30,7 @@ rules:
   - list
   - watch
   - delete
-{{- if .Values.server.sso }}
+  {{- if .Values.server.sso }}
 - apiGroups:
   - ""
   resources:
@@ -46,9 +46,7 @@ rules:
   - secrets
   verbs:
   - create
-{{- end}}
-{{- if .Values.server.sso }}
-  {{- if .Values.server.sso.rbac }}
+    {{- if .Values.server.sso.rbac }}
 - apiGroups:
   - ""
   resources:
@@ -56,8 +54,8 @@ rules:
   verbs:
   - get
   - list
+    {{- end }}
   {{- end }}
-{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -6,7 +6,9 @@ kind: Role
 kind: ClusterRole
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  name: {{ template "argo-workflows.server.fullname" . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -115,7 +117,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}-cluster-template
+  name: {{ template "argo-workflows.server.fullname" . }}-cluster-template
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.server.enabled .Values.server.createServiceAccount -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.singleNamespace }}
+kind: RoleBinding
+{{ else }}
+kind: ClusterRoleBinding
+{{- end }}
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.singleNamespace }}
+  kind: Role
+  {{ else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ .Release.Name }}-{{ .Values.server.name}}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.server.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.server.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -6,7 +6,9 @@ kind: RoleBinding
 kind: ClusterRoleBinding
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ template "argo-workflows.server.fullname" . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   {{- if .Values.singleNamespace }}
@@ -14,7 +16,7 @@ roleRef:
   {{ else }}
   kind: ClusterRole
   {{- end }}
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ template "argo-workflows.server.fullname" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.server.serviceAccount }}
@@ -23,11 +25,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
+  name: {{ template "argo-workflows.server.fullname" . }}-cluster-template
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-{{ .Values.server.name}}-cluster-template
+  name: {{ template "argo-workflows.server.fullname" . }}-cluster-template
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.server.serviceAccount }}

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled .Values.server.createServiceAccount -}}
+{{- if and .Values.server.enabled .Values.server.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding
@@ -19,7 +19,7 @@ roleRef:
   name: {{ template "argo-workflows.server.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.server.serviceAccount }}
+  name: {{ template "argo-workflows.serverServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,6 +34,6 @@ roleRef:
   name: {{ template "argo-workflows.server.fullname" . }}-cluster-template
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.server.serviceAccount }}
+  name: {{ template "argo-workflows.serverServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.server.enabled -}}
+{{- if .Values.server.pdb.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.server.name}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.server.pdb.minAvailable }}
+  minAvailable: {{ .Values.server.pdb.minAvailable }}
+  {{- else if .Values.server.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.server.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: 0
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.server.name}}
+      release: {{ .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
@@ -3,12 +3,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ template "argo-workflows.server.fullname" . }}
   labels:
-    app: {{ .Release.Name }}-{{ .Values.server.name}}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
   {{- if .Values.server.pdb.minAvailable }}
   minAvailable: {{ .Values.server.pdb.minAvailable }}
@@ -19,7 +16,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.server.name}}
-      release: {{ .Release.Name }}
+      {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 6 }}
 {{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.server.pdb.enabled -}}
+{{- if and .Values.server.enabled .Values.server.pdb.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -17,5 +16,4 @@ spec:
   selector:
     matchLabels:
       {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 6 }}
-{{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.server.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.server.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-{{ .Values.server.name}}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-{{ .Values.server.name}}
+        release: {{ .Release.Name }}
+        {{- if .Values.server.podLabels }}
+        {{- toYaml .Values.server.podLabels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.server.podAnnotations }}
+      annotations:
+{{ toYaml .Values.server.podAnnotations | indent 8}}{{- end }}
+    spec:
+      serviceAccountName: {{ .Values.server.serviceAccount | quote }}
+      {{- if .Values.server.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: argo-server
+          image: "{{ .Values.server.image.registry }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
+          args:
+          - server
+          - --configmap={{ .Release.Name }}-{{ .Values.controller.name }}-configmap
+          {{- if .Values.server.extraArgs }}
+          {{- toYaml .Values.server.extraArgs | nindent 10 }}
+          {{- end }}
+          - "--secure={{ .Values.server.secure }}"
+          {{- if .Values.singleNamespace }}
+          - "--namespaced"
+          {{- end }}
+          ports:
+          - name: web
+            containerPort: 2746
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 2746
+              {{- if .Values.server.secure }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          env:
+          - name: IN_CLUSTER
+            value: "true"
+          - name: ARGO_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: BASE_HREF
+            value: {{ .Values.server.baseHref | quote }}
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          {{- with .Values.server.volumeMounts }}
+            {{- toYaml . | nindent 10}}
+          {{- end }}
+      {{- with .Values.images.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- with .Values.server.volumes }}
+        {{- toYaml . | nindent 6}}
+      {{- end }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.server.priorityClassName }}
+      priorityClassName: {{ .Values.server.priorityClassName }}
+      {{- end }}
+{{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- toYaml .Values.server.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Values.server.serviceAccount | quote }}
+      serviceAccountName: {{ template "argo-workflows.serverServiceAccountName" . }}
       {{- with .Values.server.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -16,17 +16,18 @@ spec:
       labels:
         {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 8 }}
         app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.server.image.tag | quote }}
-        {{- if .Values.server.podLabels }}
-        {{- toYaml .Values.server.podLabels | nindent 8 }}
+        {{- with .Values.server.podLabels }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.server.podAnnotations }}
+      {{- with .Values.server.podAnnotations }}
       annotations:
-{{ toYaml .Values.server.podAnnotations | indent 8}}{{- end }}
+        {{- toYaml .Values.server.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.server.serviceAccount | quote }}
-      {{- if .Values.server.podSecurityContext }}
+      {{- with .Values.server.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: argo-server
@@ -37,8 +38,8 @@ spec:
           args:
           - server
           - --configmap={{ .Release.Name }}-{{ .Values.controller.name }}-configmap
-          {{- if .Values.server.extraArgs }}
-          {{- toYaml .Values.server.extraArgs | nindent 10 }}
+          {{- with .Values.server.extraArgs }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           - "--secure={{ .Values.server.secure }}"
           {{- if .Values.singleNamespace }}
@@ -98,7 +99,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.server.priorityClassName }}
-      priorityClassName: {{ .Values.server.priorityClassName }}
+      {{- with .Values.server.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
         - name: argo-server
-          image: "{{ .Values.server.image.registry }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+          image: "{{ .Values.server.image.registry }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           args:
           - server

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -32,6 +32,8 @@ spec:
         - name: argo-server
           image: "{{ .Values.server.image.registry }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
           args:
           - server
           - --configmap={{ .Release.Name }}-{{ .Values.controller.name }}-configmap

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.server.securityContext | nindent 12 }}
           args:
           - server
-          - --configmap={{ .Release.Name }}-{{ .Values.controller.name }}-configmap
+          - --configmap={{ template "argo-workflows.controller.fullname" . }}-configmap
           {{- with .Values.server.extraArgs }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -2,22 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name}}
+  name: {{ template "argo-workflows.server.fullname" . }}
   labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.server.image.tag | quote }}
 spec:
   replicas: {{ .Values.server.replicas }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Values.server.name}}
-      release: {{ .Release.Name }}
+      {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-{{ .Values.server.name}}
-        release: {{ .Release.Name }}
+        {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 8 }}
+        app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.server.image.tag | quote }}
         {{- if .Values.server.podLabels }}
         {{- toYaml .Values.server.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.server.enabled -}}
+{{- if .Values.server.ingress.enabled -}}
+{{- $serviceName := printf "%s-%s" .Release.Name .Values.server.name -}}
+{{- $servicePort := .Values.server.servicePort -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.server.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.server.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range .Values.server.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          {{- if $.Values.server.ingress.paths }}
+          {{- range $.Values.server.ingress.paths }}
+          - backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+          {{- end }}
+          {{- end }}
+          - backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.server.ingress.tls }}
+  tls:
+{{ toYaml .Values.server.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -1,19 +1,12 @@
 {{- if .Values.server.enabled -}}
 {{- if .Values.server.ingress.enabled -}}
-{{- $serviceName := printf "%s-%s" .Release.Name .Values.server.name -}}
+{{- $serviceName := include "argo-workflows.server.fullname" . -}}
 {{- $servicePort := .Values.server.servicePort -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end -}}
-kind: Ingress
+apiVersion: {{ include "argo-workflows.ingress.apiVersion" . }}
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  name: {{ template "argo-workflows.server.fullname" . }}
   labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "argo-workflows.labels" $ | nindent 4 }}
     {{- range $key, $value := .Values.server.ingress.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -1,37 +1,88 @@
-{{- if .Values.server.enabled -}}
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := include "argo-workflows.server.fullname" . -}}
 {{- $servicePort := .Values.server.servicePort -}}
+{{- $paths := .Values.server.ingress.paths -}}
+{{- $extraPaths := .Values.server.ingress.extraPaths -}}
 apiVersion: {{ include "argo-workflows.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
+{{- if .Values.server.ingress.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.server.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   name: {{ template "argo-workflows.server.fullname" . }}
   labels:
-   {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    {{- range $key, $value := .Values.server.ingress.labels }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  annotations:
-    {{- range $key, $value := .Values.server.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    {{- if .Values.server.ingress.labels }}
+    {{- toYaml .Values.server.ingress.labels | nindent 4 }}
     {{- end }}
 spec:
+  {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+  {{- with .Values.server.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- end }}
   rules:
-    {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion}}
-    {{- range .Values.server.ingress.hosts }}
-    - host: {{ . }}
+  {{- if .Values.server.ingress.hosts }}
+    {{- range $host := .Values.server.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          {{- if $.Values.server.ingress.paths }}
-          {{- range $.Values.server.ingress.paths }}
-          {{- include "argo-workflows.ingress.service" (dict "kubeVersion" $kubeVersion "serviceName" .serviceName "servicePort" .servicePort) | nindent 10 }}
+          {{- if $extraPaths }}
+          {{- toYaml $extraPaths | nindent 10 }}
           {{- end }}
-          {{- end }}
-          {{- include "argo-workflows.ingress.service" (dict "kubeVersion" $kubeVersion "serviceName" $serviceName "servicePort" $servicePort) | nindent 10 }}
+          {{- range $p := $paths }}
+          - path: {{ $p }}
+            {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if kindIs "float64" $servicePort }}
+                  number: {{ $servicePort }}
+                  {{- else }}
+                  name: {{ $servicePort }}
+                  {{- end }}
+              {{- else }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
+          {{- end -}}
     {{- end -}}
-    {{- with .Values.server.ingress.tls }}
+  {{- else }}
+    - http:
+        paths:
+          {{- if $extraPaths }}
+          {{- toYaml $extraPaths | nindent 10 }}
+          {{- end }}
+          {{- range $p := $paths }}
+          - path: {{ $p }}
+            {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  {{- if kindIs "float64" $servicePort }}
+                  number: {{ $servicePort }}
+                  {{- else }}
+                  name: {{ $servicePort }}
+                  {{- end }}
+              {{- else }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
+          {{- end -}}
+  {{- end -}}
+  {{- if .Values.server.ingress.tls }}
   tls:
-      {{- toYaml . | nindent 4 }}
-    {{- end -}}
+    {{- toYaml .Values.server.ingress.tls | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -3,10 +3,11 @@
 {{- $serviceName := include "argo-workflows.server.fullname" . -}}
 {{- $servicePort := .Values.server.servicePort -}}
 apiVersion: {{ include "argo-workflows.ingress.apiVersion" . }}
+kind: Ingress
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
   labels:
-    {{- include "argo-workflows.labels" $ | nindent 4 }}
+   {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     {{- range $key, $value := .Values.server.ingress.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -16,24 +17,21 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion}}
     {{- range .Values.server.ingress.hosts }}
     - host: {{ . }}
       http:
         paths:
           {{- if $.Values.server.ingress.paths }}
           {{- range $.Values.server.ingress.paths }}
-          - backend:
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .servicePort }}
+          {{- include "argo-workflows.ingress.service" (dict "kubeVersion" $kubeVersion "serviceName" .serviceName "servicePort" .servicePort) | nindent 10 }}
           {{- end }}
           {{- end }}
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          {{- include "argo-workflows.ingress.service" (dict "kubeVersion" $kubeVersion "serviceName" $serviceName "servicePort" $servicePort) | nindent 10 }}
     {{- end -}}
-  {{- if .Values.server.ingress.tls }}
+    {{- with .Values.server.ingress.tls }}
   tls:
-{{ toYaml .Values.server.ingress.tls | indent 4 }}
+      {{- toYaml . | nindent 4 }}
+    {{- end -}}
   {{- end -}}
-{{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- toYaml .Values.server.ingress.labels | nindent 4 }}
     {{- end }}
 spec:
-  {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
   {{- with .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ . }}
   {{- end }}
@@ -35,11 +35,11 @@ spec:
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -62,11 +62,11 @@ spec:
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if eq (include "argo-workflows.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/argo-workflows/templates/server/server-sa.yaml
+++ b/charts/argo-workflows/templates/server/server-sa.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.server.enabled .Values.server.createServiceAccount -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.server.serviceAccount }}
+  annotations:
+{{ toYaml .Values.server.serviceAccountAnnotations | indent 4 }}
+{{- end -}}

--- a/charts/argo-workflows/templates/server/server-sa.yaml
+++ b/charts/argo-workflows/templates/server/server-sa.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.server.serviceAccount }}
+  name: {{ template "argo-workflows.serverServiceAccountName" . }}
   annotations:
 {{ toYaml .Values.server.serviceAccountAnnotations | indent 4 }}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-sa.yaml
+++ b/charts/argo-workflows/templates/server/server-sa.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.serverServiceAccountName" . }}
+  {{- with .Values.server.serviceAccountAnnotations  }}
   annotations:
-{{ toYaml .Values.server.serviceAccountAnnotations | indent 4 }}
+    {{- toYaml . | indent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-sa.yaml
+++ b/charts/argo-workflows/templates/server/server-sa.yaml
@@ -1,9 +1,9 @@
-{{- if and .Values.server.enabled .Values.server.createServiceAccount -}}
+{{- if and .Values.server.enabled .Values.server.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.serverServiceAccountName" . }}
-  {{- with .Values.server.serviceAccountAnnotations  }}
+  {{- with .Values.server.serviceAccount.annotations  }}
   annotations:
     {{- toYaml . | indent 4 }}
   {{- end }}

--- a/charts/argo-workflows/templates/server/server-service.yaml
+++ b/charts/argo-workflows/templates/server/server-service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.server.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.server.serviceLabels }}
+    {{- toYaml .Values.server.serviceLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.server.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.server.serviceAnnotations | indent 4}}{{- end }}
+spec:
+  ports:
+  - port: {{ .Values.server.servicePort }}
+    {{- if .Values.server.servicePortName }}
+    name: {{ .Values.server.servicePortName }}
+    {{- end }}
+    targetPort: 2746
+  selector:
+    app: {{ .Release.Name }}-{{ .Values.server.name }}
+  sessionAffinity: None
+  type: {{ .Values.server.serviceType }}
+  {{- if and (eq .Values.server.serviceType "LoadBalancer") .Values.server.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.server.loadBalancerIP | quote }}
+  {{- end }}
+  {{- if and (eq .Values.server.serviceType "LoadBalancer") .Values.server.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.server.loadBalancerSourceRanges | indent 4 }}{{- end }}
+{{- end -}}

--- a/charts/argo-workflows/templates/server/server-service.yaml
+++ b/charts/argo-workflows/templates/server/server-service.yaml
@@ -6,14 +6,15 @@ metadata:
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.server.image.tag | quote }}
-  {{- if .Values.server.serviceAnnotations }}
+  {{- with .Values.server.serviceAnnotations }}
   annotations:
-{{ toYaml .Values.server.serviceAnnotations | indent 4}}{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.server.servicePort }}
-    {{- if .Values.server.servicePortName }}
-    name: {{ .Values.server.servicePortName }}
+    {{- with .Values.server.servicePortName }}
+    name: {{ . }}
     {{- end }}
     targetPort: 2746
   selector:
@@ -25,5 +26,6 @@ spec:
   {{- end }}
   {{- if and (eq .Values.server.serviceType "LoadBalancer") .Values.server.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.server.loadBalancerSourceRanges | indent 4 }}{{- end }}
+    {{- toYaml .Values.server.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-service.yaml
+++ b/charts/argo-workflows/templates/server/server-service.yaml
@@ -2,14 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.server.name }}
+  name: {{ template "argo-workflows.server.fullname" . }}
   labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- if .Values.server.serviceLabels }}
-    {{- toYaml .Values.server.serviceLabels | nindent 4 }}
-    {{- end }}
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.server.image.tag | quote }}
   {{- if .Values.server.serviceAnnotations }}
   annotations:
 {{ toYaml .Values.server.serviceAnnotations | indent 4}}{{- end }}
@@ -21,7 +17,7 @@ spec:
     {{- end }}
     targetPort: 2746
   selector:
-    app: {{ .Release.Name }}-{{ .Values.server.name }}
+    {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 4 }}
   sessionAffinity: None
   type: {{ .Values.server.serviceType }}
   {{- if and (eq .Values.server.serviceType "LoadBalancer") .Values.server.loadBalancerIP }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -172,6 +172,13 @@ server:
   podLabels: {}
   # SecurityContext to set on the server pods
   podSecurityContext: {}
+  securityContext:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   name: server
   serviceType: ClusterIP
   servicePort: 2746

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -235,36 +235,32 @@ server:
   ##
   ingress:
     enabled: false
+    annotations: {}
+    labels: {}
+    ingressClassName: ""
 
-    ## Annotations to be added to the web ingress.
+    ## Argo Workflows Server Ingress.
+    ## Hostnames must be provided if Ingress is enabled.
+    ## Secrets must be manually created in the namespace
     ##
-    # annotations:
-    #   kubernetes.io/ingress.class: nginx
-    #   kubernetes.io/tls-acme: "true"
+    hosts:
+      []
+      # - argocd.example.com
+    paths:
+      - /
+    extraPaths:
+      []
+      # - path: /*
+      #   backend:
+      #     serviceName: ssl-redirect
+      #     servicePort: use-annotation
+    tls:
+      []
+      # - secretName: argocd-example-tls
+      #   hosts:
+      #     - argocd.example.com
+    https: false
 
-    ## Labels to be added to the web ingress.
-    ##
-    # labels:
-    #   use-cloudflare-solver: "true"
-
-    ## Hostnames.
-    ## Must be provided if Ingress is enabled.
-    ##
-    # hosts:
-    #   - argo.domain.com
-
-    ## Additional Paths for each host
-    # paths:
-    #   - serviceName: "ssl-redirect"
-    #     servicePort: "use-annotation"
-
-    ## TLS configuration.
-    ## Secrets must be manually created in the namespace.
-    ##
-    # tls:
-    #   - secretName: argo-ui-tls
-    #     hosts:
-    #       - argo.domain.com
   clusterWorkflowTemplates:
     # Give the server permissions to edit ClusterWorkflowTemplates.
     enableEditing: true

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -1,0 +1,325 @@
+images:
+  # imagePullPolicy to apply to all containers
+  pullPolicy: Always
+  # Secrets with credentials to pull images from a private registry
+  pullSecrets: []
+  # - name: argo-pull-secret
+
+init:
+  # By default the installation will not set an explicit one, which will mean it uses `default` for the namespace the chart is
+  # being deployed to.  In RBAC clusters, that will almost certainly fail.  See the NOTES: section of the readme for more info.
+  serviceAccount: ""
+
+createAggregateRoles: true
+
+# Restrict Argo to only deploy into a single namespace by apply Roles and RoleBindings instead of the Cluster equivalents,
+# and start argo-cli with the --namespaced flag. Use it in clusters with strict access policy.
+singleNamespace: false
+
+workflow:
+  namespace: "" # Specify namespace if workflows run in another namespace than argo. This controls where the service account and RBAC resources will be created.
+  serviceAccount:
+    create: false # Specifies whether a service account should be created
+    annotations: {}
+    name: "argo-workflow" # Service account which is used to run workflows
+  rbac:
+    create: false # adds Role and RoleBinding for the above specified service account to be able to run workflows
+
+controller:
+  image:
+    registry: quay.io
+    repository: argoproj/workflow-controller
+    tag: v3.0.1
+  # parallelism dictates how many workflows can be running at the same time
+  parallelism:
+  # podAnnotations is an optional map of annotations to be applied to the controller Pods
+  podAnnotations: {}
+  # Optional labels to add to the controller pods
+  podLabels: {}
+  # SecurityContext to set on the controller pods
+  podSecurityContext: {}
+  # podPortName: http
+  metricsConfig:
+    enabled: false
+    path: /metrics
+    port: 9090
+  # the controller container's securityContext
+  securityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  persistence: {}
+  # connectionPool:
+  #   maxIdleConns: 100
+  #   maxOpenConns: 0
+  # # save the entire workflow into etcd and DB
+  # nodeStatusOffLoad: false
+  # # enable archiving of old workflows
+  # archive: false
+  # postgresql:
+  #   host: localhost
+  #   port: 5432
+  #   database: postgres
+  #   tableName: argo_workflows
+  #   # the database secrets must be in the same namespace of the controller
+  #   userNameSecret:
+  #     name: argo-postgres-config
+  #     key: username
+  #   passwordSecret:
+  #     name: argo-postgres-config
+  #     key: password
+  workflowDefaults: {} # Only valid for 2.7+
+  #  spec:
+  #    ttlStrategy:
+  #      secondsAfterCompletion: 84600
+  # workflowWorkers: 32
+  # podWorkers: 32
+  workflowRestrictions: {} # Only valid for 2.9+
+  #  templateReferencing: Strict|Secure
+  telemetryConfig:
+    enabled: false
+    path: /telemetry
+    port: 8081
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+  serviceAccount: argo
+  # Service account annotations
+  serviceAccountAnnotations: {}
+  name: workflow-controller
+  workflowNamespaces:
+    - default
+  containerRuntimeExecutor: docker
+  instanceID:
+    # `instanceID.enabled` configures the controller to filter workflow submissions
+    # to only those which have a matching instanceID attribute.
+    enabled: false
+    # NOTE: If `instanceID.enabled` is set to `true` then either `instanceID.userReleaseName`
+    # or `instanceID.explicitID` must be defined.
+    # useReleaseName: true
+    # explicitID: unique-argo-controller-identifier
+  logging:
+    level: info
+    globallevel: "0"
+  serviceType: ClusterIP
+  metricsServicePort: 8080
+  metricsServicePortName: metrics
+  telemetryServicePort: 8081
+  telemetryServicePortName: telemetry
+  # Annotations to be applied to the controller Service
+  serviceAnnotations: {}
+  # Optional labels to add to the controller Service
+  serviceLabels: {}
+  # Source ranges to allow access to service from. Only applies to
+  # service type `LoadBalancer`
+  loadBalancerSourceRanges: []
+  resources: {}
+  # The list of environment variable definitions to be added to the controller
+  # manages container verbatim.
+  extraEnv: []
+  # Extra arguments to be added to the controller
+  extraArgs: []
+  replicas: 1
+  pdb:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+  ## Node selectors and tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations: []
+  affinity: {}
+  # Leverage a PriorityClass to ensure your pods survive resource shortages
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  # PriorityClass: system-cluster-critical
+  priorityClassName: ""
+  # https://argoproj.github.io/argo/links/
+  links: []
+
+# executor controls how the init and wait container should be customized
+executor:
+  image:
+    registry: quay.io
+    repository: argoproj/argoexec
+    tag: v3.0.1
+  resources: {}
+  # Adds environment variables for the executor.
+  env: {}
+  # sets security context for the executor container
+  securityContext: {}
+
+server:
+  enabled: true
+  # only updates base url of resources on client side,
+  # it's expected that a proxy server rewrites the request URL and gets rid of this prefix
+  # https://github.com/argoproj/argo/issues/716#issuecomment-433213190
+  baseHref: /
+  image:
+    registry: quay.io
+    repository: argoproj/argocli
+    tag: v3.0.1
+  # optional map of annotations to be applied to the ui Pods
+  podAnnotations: {}
+  # Optional labels to add to the UI pods
+  podLabels: {}
+  # SecurityContext to set on the server pods
+  podSecurityContext: {}
+  name: server
+  serviceType: ClusterIP
+  servicePort: 2746
+  # servicePortName: http
+  serviceAccount: argo-server
+  # Whether to create the service account with the name specified in
+  # server.serviceAccount and bind it to the server role.
+  createServiceAccount: true
+  # Service account annotations
+  serviceAccountAnnotations: {}
+  # Annotations to be applied to the UI Service
+  serviceAnnotations: {}
+  # Optional labels to add to the UI Service
+  serviceLabels: {}
+  # Static IP address to assign to loadBalancer
+  # service type `LoadBalancer`
+  loadBalancerIP: ""
+  # Source ranges to allow access to service from. Only applies to
+  # service type `LoadBalancer`
+  loadBalancerSourceRanges: []
+  resources: {}
+  replicas: 1
+  pdb:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
+  ## Node selectors and tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations: []
+  affinity: {}
+  # Leverage a PriorityClass to ensure your pods survive resource shortages
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  # PriorityClass: system-cluster-critical
+  priorityClassName: ""
+
+  # Run the argo server in "secure" mode. Configure this value instead of
+  # "--secure" in extraArgs. See the following documentation for more details
+  # on secure mode:
+  # https://argoproj.github.io/argo-workflows/tls/
+  secure: false
+
+  # Extra arguments to provide to the Argo server binary.
+  extraArgs: []
+
+  ## Additional volumes to the server main container.
+  volumeMounts: []
+  volumes: []
+
+  ## Ingress configuration.
+  ## ref: https://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    enabled: false
+
+    ## Annotations to be added to the web ingress.
+    ##
+    # annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: "true"
+
+    ## Labels to be added to the web ingress.
+    ##
+    # labels:
+    #   use-cloudflare-solver: "true"
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - argo.domain.com
+
+    ## Additional Paths for each host
+    # paths:
+    #   - serviceName: "ssl-redirect"
+    #     servicePort: "use-annotation"
+
+    ## TLS configuration.
+    ## Secrets must be manually created in the namespace.
+    ##
+    # tls:
+    #   - secretName: argo-ui-tls
+    #     hosts:
+    #       - argo.domain.com
+  clusterWorkflowTemplates:
+    # Give the server permissions to edit ClusterWorkflowTemplates.
+    enableEditing: true
+  sso:
+    ## SSO configuration when SSO is specified as a server auth mode.
+    ## All the values are required. SSO is activated by adding --auth-mode=sso
+    ## to the server command line.
+    #
+    ## The root URL of the OIDC identity provider.
+    # issuer: https://accounts.google.com
+    ## Name of a secret and a key in it to retrieve the app OIDC client ID from.
+    # clientId:
+    #   name: argo-server-sso
+    #   key: client-id
+    ## Name of a secret and a key in it to retrieve the app OIDC client secret from.
+    # clientSecret:
+    #   name: argo-server-sso
+    #   key: client-secret
+    ## The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.
+    # redirectUrl: https://argo/oauth2/callback
+    # rbac:
+    #   enabled: true
+    ## When present, restricts secrets the server can read to a given list.
+    ## You can use it to restrict the server to only be able to access the
+    ## service account token secrets that are associated with service accounts
+    ## used for authorization.
+    #   secretWhitelist: []
+    ## Scopes requested from the SSO ID provider.  The 'groups' scope requests
+    ## group membership information, which is usually used for authorization
+    ## decisions.
+    # scopes:
+    # - groups
+
+# Influences the creation of the ConfigMap for the workflow-controller itself.
+useDefaultArtifactRepo: false
+useStaticCredentials: true
+artifactRepository:
+  # archiveLogs will archive the main container logs as an artifact
+  archiveLogs: false
+  s3:
+    # Note the `key` attribute is not the actual secret, it's the PATH to
+    # the contents in the associated secret, as defined by the `name` attribute.
+    accessKeySecret:
+      # name: <releaseName>-minio
+      key: accesskey
+    secretKeySecret:
+      # name: <releaseName>-minio
+      key: secretkey
+    insecure: true
+    # bucket:
+    # endpoint:
+    # region:
+    # roleARN:
+    # useSDKCreds: true
+  # gcs:
+  # bucket: <project>-argo
+  # keyFormat: "{{workflow.namespace}}/{{workflow.name}}/"
+  # serviceAccountKeySecret is a secret selector.
+  # It references the k8s secret named 'my-gcs-credentials'.
+  # This secret is expected to have have the key 'serviceAccountKey',
+  # containing the base64 encoded credentials
+  # to the bucket.
+  #
+  # If it's running on GKE and Workload Identity is used,
+  # serviceAccountKeySecret is not needed.
+  # serviceAccountKeySecret:
+  # name: my-gcs-credentials
+  # key: serviceAccountKey

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -29,7 +29,8 @@ controller:
   image:
     registry: quay.io
     repository: argoproj/workflow-controller
-    tag: v3.0.1
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   # parallelism dictates how many workflows can be running at the same time
   parallelism:
   # podAnnotations is an optional map of annotations to be applied to the controller Pods
@@ -146,7 +147,8 @@ executor:
   image:
     registry: quay.io
     repository: argoproj/argoexec
-    tag: v3.0.1
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   resources: {}
   # Adds environment variables for the executor.
   env: {}
@@ -162,7 +164,8 @@ server:
   image:
     registry: quay.io
     repository: argoproj/argocli
-    tag: v3.0.1
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
   # optional map of annotations to be applied to the ui Pods
   podAnnotations: {}
   # Optional labels to add to the UI pods

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -44,6 +44,8 @@ controller:
     enabled: false
     path: /metrics
     port: 9090
+    servicePort: 8080
+    servicePortName: metrics
   # the controller container's securityContext
   securityContext:
     readOnlyRootFilesystem: true
@@ -84,12 +86,16 @@ controller:
     enabled: false
     path: /telemetry
     port: 8081
+    servicePort: 8081
+    servicePortName: telemetry
   serviceMonitor:
     enabled: false
     additionalLabels: {}
-  serviceAccount: argo
-  # Service account annotations
-  serviceAccountAnnotations: {}
+  serviceAccount:
+    create: true
+    name: argo
+    # Annotations applied to created service account
+    annotations: {}
   name: workflow-controller
   workflowNamespaces:
     - default
@@ -106,10 +112,6 @@ controller:
     level: info
     globallevel: "0"
   serviceType: ClusterIP
-  metricsServicePort: 8080
-  metricsServicePortName: metrics
-  telemetryServicePort: 8081
-  telemetryServicePortName: telemetry
   # Annotations to be applied to the controller Service
   serviceAnnotations: {}
   # Optional labels to add to the controller Service
@@ -183,12 +185,10 @@ server:
   serviceType: ClusterIP
   servicePort: 2746
   # servicePortName: http
-  serviceAccount: argo-server
-  # Whether to create the service account with the name specified in
-  # server.serviceAccount and bind it to the server role.
-  createServiceAccount: true
-  # Service account annotations
-  serviceAccountAnnotations: {}
+  serviceAccount:
+    create: true
+    name: argo-server
+    annotations: {}
   # Annotations to be applied to the UI Service
   serviceAnnotations: {}
   # Optional labels to add to the UI Service

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -139,7 +139,7 @@ controller:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   # PriorityClass: system-cluster-critical
   priorityClassName: ""
-  # https://argoproj.github.io/argo/links/
+  # https://argoproj.github.io/argo-workflows/links/
   links: []
 
 # executor controls how the init and wait container should be customized
@@ -159,7 +159,7 @@ server:
   enabled: true
   # only updates base url of resources on client side,
   # it's expected that a proxy server rewrites the request URL and gets rid of this prefix
-  # https://github.com/argoproj/argo/issues/716#issuecomment-433213190
+  # https://github.com/argoproj/argo-workflows/issues/716#issuecomment-433213190
   baseHref: /
   image:
     registry: quay.io

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.11
+version: 1.0.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 dependencies:

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.10
+version: 0.16.11
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 dependencies:

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -5,11 +5,6 @@ name: argo
 version: 0.16.10
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
-maintainers:
-  - name: alexec
-  - name: alexmt
-  - name: jessesuen
-  - name: benjaminws
 dependencies:
 - name: minio
   version: 8.0.9

--- a/charts/argo/README.md
+++ b/charts/argo/README.md
@@ -1,5 +1,7 @@
 ## Argo Workflows Chart
 
+> ⚠ DEPRECATION WARNING: this chart is for v2 of Argo Workflows. For v3, a new chart is available at <https://github.com/argoproj/argo-helm/tree/master/charts/argo-workflows>
+
 This is a **community maintained** chart. It is used to set up argo and it's needed dependencies through one command. This is used in conjunction with [helm](https://github.com/kubernetes/helm).
 
 If you want your deployment of this helm chart to most closely match the [argo CLI](https://github.com/argoproj/argo-workflows), you should deploy it in the `kube-system` namespace.


### PR DESCRIPTION
Resolves #660:

uses the workaround of setting `--secure=false` by default: https://github.com/argoproj/argo-workflows/issues/5607

resolves #646:

renames the chart (while keeping the old one around but marking as deprecated)

resolves #636:

copied all the CRDs from https://github.com/argoproj/argo-workflows/tree/master/manifests/base/crds/minimal and updated clusterroles for the new workfloweventbindings resource

resolves #483:

while the apiextension version was bumped to v1, the resource spec was not updated correctly. This is solved by resolving #636 as well.

I've documented the breaking changes in the README. I tried not to change *too* much, but we could definitely break more - now is the time!

I've removed any included minio support for now until https://github.com/argoproj/argo-helm/pull/649 is resolved - so we can add it back later with a clean solution.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
