### PR TITLE
chore(argo): Fix service name in argo/templates/NOTES.txt

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.12.5
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.16.9
+version: 0.16.10
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/templates/NOTES.txt
+++ b/charts/argo/templates/NOTES.txt
@@ -11,6 +11,6 @@ argo submit https://raw.githubusercontent.com/argoproj/argo/master/examples/hell
 3. Access Minio UI and create bucket '{{ .Values.minio.defaultBucket.name }}'. Minio UI is available on port 9000 and available via external URL. URL might be retrieved using following
 command:
 
-kubectl --namespace {{ .Release.Namespace }} get services -o wide | grep {{ .Release.Name }}-minio-svc
+kubectl --namespace {{ .Release.Namespace }} get services -o wide | grep {{ .Release.Name }}-minio
 
 {{ end }}


### PR DESCRIPTION
Fix wrong MinIO service name in argo/templates/NOTES.txt

Signed-off-by: Ryan Lo <lowc1012@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
