### PR TITLE
fix(argo-events): add missing status resources in rbac clusterrole

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.3.1
+version: 1.3.2
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/templates/argo-events-cluster-roles.yaml
+++ b/charts/argo-events/templates/argo-events-cluster-roles.yaml
@@ -47,10 +47,13 @@ rules:
       - workflowtemplates/finalizers
       - sensors
       - sensors/finalizers
+      - sensors/status
       - eventsources
       - eventsources/finalizers
+      - eventsources/status
       - eventbus
       - eventbus/finalizers
+      - eventbus/status
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Finishing off the work started here (https://github.com/argoproj/argo-helm/pull/667) to fix https://github.com/argoproj/argo-helm/pull/666


Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
