### PR TITLE
docs(argo-workflows): Add missing value on values.yaml

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "v3.0.2"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -14,11 +14,11 @@ createAggregateRoles: true
 
 ## String to partially override "argo-workflows.fullname" template
 ##
-# nameOverride:
+nameOverride:
 
 ## String to fully override "argo-workflows.fullname" template
 ##
-# fullnameOverride:
+fullnameOverride:
 
 # Restrict Argo to only deploy into a single namespace by apply Roles and RoleBindings instead of the Cluster equivalents,
 # and start argo-cli with the --namespaced flag. Use it in clusters with strict access policy.

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -12,9 +12,12 @@ init:
 
 createAggregateRoles: true
 
-# Override app name
-# Internally, this will be truncated at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-fullnameOverride: ""
+## String to partially override "argo-workflows.fullname" template
+##
+# nameOverride:
+## String to fully override "argo-workflows.fullname" template
+##
+# fullnameOverride:
 
 # Restrict Argo to only deploy into a single namespace by apply Roles and RoleBindings instead of the Cluster equivalents,
 # and start argo-cli with the --namespaced flag. Use it in clusters with strict access policy.

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -15,6 +15,7 @@ createAggregateRoles: true
 ## String to partially override "argo-workflows.fullname" template
 ##
 # nameOverride:
+
 ## String to fully override "argo-workflows.fullname" template
 ##
 # fullnameOverride:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -12,6 +12,10 @@ init:
 
 createAggregateRoles: true
 
+# Override app name
+# Internally, this will be truncated at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+fullnameOverride: ""
+
 # Restrict Argo to only deploy into a single namespace by apply Roles and RoleBindings instead of the Cluster equivalents,
 # and start argo-cli with the --namespaced flag. Use it in clusters with strict access policy.
 singleNamespace: false


### PR DESCRIPTION
Signed-off-by: yu-croco <yuki.kita22@gmail.com>

In this PR https://github.com/argoproj/argo-helm/pull/769 , `fullnameOverride` was added but it was not defined on `values.yaml`, so I added it. 🙋 

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
