### PR TITLE
feat(argo-cd): Extract ServiceMonitor interval to values

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.3.6
+version: 3.4.0
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.3.5
+version: 3.3.6
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -20,9 +20,7 @@ spec:
       {{- with .Values.controller.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.path }}
-      path: {{ . }}
-      {{- end }}
+      path: /metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -17,8 +17,12 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      interval: 30s
-      path: /metrics
+      {{- with .Values.controller.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -20,9 +20,7 @@ spec:
       {{- with .Values.controller.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.path }}
-      path: {{ . }}
-      {{- end }}
+      path: /metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -17,8 +17,12 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      interval: 30s
-      path: /metrics
+      {{- with .Values.controller.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -20,9 +20,7 @@ spec:
       {{- with .Values.controller.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.path }}
-      path: {{ . }}
-      {{- end }}
+      path: /metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -17,8 +17,12 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      interval: 30s
-      path: /metrics
+      {{- with .Values.controller.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -20,9 +20,7 @@ spec:
       {{- with .Values.controller.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.path }}
-      path: {{ . }}
-      {{- end }}
+      path: /metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -17,8 +17,12 @@ metadata:
 spec:
   endpoints:
     - port: metrics
-      interval: 30s
-      path: /metrics
+      {{- with .Values.controller.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.path }}
+      path: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -144,7 +144,6 @@ controller:
     serviceMonitor:
       enabled: false
       interval: 30s
-      path: /metrics
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
@@ -206,7 +205,6 @@ dex:
     serviceMonitor:
       enabled: false
       interval: 30s
-      path: /metrics
 
   image:
     repository: quay.io/dexidp/dex
@@ -495,7 +493,6 @@ server:
     serviceMonitor:
       enabled: false
       interval: 30s
-      path: /metrics
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
@@ -845,7 +842,6 @@ repoServer:
     serviceMonitor:
       enabled: false
       interval: 30s
-      path: /metrics
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -143,6 +143,8 @@ controller:
       servicePort: 8082
     serviceMonitor:
       enabled: false
+      interval: 30s
+      path: /metrics
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
@@ -203,6 +205,8 @@ dex:
       labels: {}
     serviceMonitor:
       enabled: false
+      interval: 30s
+      path: /metrics
 
   image:
     repository: quay.io/dexidp/dex
@@ -490,6 +494,8 @@ server:
       servicePort: 8083
     serviceMonitor:
       enabled: false
+      interval: 30s
+      path: /metrics
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
@@ -838,6 +844,8 @@ repoServer:
       servicePort: 8084
     serviceMonitor:
       enabled: false
+      interval: 30s
+      path: /metrics
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring


### PR DESCRIPTION
## Problem

My production environment is using 60s scrape interval:
- Some charts has no defaults(so used default value in prometheus and it is just works)
- Some charts has 30s defaults in values files
- This chart has hardcoded values in manifests, so no chance to use 60s interval

## Decisions

It is better to have no defaults at all, ServiceMonitor will be fallback to scrapeInterval from defined prometheus configuration, so one place to change scrape intervals and only one reason to add it manually - to override defaults if it really need

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.

## Templated version

```
helm template test-release -n test-namespace -f .\values.yaml  . > templated.yaml
```

```yaml
# Source: argo-cd/templates/argocd-application-controller/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release-argocd-application-controller
  labels:
    helm.sh/chart: argo-cd-3.3.5
    app.kubernetes.io/name: argocd-application-controller
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/component: application-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
spec:
  endpoints:
    - port: metrics
      interval: 30s
      path: /metrics
  namespaceSelector:
    matchNames:
      - test-namespace
  selector:
    matchLabels:
      app.kubernetes.io/name: argocd-metrics
      app.kubernetes.io/instance: test-release
      app.kubernetes.io/component: application-controller
---
# Source: argo-cd/templates/argocd-repo-server/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release-argocd-repo-server
  labels:
    helm.sh/chart: argo-cd-3.3.5
    app.kubernetes.io/name: argocd-repo-server
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/component: repo-server
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
spec:
  endpoints:
    - port: metrics
      interval: 30s
      path: /metrics
  namespaceSelector:
    matchNames:
      - test-namespace
  selector:
    matchLabels:
      app.kubernetes.io/name: argocd-repo-server-metrics
      app.kubernetes.io/instance: test-release
      app.kubernetes.io/component: repo-server
---
# Source: argo-cd/templates/argocd-server/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release-argocd-server
  labels:
    helm.sh/chart: argo-cd-3.3.5
    app.kubernetes.io/name: argocd-server
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/component: server
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
spec:
  endpoints:
    - port: metrics
      interval: 30s
      path: /metrics
  namespaceSelector:
    matchNames:
      - test-namespace
  selector:
    matchLabels:
      app.kubernetes.io/name: argocd-server-metrics
      app.kubernetes.io/instance: test-release
      app.kubernetes.io/component: server
---
# Source: argo-cd/templates/dex/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release-argocd-dex-server
  labels:
    helm.sh/chart: argo-cd-3.3.5
    app.kubernetes.io/name: argocd-dex-server
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/component: dex-server
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
spec:
  endpoints:
    - port: metrics
      interval: 30s
      path: /metrics
  namespaceSelector:
    matchNames:
      - test-namespace
  selector:
    matchLabels:
      app.kubernetes.io/name: argocd-dex-server
      app.kubernetes.io/instance: test-release
      app.kubernetes.io/component: dex-server
```
