### PR TITLE
fix: spec.preserveUnknownFields must be set to false to allow upgrades from v1beta1

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.5.0
+version: 0.5.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -17,6 +17,7 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -17,6 +17,7 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -17,6 +17,7 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -17,6 +17,7 @@ spec:
     shortNames:
     - exp
     singular: experiment
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -17,6 +17,7 @@ spec:
     shortNames:
     - ro
     singular: rollout
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
Follows https://github.com/argoproj/argo-rollouts/pull/1069 and fixes #604

This is just following along from prior work in the argo-rollouts repository to ensure that upgrades can happen between prior CRD API versions.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
