### PR TITLE
feat(argocd-applicationset): Lookup referenced Configmaps on Install

### DIFF
--- a/charts/argocd-applicationset/Chart.yaml
+++ b/charts/argocd-applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationset
 description: A Helm chart for installing ArgoCD ApplicationSet
 type: application
-version: 0.1.3
+version: 0.2.0
 appVersion: "v0.1.0"
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png

--- a/charts/argocd-applicationset/templates/deployment.yaml
+++ b/charts/argocd-applicationset/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- $knownHosts := (lookup "v1" "ConfigMap" .Release.Namespace "argocd-ssh-known-hosts-cm") -}}
+{{- $tlsCerts := (lookup "v1" "ConfigMap" .Release.Namespace "argocd-tls-certs-cm") -}}
+{{- $gpgKeys:= (lookup "v1" "ConfigMap" .Release.Namespace "argocd-gpg-keys-cm") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,15 +53,15 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.mountSSHKnownHostsVolume }}
+            {{- if and $knownHosts .Values.mountSSHKnownHostsVolume }}
             - mountPath: /app/config/ssh
               name: ssh-known-hosts
             {{- end }}
-            {{- if .Values.mountTLSCertsVolume }}
+            {{- if and $tlsCerts .Values.mountTLSCertsVolume }}
             - mountPath: /app/config/tls
               name: tls-certs
             {{- end }}
-            {{- if .Values.mountGPGKeysVolume }}
+            {{- if and $gpgKeys .Values.mountGPGKeysVolume }}
             - mountPath: /app/config/gpg/source
               name: gpg-keys
             {{- end }}
@@ -67,17 +70,17 @@ spec:
               name: gpg-keyring
             {{- end }}
       volumes:
-      {{- if .Values.mountSSHKnownHostsVolume }}
+      {{- if and $knownHosts .Values.mountSSHKnownHostsVolume }}
       - configMap:
           name: argocd-ssh-known-hosts-cm
         name: ssh-known-hosts
       {{- end }}
-      {{- if .Values.mountTLSCertsVolume }}
+      {{- if and $tlsCerts .Values.mountTLSCertsVolume }}
       - configMap:
           name: argocd-tls-certs-cm
         name: tls-certs
       {{- end }}
-      {{- if .Values.mountGPGKeysVolume }}
+      {{- if and $gpgKeys .Values.mountGPGKeysVolume }}
       - configMap:
           name: argocd-gpg-keys-cm
         name: gpg-keys


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliverbaehler@hotmail.com>

With this feature we ensure that configmaps that don't exist are not mounted and therefor improve user experience. Also we can more easily install the chart in linting scenarios and no longer need to set the variables to false.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
