### PR TITLE
feat(argo-ci): deprecate argo-ci helm chart

### DIFF
--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -5,10 +5,6 @@ version: 1.0.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 appVersion: v1.0.0-alpha2
 home: https://github.com/argoproj/argo-helm
-maintainers:
-  - name: alexec
-  - name: alexmt
-  - name: jessesuen
 deprecated: true
 dependencies:
   - name: argo

--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for Argo-CI
 name: argo-ci
-version: 0.1.7
+version: 1.0.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 appVersion: v1.0.0-alpha2
 home: https://github.com/argoproj/argo-helm
@@ -9,3 +9,8 @@ maintainers:
   - name: alexec
   - name: alexmt
   - name: jessesuen
+deprecated: true
+dependencies:
+  - name: argo
+    version: "^0.16.0"
+    repository: https://argoproj.github.io/argo-helm

--- a/charts/argo-ci/README.md
+++ b/charts/argo-ci/README.md
@@ -1,3 +1,5 @@
 # Argo CI Chart
 
+**Deprecated** - Use [Argo-Events](./argo-events) instead.
+
 This is a **community maintained** chart.

--- a/charts/argo-ci/requirements.lock
+++ b/charts/argo-ci/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: argo
-  repository: https://argoproj.github.io/argo-helm
-  version: 0.2.1
-digest: sha256:af0f837200061b1720c0e05168dfc4a9537582f3004de62eeb5ef01b4c78db64
-generated: 2018-10-23T14:50:47.570677461-07:00

--- a/charts/argo-ci/requirements.yaml
+++ b/charts/argo-ci/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: argo
-  version: 0.2.1
-  repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliverbaehler@hotmail.com>

Since this chart is no longer used we officially should deprecate it. Therefore we can also exclude it for the new lint workflow. Last change has been 8 months ago. 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
