### PR TITLE
chore(argo): fix referenced URL

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.8
+version: 0.16.9
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -136,7 +136,7 @@ controller:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   # PriorityClass: system-cluster-critical
   priorityClassName: ""
-  # https://argoproj.github.io/argo/links/
+  # https://argoproj.github.io/argo-workflows/links/
   links: []
 
 # executor controls how the init and wait container should be customized
@@ -206,7 +206,7 @@ server:
   # Run the argo server in "secure" mode. Configure this value instead of
   # "--secure" in extraArgs. See the following documentation for more details
   # on secure mode:
-  # https://argoproj.github.io/argo/tls/#encrypted
+  # https://argoproj.github.io/argo-workflows/tls/#encrypted
   secure: false
 
   # Extra arguments to provide to the Argo server binary.


### PR DESCRIPTION
Some referenced URL were out dated due to [argo-workflow](https://argoproj.github.io/argo-workflows/) website's upgrade, so I fixed them. 😄 

Signed-off-by: Yuki Kitakata <yuki.kita22@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
