### PR TITLE
feat(argo-events): Add support for pod annotations.

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.2.5
+version: 1.3.0
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.2.4
+version: 1.2.5
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/templates/eventbus-controller-deployment.yaml
+++ b/charts/argo-events/templates/eventbus-controller-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: {{ .Release.Name }}-{{ .Values.eventbusController.name }}
         release: {{ .Release.Name }}
       {{- with .Values.eventbusController.podAnnotations }}
-      annotations: {{- . | toYaml | nindent 8 }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}

--- a/charts/argo-events/templates/eventbus-controller-deployment.yaml
+++ b/charts/argo-events/templates/eventbus-controller-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: {{ .Release.Name }}-{{ .Values.eventbusController.name }}
         release: {{ .Release.Name }}
+      {{- with .Values.eventbusController.podAnnotations }}
+      annotations: {{- . | toYaml | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       containers:

--- a/charts/argo-events/templates/eventsource-controller-deployment.yaml
+++ b/charts/argo-events/templates/eventsource-controller-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: {{ .Release.Name }}-{{ .Values.eventsourceController.name }}
         release: {{ .Release.Name }}
       {{- with .Values.eventsourceController.podAnnotations }}
-      annotations: {{- . | toYaml | nindent 8 }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}

--- a/charts/argo-events/templates/eventsource-controller-deployment.yaml
+++ b/charts/argo-events/templates/eventsource-controller-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: {{ .Release.Name }}-{{ .Values.eventsourceController.name }}
         release: {{ .Release.Name }}
+      {{- with .Values.eventsourceController.podAnnotations }}
+      annotations: {{- . | toYaml | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       containers:

--- a/charts/argo-events/templates/sensor-controller-deployment.yaml
+++ b/charts/argo-events/templates/sensor-controller-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: {{ .Release.Name }}-{{ .Values.sensorController.name }}
         release: {{ .Release.Name }}
       {{- with .Values.sensorController.podAnnotations }}
-      annotations: {{- . | toYaml | nindent 8 }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}

--- a/charts/argo-events/templates/sensor-controller-deployment.yaml
+++ b/charts/argo-events/templates/sensor-controller-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: {{ .Release.Name }}-{{ .Values.sensorController.name }}
         release: {{ .Release.Name }}
+      {{- with .Values.sensorController.podAnnotations }}
+      annotations: {{- . | toYaml | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       containers:

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -48,6 +48,7 @@ sensorController:
   tag: v1.2.3
   replicaCount: 1
   sensorImage: sensor
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: {}
   affinity: {}
@@ -58,6 +59,7 @@ eventsourceController:
   tag: v1.2.3
   replicaCount: 1
   eventsourceImage: eventsource
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: {}
   affinity: {}
@@ -67,6 +69,7 @@ eventbusController:
   image: eventbus-controller
   tag: v1.2.3
   replicaCount: 1
+  podAnnotations: {}
   nodeSelector: {}
   tolerations: {}
   affinity: {}


### PR DESCRIPTION
This change adds support for annotating pods generated by the main Argo Events controllers with custom annotations. This is needed, for example, for interacting with third party services collecting data from them.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
