### PR TITLE
chore(argo-cd): upgrade redis-ha version to 4.12.14

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.10.4
-digest: sha256:e36321520ffd6f91962b0bcfeae947a86983d6b6d273eb616f08425e2b8ab9c2
-generated: "2021-04-14T13:41:16.151666-07:00"
+  version: 4.12.14
+digest: sha256:34275a4f4df92c570d07b0553da5d1fa200b6f057f7091746c853fd7399ee30a
+generated: "2021-05-03T16:02:41.4356045-04:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.2.2
+version: 3.2.3
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:
@@ -16,6 +16,6 @@ maintainers:
   - name: seanson
 dependencies:
   - name: redis-ha
-    version: 4.10.4
+    version: 4.12.14
     repository: https://dandydeveloper.github.io/charts/
     condition: redis-ha.enabled


### PR DESCRIPTION
Signed-off-by: Aniek Gul <aniekgul@hotmail.com>

This brings the redis-ha version in-line with what [argocd is using](https://github.com/argoproj/argo-cd/blob/master/manifests/ha/base/redis-ha/chart/requirements.yaml).

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
