### PR TITLE
fix(argo-cd): Update dex to v2.27.0

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.3
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.6.3
+version: 3.6.4
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -216,8 +216,8 @@ dex:
       interval: 30s
 
   image:
-    repository: quay.io/dexidp/dex
-    tag: v2.26.0
+    repository: ghcr.io/dexidp/dex
+    tag: v2.27.0
     imagePullPolicy: IfNotPresent
   initImage:
     repository:


### PR DESCRIPTION
We missed the update to dex v2.27.0 in the argo-cd release 1.8.2: https://github.com/argoproj/argo-cd/releases/tag/v1.8.2

The update to 2.27.0 should reduce the security issue(s):
![image](https://user-images.githubusercontent.com/7290987/120068035-e9736c00-c07e-11eb-9402-c9d6e3708cc1.png)
Ref:https://artifacthub.io/packages/helm/argo/argo-cd?modal=security-report

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
