### PR TITLE
chore(argo-events): update argo-events to app version 1.3.1

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.3.3
+version: 1.4.0
 keywords:
   - argo-events
   - sensor-controller
@@ -12,6 +12,6 @@ sources:
 maintainers:
   - name: VaibhavPage
   - name: whynowy
-appVersion: 1.2.3
+appVersion: 1.3.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -45,7 +45,7 @@ singleNamespace: true
 sensorController:
   name: sensor-controller
   image: sensor-controller
-  tag: v1.2.3
+  tag: v1.3.1
   replicaCount: 1
   sensorImage: sensor
   podAnnotations: {}
@@ -58,7 +58,7 @@ sensorController:
 eventsourceController:
   name: eventsource-controller
   image: eventsource-controller
-  tag: v1.2.3
+  tag: v1.3.1
   replicaCount: 1
   eventsourceImage: eventsource
   podAnnotations: {}
@@ -71,7 +71,7 @@ eventsourceController:
 eventbusController:
   name: eventbus-controller
   image: eventbus-controller
-  tag: v1.2.3
+  tag: v1.3.1
   replicaCount: 1
   podAnnotations: {}
   nodeSelector: {}


### PR DESCRIPTION
Updating helm chart to version 1.3.1 of argo-events.



Signed-off-by: Alec Rajeev <alecinthecloud@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
