### PR TITLE
feat: add encrypt values for secret section

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2.0.3
+appVersion: 2.0.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.6.6
+version: 3.6.7
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.4
+appVersion: 2.0.3
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
 version: 3.6.7

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -20,30 +20,34 @@ data:
 stringData:
 {{- end }}
   {{- if .Values.configs.secret.githubSecret }}
-  webhook.github.secret: {{ .Values.configs.secret.githubSecret | b64enc }}
+  webhook.github.secret: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.githubSecret | b64enc }} {{ else }} {{ .Values.configs.secret.githubSecret }} {{ end }}
   {{- end }}
   {{- if .Values.configs.secret.gitlabSecret }}
-  webhook.gitlab.secret: {{ .Values.configs.secret.gitlabSecret | b64enc }}
+  webhook.gitlab.secret: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.gitlabSecret | b64enc }} {{ else }} {{ .Values.configs.secret.gitlabSecret }} {{ end }}
   {{- end }}
   {{- if .Values.configs.secret.bitbucketServerSecret }}
-  webhook.bitbucketserver.secret: {{ .Values.configs.secret.bitbucketServerSecret | b64enc }}
+  webhook.bitbucketserver.secret: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.bitbucketServerSecret | b64enc }} {{ else }} {{ .Values.configs.secret.bitbucketServerSecret }} {{ end }}
   {{- end }}
   {{- if .Values.configs.secret.bitbucketUUID }}
-  webhook.bitbucket.uuid: {{ .Values.configs.secret.bitbucketUUID | b64enc }}
+  webhook.bitbucket.uuid: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.bitbucketUUID | b64enc }} {{ else }} {{ .Values.configs.secret.bitbucketUUID }} {{ end }}
   {{- end }}
   {{- if .Values.configs.secret.gogsSecret }}
-  webhook.gogs.secret: {{ .Values.configs.secret.gogsSecret | b64enc }}
+  webhook.gogs.secret: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.gogsSecret | b64enc }} {{ else }} {{ .Values.configs.secret.gogsSecret }} {{ end }}
   {{- end }}
   {{- if .Values.configs.secret.argocdServerTlsConfig }}
-  tls.key: {{ .Values.configs.secret.argocdServerTlsConfig.key | b64enc }}
-  tls.crt: {{ .Values.configs.secret.argocdServerTlsConfig.crt | b64enc }}
+  tls.key: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.argocdServerTlsConfig.key | b64enc }} {{ else }} {{ .Values.configs.secret.argocdServerTlsConfig.key }} {{ end }}
+  tls.crt: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.argocdServerTlsConfig.crt | b64enc }} {{ else }} {{ .Values.configs.secret.argocdServerTlsConfig.crt }} {{ end }}
   {{- end }}
   {{- if .Values.configs.secret.argocdServerAdminPassword }}
-  admin.password: {{ .Values.configs.secret.argocdServerAdminPassword | b64enc }}
-  admin.passwordMtime: {{ default (date "2006-01-02T15:04:05Z" now) .Values.configs.secret.argocdServerAdminPasswordMtime | b64enc }}
+  admin.password: {{- if .Values.configs.secret.encrypt }}{{ .Values.configs.secret.argocdServerAdminPassword | b64enc }} {{ else }} {{ .Values.configs.secret.argocdServerAdminPassword }} {{ end }}
+  admin.passwordMtime: {{- if .Values.configs.secret.encrypt }}{{ default (date "2006-01-02T15:04:05Z" now) .Values.configs.secret.argocdServerAdminPasswordMtime | b64enc }} {{ else }} {{ default (date "2006-01-02T15:04:05Z" now) .Values.configs.secret.argocdServerAdminPasswordMtime }} {{ end }}
   {{- end }}
   {{- range $key, $value := .Values.configs.secret.extra }}
+  {{- if .Values.configs.secret.encrypt }}
   {{ $key }}: {{ $value | b64enc }}
+  {{- else }}
+  {{ $key }}: {{ $value}}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -14,7 +14,11 @@ metadata:
 type: Opaque
 {{- if or .Values.configs.secret.githubSecret (or .Values.configs.secret.gitlabSecret .Values.configs.secret.bitbucketUUID .Values.configs.secret.bitbucketServerSecret .Values.configs.secret.gogsSecret .Values.configs.secret.argocdServerAdminPassword .Values.configs.secret.argocdServerTlsConfig .Values.configs.secret.extra) }}
 # Setting a blank data again will wipe admin password/key/cert
+{{- if .Values.configs.secret.encrypt }}
 data:
+{{- else }}
+stringData:
+{{- end }}
   {{- if .Values.configs.secret.githubSecret }}
   webhook.github.secret: {{ .Values.configs.secret.githubSecret | b64enc }}
   {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -11,7 +11,7 @@ installCRDs: true
 global:
   image:
     repository: quay.io/argoproj/argocd
-    tag: v2.0.3
+    tag: v2.0.4
     imagePullPolicy: IfNotPresent
   securityContext: {}
   #  runAsUser: 999
@@ -1048,6 +1048,8 @@ configs:
     # -----END RSA PRIVATE KEY-----
   secret:
     createSecret: true
+    # Use secret with stringData instead data, without base64 encryptions
+    encrypt: true
     ## Annotations to be added to argocd-secret
     ##
     annotations: {}


### PR DESCRIPTION
Problem:
we prepare passwords via terraform and use bcrypt to encrypt the password (example of the encrypted password is "$2a$10$H1a30nMr9v2QE2nkyz0BoOD2J0I6FQFMtHS0csEg12RBWzfRuuoE6". When ArgoCD creates a secret and tries to encrypt in base64, characters like $ are interpreted by the shell as variables and breaks the password.

Solutions:
This will help to pass the prepared secrets encrypted via bcrypt to the chart parameters. If ".Values.configs.secret.encrypt" = false, used stringData without base64 encrypt procedure.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
