### PR TITLE
fix(argo-cd): fix missing colon in example service definitions

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.3
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.6.8
+version: 3.6.9
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -567,7 +567,7 @@ server:
       # - path: /*
       #   pathType: Prefix
       #   backend:
-      #     service
+      #     service:
       #       name: ssl-redirect
       #       port:
       #         name: use-annotation
@@ -604,7 +604,7 @@ server:
       # - path: /*
       #   pathType: Prefix
       #   backend:
-      #     service
+      #     service:
       #       name: ssl-redirect
       #       port:
       #         name: use-annotation


### PR DESCRIPTION
Signed-off-by: Alex Andrews <alias-dev@protonmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
