### PR TITLE
fix(argo-rollouts): Allow metrics service without ServiceMonitor

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.0.1"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 1.0.0
+version: 1.0.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -39,6 +39,7 @@ $ helm install my-release argo/argo-rollouts
 | controller.tolerations | list | `[]` | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | controller.affinity | object | `{}` | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
 | controller.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) |
+| controller.metrics.enabled | bool | `false` | Deploy metrics service |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | controller.metrics.serviceMonitor.additionalAnnotations | object | `{}` | Annotations to be added to the ServiceMonitor |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Labels to be added to the ServiceMonitor |

--- a/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.metrics.serviceMonitor.enabled }}
+{{- if .Values.controller.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/argo-rollouts/templates/argo-rollouts-service-monitor.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.metrics.serviceMonitor.enabled }}
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -25,6 +25,7 @@ controller:
   #    memory: 64Mi
 
   metrics:
+    enabled: false
     serviceMonitor:
       enabled: false
       additionalLabels: {}


### PR DESCRIPTION
With the upgrade to version 1.0.0 of the chart, a regression was introduced.

Before, even if you had not installed in your cluster the CoreOS Service Monitor, the chart would allow you to expose a metrics service for your metrics provider to read.

Now, if you do not set `controller.metrics.serviceMonitor.enabled` on your release, the service will not be created, breaking metric exports.

But, if you set `controller.metrics.serviceMonitor.enabled`, it will attempt to create a `ServiceMonitor.monitoring.coreos.com/v1` resource, which, if you do not have it installed in your cluster, breaks the release.

This makes it so the metrics Service is always deployed, allowing people who do not have the CoreOS ServiceMonitor to also make use of these metrics.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
