### PR TITLE
chore: Fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,13 +7,13 @@
 /charts/argo-workflows/ @stefansedich @paguos @vladlosev @yann-soubeyrand @oliverbaehler
 
 # Argo CD
-/charts/argo-cd @seanson @davidkarlsen @mr-sour @yann-soubeyrand @oliverbaehler @mbevc1
+/charts/argo-cd/ @seanson @davidkarlsen @mr-sour @yann-soubeyrand @oliverbaehler @mbevc1
 
 # Argo Events
-/charts/argo-events @jbehling @VaibhavPage @oliverbaehler
+/charts/argo-events/ @jbehling @VaibhavPage @oliverbaehler
 
 # Argo Rollouts
-/charts/argo-rollouts @oliverbaehler
+/charts/argo-rollouts/ @oliverbaehler
 
 # Argo CD Notifications
-/charts/argocd-notifications @alexmt @andyfeller @oliverbaehler @mbevc1
+/charts/argocd-notifications/ @alexmt @andyfeller @oliverbaehler @mbevc1


### PR DESCRIPTION
Using correct pattern to match all Chart subfolder (https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax). Currently not matching all Codeowners.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
