### PR TITLE
feat(argo-rollouts): Update manifests for v1.0.1

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
-appVersion: "0.10.2"
+apiVersion: v2
+appVersion: "v1.0.1"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 0.5.5
+version: 1.0.0
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -22,7 +22,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add argo https://argoproj.github.io/argo-helm
-$ helm install --name my-release argo/argo-rollouts
+$ helm install my-release argo/argo-rollouts
 ```
 
 ## Chart Values
@@ -62,6 +62,8 @@ $ helm install --name my-release argo/argo-rollouts
 * `quay.io` is the default registry now
 * We introduce a template function for the labels here to reduce code duplication. This also affects the Deployment `matchLabels` selector.  
   To upgrade an existing installation, please **add the `--force` parameter** to the `helm upgrade` command or **delete the Deployment resource** before you upgrade. This is necessary because Deployment's label selector is immutable.
+* All resources are now prefixed with the template `"argo-rollouts.fullname"`.
+  This enables the users to override resource names via the `nameOverride` and `fullnameOverride` parameters.
 * Breaking parameters update
   * `securityContext` was renamed to `containerSecurityContext`
   * Added `controller.image.registry`. Prior to this chart version you had to override the registry via `controller.image.repository`

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -1,12 +1,11 @@
-Argo Rollouts Chart
-=============
-A Helm chart for Argo Rollouts, progressive delivery for Kubernetes.
+# Argo Rollouts Chart
 
-Current chart version is `0.5.4`
+A Helm chart for Argo Rollouts, progressive delivery for Kubernetes.
 
 Source code can be found [here](https://github.com/argoproj/argo-rollouts)
 
 ## Additional Information
+
 This is a **community maintained** chart. This chart installs [argo-rollouts](https://argoproj.github.io/argo-rollouts/), progressive delivery for Kubernetes.
 
 The default installation is intended to be similar to the provided Argo Rollouts [releases](https://github.com/argoproj/argo-rollouts/releases).
@@ -14,6 +13,7 @@ The default installation is intended to be similar to the provided Argo Rollouts
 ## Prerequisites
 
 - Kubernetes 1.7+
+- Helm v3.0.0+
 
 
 ## Installing the Chart
@@ -29,20 +29,37 @@ $ helm install --name my-release argo/argo-rollouts
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| clusterInstall | bool | `true` |  |
-| controller.component | string | `"rollouts-controller"` |  |
-| controller.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controller.image.repository | string | `"argoproj/argo-rollouts"` |  |
-| controller.image.tag | string | `"v0.10.2"` |  |
-| controller.name | string | `"argo-rollouts"` |  |
-| controller.resources | Resource limits and requests for the controller pods. | `{}` |
-| controller.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
-| controller.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
-| controller.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
-| controller.metrics.serviceMonitor.enabled | bool | `false` |  |
-| imagePullSecrets | list | `[]` |  |
-| installCRDs | bool | `true` |  |
-| crdAnnotations | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| serviceAccount.name | string | `"argo-rollouts"` |  |
+| clusterInstall | bool | `true` | `false` runs controller in namespaced mode (does not require cluster RBAC) |
+| controller.component | string | `"rollouts-controller"` | Value of label `app.kubernetes.io/component` |
+| controller.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| controller.image.registry | string | `quay.io` | Registry to use |
+| controller.image.repository | string | `"argoproj/argo-rollouts"` | Repository to use |
+| controller.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
+| controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
+| controller.tolerations | list | `[]` | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
+| controller.affinity | object | `{}` | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
+| controller.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) |
+| controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
+| controller.metrics.serviceMonitor.additionalAnnotations | object | `{}` | Annotations to be added to the ServiceMonitor |
+| controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Labels to be added to the ServiceMonitor |
+| imagePullSecrets | list | `[]` | Registry secret names as an array |
+| installCRDs | bool | `true` | Install and upgrade CRDs |
+| crdAnnotations | object | `{}` | Annotations to be added to all CRDs |
+| podAnnotations | object | `{}` | Annotations to be added to the Rollout pods |
+| podLabels | object | `{}` | Labels to be added to the Rollout pods |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| podSecurityContext | object | `{"runAsNonRoot": true}` | Security Context to set on pod level |
+| containerSecurityContext | object | `{}` | Security Context to set on container level |
+
+## Upgrading
+
+### To 1.0.0
+
+* This is a breaking change which only supports Helm v3.0.0+ now. If you still use Helm v2, please consider upgrading because v2 is EOL since November 2020.  
+  To migrate to Helm v3 please have a look at the [Helm 2to3 Plugin](https://github.com/helm/helm-2to3). This tool will convert the existing ConfigMap used for Tiller to a Secret of type `helm.sh/release.v1`.
+* `quay.io` is the default registry now
+* Breaking parameters update
+  * `securityContext` was renamed to `containerSecurityContext`
+  * Added `controller.image.registry`. Prior to this chart version you had to override the registry via `controller.image.repository`

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -60,6 +60,8 @@ $ helm install --name my-release argo/argo-rollouts
 * This is a breaking change which only supports Helm v3.0.0+ now. If you still use Helm v2, please consider upgrading because v2 is EOL since November 2020.  
   To migrate to Helm v3 please have a look at the [Helm 2to3 Plugin](https://github.com/helm/helm-2to3). This tool will convert the existing ConfigMap used for Tiller to a Secret of type `helm.sh/release.v1`.
 * `quay.io` is the default registry now
+* We introduce a template function for the labels here to reduce code duplication. This also affects the Deployment `matchLabels` selector.  
+  To upgrade an existing installation, please **add the `--force` parameter** to the `helm upgrade` command or **delete the Deployment resource** before you upgrade. This is necessary because Deployment's label selector is immutable.
 * Breaking parameters update
   * `securityContext` was renamed to `containerSecurityContext`
   * Added `controller.image.registry`. Prior to this chart version you had to override the registry via `controller.image.repository`

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "argo-rollouts.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "argo-rollouts.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "argo-rollouts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -32,6 +32,27 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "argo-rollouts.labels" -}}
+helm.sh/chart: {{ include "argo-rollouts.chart" . }}
+{{ include "argo-rollouts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: argo-rollouts
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "argo-rollouts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argo-rollouts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "argo-rollouts.serviceAccountName" -}}

--- a/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
@@ -6,9 +6,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-view
-    app.kubernetes.io/part-of: argo-rollouts
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io
@@ -32,9 +30,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-edit
-    app.kubernetes.io/part-of: argo-rollouts
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io
@@ -64,9 +60,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-admin
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
@@ -2,12 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-aggregate-to-view
+  name: {{ include "argo-rollouts.fullname" . }}-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/component: {{ .Values.controller.component }}
     app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-view
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 - apiGroups:
   - argoproj.io
@@ -27,12 +28,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-aggregate-to-edit
+  name: {{ include "argo-rollouts.fullname" . }}-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/component: {{ .Values.controller.component }}
     app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-edit
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
+    app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 - apiGroups:
   - argoproj.io
@@ -58,12 +60,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-aggregate-to-admin
+  name: {{ include "argo-rollouts.fullname" . }}-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/component: aggregate-cluster-role
+    app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name:  {{ .Release.Name }}-aggregate-to-admin
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-aggregate-roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "argo-rollouts.fullname" . }}-view
+  name: {{ include "argo-rollouts.fullname" . }}-aggregate-to-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     app.kubernetes.io/component: {{ .Values.controller.component }}
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "argo-rollouts.fullname" . }}-edit
+  name: {{ include "argo-rollouts.fullname" . }}-aggregate-to-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     app.kubernetes.io/component: {{ .Values.controller.component }}
@@ -56,7 +56,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "argo-rollouts.fullname" . }}-admin
+  name: {{ include "argo-rollouts.fullname" . }}-aggregate-to-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/component: {{ .Values.controller.component }}

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -2,11 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-clusterrole
+  name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}-clusterrole
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
 rules:
 - apiGroups:
   - argoproj.io
@@ -57,6 +58,16 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  - apps
+  resources:
+  - deployments
+  - podtemplates
+  verbs:
+  - get
+  - list
+  - watch
 # services patch needed to update selector of canary/stable/active/preview services
 - apiGroups:
   - ""
@@ -135,6 +146,7 @@ rules:
   - watch
   - get
   - update
+  - patch
   - list
 # trafficsplit access needed for using the SMI provider
 - apiGroups:
@@ -147,4 +159,15 @@ rules:
   - get
   - update
   - patch
+- apiGroups:
+  - getambassador.io
+  resources:
+  - mappings
+  verbs:
+  - create
+  - watch
+  - get
+  - update
+  - list
+  - delete
 {{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}-clusterrole
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrolebinding.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrolebinding.yaml
@@ -2,17 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-clusterrolebinding
+  name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}-clusterrolebinding
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-clusterrole
+  name: {{ include "argo-rollouts.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "argo-rollouts.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrolebinding.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrolebinding.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}-clusterrolebinding
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -1,50 +1,56 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/part-of: {{ .Release.Name }}
-    {{- if .Values.podLabels }}
-{{- toYaml .Values.podLabels | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/part-of: argo-rollouts
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Release.Name }}
+  strategy:
+    type: Recreate
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       annotations:
-      {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         app.kubernetes.io/name: {{ .Release.Name }}
+        {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}
       containers:
-      - image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+      - image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
         {{- if not .Values.clusterInstall }}
         args:
         - --namespaced
         {{- end }}
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-        name: {{ .Values.controller.name }}
+        name: argo-rollouts
+        ports:
+        - containerPort: 8090
+          name: metrics
         securityContext:
-          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
       {{- if .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.controller.nodeSelector | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.controller.tolerations }}
       tolerations:
         {{- toYaml .Values.controller.tolerations | nindent 8 }}
@@ -53,5 +59,3 @@ spec:
       affinity:
         {{- toYaml .Values.controller.affinity | nindent 8 }}
       {{- end }}
-  strategy:
-    type: Recreate

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -4,13 +4,11 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      {{- include "argo-rollouts.selectorLabels" . | nindent 6 }}
   strategy:
     type: Recreate
   template:
@@ -20,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
+        {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
         {{- range $key, $value := .Values.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}-metrics
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}-metrics
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
   {{- with .Values.serviceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,5 +17,5 @@ spec:
     port: 8090
     targetPort: 8090
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    {{- include "argo-rollouts.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
@@ -1,14 +1,16 @@
+{{- if .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-metrics
+  name: {{ include "argo-rollouts.fullname" . }}-metrics
   labels:
     app.kubernetes.io/component: server
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}-metrics
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
+  {{- with .Values.serviceAnnotations }}
   annotations:
-  {{- range $key, $value := .Values.serviceAnnotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ports:
@@ -18,3 +20,4 @@ spec:
     targetPort: 8090
   selector:
     app.kubernetes.io/name: {{ .Release.Name }}
+{{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-role.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-role.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}-role
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo-rollouts/templates/argo-rollouts-role.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-role.yaml
@@ -1,11 +1,13 @@
+{{- if not .Values.clusterInstall }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-role
+  name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}-role
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
 rules:
 - apiGroups:
   - argoproj.io
@@ -145,3 +147,4 @@ rules:
   - get
   - update
   - patch
+{{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-rolebinding.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-rolebinding.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}-role-binding
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/argo-rollouts/templates/argo-rollouts-rolebinding.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-rolebinding.yaml
@@ -1,15 +1,18 @@
+{{- if not .Values.clusterInstall }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-role-binding
+  name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}-role-binding
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-role
+  name: {{ include "argo-rollouts.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "argo-rollouts.serviceAccountName" . }}
+{{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-sa.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-sa.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.serviceAccountName" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-rollouts/templates/argo-rollouts-sa.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-sa.yaml
@@ -1,8 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "argo-rollouts.serviceAccountName" . }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/part-of: argo-rollouts
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-service-monitor.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-service-monitor.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }}-metrics
-    app.kubernetes.io/part-of: argo-rollouts
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.controller.metrics.serviceMonitor.additionalLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -24,7 +22,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: server
-      app.kubernetes.io/name: {{ .Release.Name }}-metrics
-      app.kubernetes.io/part-of: argo-rollouts
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "argo-rollouts.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/argo-rollouts/templates/argo-rollouts-service-monitor.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-service-monitor.yaml
@@ -2,17 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "argo-rollouts.fullname" . }}
   labels:
     app.kubernetes.io/component: server
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: {{ .Release.Name }}-metrics
-    app.kubernetes.io/part-of: {{ .Release.Name }}
-    {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    app.kubernetes.io/part-of: argo-rollouts
+    {{- range $key, $value := .Values.controller.metrics.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
-  {{- if .Values.controller.metrics.serviceMonitor.additionalAnnotations }}
+  {{- with .Values.controller.metrics.serviceMonitor.additionalAnnotations }}
   annotations:
-{{ toYaml .Values.controller.metrics.serviceMonitor.additionalAnnotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   endpoints:
@@ -24,5 +25,6 @@ spec:
     matchLabels:
       app.kubernetes.io/component: server
       app.kubernetes.io/name: {{ .Release.Name }}-metrics
-      app.kubernetes.io/part-of: {{ .Release.Name }}
+      app.kubernetes.io/part-of: argo-rollouts
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
     {{- if .Values.crdAnnotations }}
-{{- toYaml .Values.crdAnnotations | nindent 4 }}
+    {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: argo-rollouts
@@ -2308,6 +2308,7 @@ spec:
                                       start:
                                         type: string
                                       step:
+                                        format: int64
                                         type: integer
                                     required:
                                     - end
@@ -2327,6 +2328,7 @@ spec:
                                       start:
                                         type: string
                                       step:
+                                        format: int64
                                         type: integer
                                     required:
                                     - end
@@ -2348,8 +2350,10 @@ spec:
                             threshold:
                               properties:
                                 marginal:
+                                  format: int64
                                   type: integer
                                 pass:
+                                  format: int64
                                   type: integer
                               required:
                               - marginal
@@ -2407,6 +2411,7 @@ spec:
                             jsonPath:
                               type: string
                             timeoutSeconds:
+                              format: int64
                               type: integer
                             url:
                               type: string

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
     {{- if .Values.crdAnnotations }}
-{{- toYaml .Values.crdAnnotations | nindent 4 }}
+    {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: argo-rollouts
@@ -2303,6 +2303,7 @@ spec:
                                       start:
                                         type: string
                                       step:
+                                        format: int64
                                         type: integer
                                     required:
                                     - end
@@ -2322,6 +2323,7 @@ spec:
                                       start:
                                         type: string
                                       step:
+                                        format: int64
                                         type: integer
                                     required:
                                     - end
@@ -2343,8 +2345,10 @@ spec:
                             threshold:
                               properties:
                                 marginal:
+                                  format: int64
                                   type: integer
                                 pass:
+                                  format: int64
                                   type: integer
                               required:
                               - marginal
@@ -2402,6 +2406,7 @@ spec:
                             jsonPath:
                               type: string
                             timeoutSeconds:
+                              format: int64
                               type: integer
                             url:
                               type: string

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
     {{- if .Values.crdAnnotations }}
-{{- toYaml .Values.crdAnnotations | nindent 4 }}
+    {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: argo-rollouts
@@ -2303,6 +2303,7 @@ spec:
                                       start:
                                         type: string
                                       step:
+                                        format: int64
                                         type: integer
                                     required:
                                     - end
@@ -2322,6 +2323,7 @@ spec:
                                       start:
                                         type: string
                                       step:
+                                        format: int64
                                         type: integer
                                     required:
                                     - end
@@ -2343,8 +2345,10 @@ spec:
                             threshold:
                               properties:
                                 marginal:
+                                  format: int64
                                   type: integer
                                 pass:
+                                  format: int64
                                   type: integer
                               required:
                               - marginal
@@ -2402,6 +2406,7 @@ spec:
                             jsonPath:
                               type: string
                             timeoutSeconds:
+                              format: int64
                               type: integer
                             url:
                               type: string

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
     {{- if .Values.crdAnnotations }}
-{{- toYaml .Values.crdAnnotations | nindent 4 }}
+    {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: argo-rollouts

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
     {{- if .Values.crdAnnotations }}
-{{- toYaml .Values.crdAnnotations | nindent 4 }}
+    {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: argo-rollouts
@@ -32,11 +32,13 @@ spec:
       jsonPath: .status.replicas
       name: Current
       type: integer
-    - description: Total number of non-terminated pods targeted by this rollout that have the desired template spec
+    - description: Total number of non-terminated pods targeted by this rollout that
+        have the desired template spec
       jsonPath: .status.updatedReplicas
       name: Up-to-date
       type: integer
-    - description: Total number of available pods (ready for at least minReadySeconds) targeted by this rollout
+    - description: Total number of available pods (ready for at least minReadySeconds)
+        targeted by this rollout
       jsonPath: .status.availableReplicas
       name: Available
       type: integer
@@ -303,6 +305,12 @@ spec:
                         - type: integer
                         - type: string
                         x-kubernetes-int-or-string: true
+                      scaleDownDelayRevisionLimit:
+                        format: int32
+                        type: integer
+                      scaleDownDelaySeconds:
+                        format: int32
+                        type: integer
                       stableMetadata:
                         properties:
                           annotations:
@@ -489,6 +497,15 @@ spec:
                             required:
                             - ingress
                             - servicePort
+                            type: object
+                          ambassador:
+                            properties:
+                              mappings:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - mappings
                             type: object
                           istio:
                             properties:
@@ -2651,9 +2668,15 @@ spec:
                     - containers
                     type: object
                 type: object
-            required:
-            - selector
-            - template
+              workloadRef:
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                type: object
             type: object
           status:
             properties:
@@ -2768,6 +2791,8 @@ spec:
               currentStepIndex:
                 format: int32
                 type: integer
+              message:
+                type: string
               observedGeneration:
                 type: string
               pauseConditions:
@@ -2783,6 +2808,8 @@ spec:
                   - startTime
                   type: object
                 type: array
+              phase:
+                type: string
               promoteFull:
                 type: boolean
               readyReplicas:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -3,7 +3,6 @@ installCRDs: true
 clusterInstall: true
 
 controller:
-  name: argo-rollouts
   component: rollouts-controller
   ## Node selectors and tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -12,8 +11,9 @@ controller:
   tolerations: []
   affinity: {}
   image:
+    registry: quay.io
     repository: argoproj/argo-rollouts
-    tag: v0.10.2
+    tag: ""
     pullPolicy: IfNotPresent
 
   resources: {}
@@ -31,7 +31,13 @@ controller:
       additionalAnnotations: {}
 
 serviceAccount:
-  name: argo-rollouts
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 ## Annotations to be added to all CRDs
 ##
@@ -40,6 +46,21 @@ crdAnnotations: {}
 ## Annotations to be added to the Rollout pods
 ##
 podAnnotations: {}
+
+## Security Context to set on pod level
+##
+podSecurityContext:
+  runAsNonRoot: true
+
+## Security Context to set on container level
+##
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
 ## Annotations to be added to the Rollout service
 ##


### PR DESCRIPTION
Resolves #740 
This also resolves #754 since we now use the template function `"argo-rollouts.fullname"` whenever possible.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] ~Any new values are backwards compatible and/or have sensible default.~
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
