### PR TITLE
feat(argo-cd): Add label to cluster-secrets for usage with appSet cluster selector

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.2.0
+version: 3.2.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "argo-cd.name" $ }}-cluster-{{ .name }}
   labels:
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
+    {{- if .labels }}
+      {{- toYaml .labels | nindent 4 }}
+    {{- end }}
     argocd.argoproj.io/secret-type: cluster
   {{- with .annotations }}
   annotations:

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ include "argo-cd.name" $ }}-cluster-{{ .name }}
   labels:
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
-    {{- if .labels }}
-      {{- toYaml .labels | nindent 4 }}
+    {{- with .labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     argocd.argoproj.io/secret-type: cluster
   {{- with .annotations }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -881,8 +881,8 @@ configs:
   clusterCredentials: []
     # - name: mycluster
     #   server: https://mycluster.com
-    #   annotations: {}
     #   labels: {}
+    #   annotations: {}
     #   config:
     #     bearerToken: "<authentication token>"
     #     tlsClientConfig:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -881,6 +881,7 @@ configs:
   clusterCredentials: []
     # - name: mycluster
     #   server: https://mycluster.com
+    #   labels: {}
     #   annotations: {}
     #   config:
     #     bearerToken: "<authentication token>"
@@ -889,6 +890,7 @@ configs:
     #       caData: "<base64 encoded certificate>"
     # - name: mycluster2
     #   server: https://mycluster2.com
+    #   labels: {}
     #   annotations: {}
     #   namespaces: namespace1,namespace2
     #   config:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -881,8 +881,8 @@ configs:
   clusterCredentials: []
     # - name: mycluster
     #   server: https://mycluster.com
-    #   labels: {}
     #   annotations: {}
+    #   labels: {}
     #   config:
     #     bearerToken: "<authentication token>"
     #     tlsClientConfig:


### PR DESCRIPTION
Allow custom labels on remote cluster for usage with AppicationSet cluster generator label selector
https://argocd-applicationset.readthedocs.io/en/stable/Generators/#label-selector

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
