### PR TITLE
chore(argo-events): Use container images from quay.io

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.6.0
+version: 1.6.1
 keywords:
   - argo-events
   - sensor-controller

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -1,5 +1,5 @@
 # docker registry
-registry: argoproj
+registry: quay.io
 
 # The image pull policy
 imagePullPolicy: Always
@@ -47,10 +47,10 @@ singleNamespace: true
 # sensor controller
 sensorController:
   name: sensor-controller
-  image: sensor-controller
+  image: argoproj/sensor-controller
   tag: v1.3.1
   replicaCount: 1
-  sensorImage: sensor
+  sensorImage: argoproj/sensor
   podAnnotations: {}
   nodeSelector: {}
   podLabels: {}
@@ -61,10 +61,10 @@ sensorController:
 
 eventsourceController:
   name: eventsource-controller
-  image: eventsource-controller
+  image: argoproj/eventsource-controller
   tag: v1.3.1
   replicaCount: 1
-  eventsourceImage: eventsource
+  eventsourceImage: argoproj/eventsource
   podAnnotations: {}
   nodeSelector: {}
   podLabels: {}
@@ -75,7 +75,7 @@ eventsourceController:
 
 eventbusController:
   name: eventbus-controller
-  image: eventbus-controller
+  image: argoproj/eventbus-controller
   tag: v1.3.1
   replicaCount: 1
   podAnnotations: {}


### PR DESCRIPTION
Upstream is changing to `quay.io`:
https://github.com/argoproj/argo-events/blob/master/manifests/base/sensor-controller/sensor-controller-deployment.yaml#L21
Let's change this in the chart default too.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
