### PR TITLE
fix(argo-cd): envFrom in repoServer

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.6.0
+version: 3.6.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -147,7 +147,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.extraArgs | Additional arguments for the controller. A list of flags | `[]` |
 | controller.enableStatefulSet | Enable deploying the controller as a StatefulSet instead of a Deployment. Used for HA installations. | `false` |
 | controller.env | Environment variables for the controller. | `[]` |
-| controller.envFrom | `envFrom` to pass to the controller. | `[]` (See [values.yaml](values.yaml) |
+| controller.envFrom | `envFrom` to pass to the controller. | `[]` (See [values.yaml](values.yaml)) |
 | controller.image.repository | Repository to use for the controller | `global.image.repository` |
 | controller.image.imagePullPolicy | Image pull policy for the controller | `global.image.imagePullPolicy` |
 | controller.image.tag | Tag to use for the controller | `global.image.tag` |
@@ -199,7 +199,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.containerPort | Repo server port | `8081` |
 | repoServer.extraArgs | Additional arguments for the repo server. A  list of flags. | `[]` |
 | repoServer.env | Environment variables for the repo server. | `[]` |
-| repoServer.envFrom | `envFrom` to pass to the repo server. | `[]` (See [values.yaml](values.yaml) |
+| repoServer.envFrom | `envFrom` to pass to the repo server. | `[]` (See [values.yaml](values.yaml)) |
 | repoServer.image.repository | Repository to use for the repo server | `global.image.repository` |
 | repoServer.image.imagePullPolicy | Image pull policy for the repo server | `global.image.imagePullPolicy` |
 | repoServer.image.tag | Tag to use for the repo server | `global.image.tag` |
@@ -260,7 +260,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.containerPort | Server container port. | `8080` |
 | server.extraArgs | Additional arguments for the server. A list of flags. | `[]` |
 | server.env | Environment variables for the server. | `[]` |
-| server.envFrom | `envFrom` to pass to the server. | `[]` (See [values.yaml](values.yaml) |
+| server.envFrom | `envFrom` to pass to the server. | `[]` (See [values.yaml](values.yaml)) |
 | server.image.repository | Repository to use for the server | `global.image.repository` |
 | server.image.imagePullPolicy | Image pull policy for the server | `global.image.imagePullPolicy` |
 | server.image.tag | Tag to use for the server | `global.image.tag` |
@@ -346,7 +346,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | dex.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | dex.name | Dex name | `"dex-server"` |
 | dex.env | Environment variables for the Dex server. | `[]` |
-| dex.envFrom | `envFrom` to pass to the Dex server. | `[]` (See [values.yaml](values.yaml) |
+| dex.envFrom | `envFrom` to pass to the Dex server. | `[]` (See [values.yaml](values.yaml)) |
 | dex.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | dex.podAnnotations | Annotations for the Dex server pods | `{}` |
 | dex.podLabels | Labels for the Dex server pods | `{}` |
@@ -380,7 +380,7 @@ through `xxx.extraArgs`
 | redis.extraArgs | Additional arguments for the `redis-server`. A list of flags. | `[]` |
 | redis.name | Redis name | `"redis"` |
 | redis.env | Environment variables for the Redis server. | `[]` |
-| redis.envFrom | `envFrom` to pass to the Redis server. | `[]` (See [values.yaml](values.yaml) |
+| redis.envFrom | `envFrom` to pass to the Redis server. | `[]` (See [values.yaml](values.yaml)) |
 | redis.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | redis.podAnnotations | Annotations for the Redis server pods | `{}` |
 | redis.podLabels | Labels for the Redis server pods | `{}` |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -147,7 +147,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.extraArgs | Additional arguments for the controller. A list of flags | `[]` |
 | controller.enableStatefulSet | Enable deploying the controller as a StatefulSet instead of a Deployment. Used for HA installations. | `false` |
 | controller.env | Environment variables for the controller. | `[]` |
-| controller.envFrom | `envFrom` to pass to the controller. | `[]` |
+| controller.envFrom | `envFrom` to pass to the controller. | `[]` (See [values.yaml](values.yaml) |
 | controller.image.repository | Repository to use for the controller | `global.image.repository` |
 | controller.image.imagePullPolicy | Image pull policy for the controller | `global.image.imagePullPolicy` |
 | controller.image.tag | Tag to use for the controller | `global.image.tag` |
@@ -199,7 +199,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.containerPort | Repo server port | `8081` |
 | repoServer.extraArgs | Additional arguments for the repo server. A  list of flags. | `[]` |
 | repoServer.env | Environment variables for the repo server. | `[]` |
-| repoServer.envFrom | `envFrom` to pass to the repo server. | `[]` |
+| repoServer.envFrom | `envFrom` to pass to the repo server. | `[]` (See [values.yaml](values.yaml) |
 | repoServer.image.repository | Repository to use for the repo server | `global.image.repository` |
 | repoServer.image.imagePullPolicy | Image pull policy for the repo server | `global.image.imagePullPolicy` |
 | repoServer.image.tag | Tag to use for the repo server | `global.image.tag` |
@@ -260,7 +260,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.containerPort | Server container port. | `8080` |
 | server.extraArgs | Additional arguments for the server. A list of flags. | `[]` |
 | server.env | Environment variables for the server. | `[]` |
-| server.envFrom | `envFrom` to pass to the server. | `[]` |
+| server.envFrom | `envFrom` to pass to the server. | `[]` (See [values.yaml](values.yaml) |
 | server.image.repository | Repository to use for the server | `global.image.repository` |
 | server.image.imagePullPolicy | Image pull policy for the server | `global.image.imagePullPolicy` |
 | server.image.tag | Tag to use for the server | `global.image.tag` |
@@ -346,7 +346,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | dex.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | dex.name | Dex name | `"dex-server"` |
 | dex.env | Environment variables for the Dex server. | `[]` |
-| dex.envFrom | `envFrom` to pass to the Dex server. | `[]` |
+| dex.envFrom | `envFrom` to pass to the Dex server. | `[]` (See [values.yaml](values.yaml) |
 | dex.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | dex.podAnnotations | Annotations for the Dex server pods | `{}` |
 | dex.podLabels | Labels for the Dex server pods | `{}` |
@@ -380,7 +380,7 @@ through `xxx.extraArgs`
 | redis.extraArgs | Additional arguments for the `redis-server`. A list of flags. | `[]` |
 | redis.name | Redis name | `"redis"` |
 | redis.env | Environment variables for the Redis server. | `[]` |
-| redis.envFrom | `envFrom` to pass to the Redis server. | `[]` |
+| redis.envFrom | `envFrom` to pass to the Redis server. | `[]` (See [values.yaml](values.yaml) |
 | redis.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | redis.podAnnotations | Annotations for the Redis server pods | `{}` |
 | redis.podLabels | Labels for the Redis server pods | `{}` |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -147,6 +147,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | controller.extraArgs | Additional arguments for the controller. A list of flags | `[]` |
 | controller.enableStatefulSet | Enable deploying the controller as a StatefulSet instead of a Deployment. Used for HA installations. | `false` |
 | controller.env | Environment variables for the controller. | `[]` |
+| controller.envFrom | `envFrom` to pass to the controller. | `[]` |
 | controller.image.repository | Repository to use for the controller | `global.image.repository` |
 | controller.image.imagePullPolicy | Image pull policy for the controller | `global.image.imagePullPolicy` |
 | controller.image.tag | Tag to use for the controller | `global.image.tag` |
@@ -198,6 +199,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | repoServer.containerPort | Repo server port | `8081` |
 | repoServer.extraArgs | Additional arguments for the repo server. A  list of flags. | `[]` |
 | repoServer.env | Environment variables for the repo server. | `[]` |
+| repoServer.envFrom | `envFrom` to pass to the repo server. | `[]` |
 | repoServer.image.repository | Repository to use for the repo server | `global.image.repository` |
 | repoServer.image.imagePullPolicy | Image pull policy for the repo server | `global.image.imagePullPolicy` |
 | repoServer.image.tag | Tag to use for the repo server | `global.image.tag` |
@@ -258,6 +260,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | server.containerPort | Server container port. | `8080` |
 | server.extraArgs | Additional arguments for the server. A list of flags. | `[]` |
 | server.env | Environment variables for the server. | `[]` |
+| server.envFrom | `envFrom` to pass to the server. | `[]` |
 | server.image.repository | Repository to use for the server | `global.image.repository` |
 | server.image.imagePullPolicy | Image pull policy for the server | `global.image.imagePullPolicy` |
 | server.image.tag | Tag to use for the server | `global.image.tag` |
@@ -343,6 +346,7 @@ Helm v3 has removed the `install-crds` hook so CRDs are now populated by files i
 | dex.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
 | dex.name | Dex name | `"dex-server"` |
 | dex.env | Environment variables for the Dex server. | `[]` |
+| dex.envFrom | `envFrom` to pass to the Dex server. | `[]` |
 | dex.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | dex.podAnnotations | Annotations for the Dex server pods | `{}` |
 | dex.podLabels | Labels for the Dex server pods | `{}` |
@@ -376,6 +380,7 @@ through `xxx.extraArgs`
 | redis.extraArgs | Additional arguments for the `redis-server`. A list of flags. | `[]` |
 | redis.name | Redis name | `"redis"` |
 | redis.env | Environment variables for the Redis server. | `[]` |
+| redis.envFrom | `envFrom` to pass to the Redis server. | `[]` |
 | redis.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | redis.podAnnotations | Annotations for the Redis server pods | `{}` |
 | redis.podLabels | Labels for the Redis server pods | `{}` |

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           value: argocd
 {{- end }}
 {{- end }}
-        {{- with .Values.openshift.envFrom }}
+        {{- with .Values.repoServer.envFrom }}
         envFrom: {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:


### PR DESCRIPTION
Fix typo introduced in https://github.com/argoproj/argo-helm/pull/743

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
