### PR TITLE
chore(chart-testing-action): Update components

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Setup Chart Linting
         id: lint
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
 
       - name: List changed charts
         id: list-changed
@@ -37,7 +37,7 @@ jobs:
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
It seems that the current KinD action (v1.1.0) is broken for an unknown reason. The KinD node is in **NotReady** state forever and therefore no pods can be scheduled.
```logs
Events:
  Type     Reason            Age                From               Message
  ----     ------            ----               ----               -------
  Warning  FailedScheduling  70s (x8 over 10m)  default-scheduler  0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
```

Example CI jobs which currently fail:
- https://github.com/argoproj/argo-helm/pull/797/checks?check_run_id=2987333533
  (https://github.com/argoproj/argo-helm/pull/797)
- https://github.com/argoproj/argo-helm/pull/812/checks?check_run_id=2975847989
  (https://github.com/argoproj/argo-helm/pull/812)
- https://github.com/argoproj/argo-helm/pull/806/checks?check_run_id=2987206575 
  (https://github.com/argoproj/argo-helm/pull/806)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have updated the chart version in `Chart.yaml` following Semantic Versioning.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
