### PR TITLE
fix(argo-rollouts): Add ConfigMap read access to support notification-engine

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v1.0.1"
+appVersion: "v1.0.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 1.0.1
+version: 1.0.2
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -76,7 +76,7 @@ rules:
   - list
   - watch
   - patch
-# secret read access to run analysis templates which reference secrets 
+# secret read access to run analysis templates which reference secrets
 # configmap access to read notification-engine configuration
 - apiGroups:
   - ""

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -76,19 +76,12 @@ rules:
   - list
   - watch
   - patch
-# secret read access to run analysis templates which reference secrets
+# secret read access to run analysis templates which reference secrets 
+# configmap access to read notification-engine configuration
 - apiGroups:
   - ""
   resources:
   - secrets
-  verbs:
-  - get
-  - list
-  - watch
-# configmap read access to support notification-engine
-- apiGroups:
-  - ""
-  resources:
   - configmaps
   verbs:
   - get

--- a/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-clusterrole.yaml
@@ -85,6 +85,15 @@ rules:
   - get
   - list
   - watch
+# configmap read access to support notification-engine
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 # pod list/update needed for updating ephemeral data
 - apiGroups:
   - ""

--- a/charts/argo-rollouts/templates/argo-rollouts-role.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-role.yaml
@@ -75,6 +75,15 @@ rules:
   - get
   - list
   - watch
+# configmap read access to support notification-engine
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 # pod list/update needed for updating ephemeral data
 - apiGroups:
   - ""

--- a/charts/argo-rollouts/templates/argo-rollouts-role.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-role.yaml
@@ -66,7 +66,7 @@ rules:
   - list
   - watch
   - patch
-# secret read access to run analysis templates which reference secrets 
+# secret read access to run analysis templates which reference secrets
 # configmap access to read notification-engine configuration
 - apiGroups:
   - ""

--- a/charts/argo-rollouts/templates/argo-rollouts-role.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-role.yaml
@@ -66,19 +66,12 @@ rules:
   - list
   - watch
   - patch
-# secret read access to run analysis templates which reference secrets
+# secret read access to run analysis templates which reference secrets 
+# configmap access to read notification-engine configuration
 - apiGroups:
   - ""
   resources:
   - secrets
-  verbs:
-  - get
-  - list
-  - watch
-# configmap read access to support notification-engine
-- apiGroups:
-  - ""
-  resources:
   - configmaps
   verbs:
   - get


### PR DESCRIPTION
With the addition of notification-engine support on Argo Rollouts, the app now needs read access to configmaps

Currently rollouts fail on master tag due to lack of configmap read access

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
