### PR TITLE
fix(argo-cd): Add ServiceAccount for redis

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.8.0
+version: 3.8.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Ability to override API versions"
+    - "[Fixed]: Cannot create a service account for redis"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -89,6 +89,17 @@ Create the name of the dex service account to use
 {{- end -}}
 
 {{/*
+Create the name of the redis service account to use
+*/}}
+{{- define "argo-cd.redisServiceAccountName" -}}
+{{- if .Values.redis.serviceAccount.create -}}
+    {{ default (include "argo-cd.redis.fullname" .) .Values.redis.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.redis.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the ArgoCD server service account to use
 */}}
 {{- define "argo-cd.serverServiceAccountName" -}}

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -71,7 +71,7 @@ Create the name of the controller service account to use
 */}}
 {{- define "argo-cd.controllerServiceAccountName" -}}
 {{- if .Values.controller.serviceAccount.create -}}
-    {{ default (include "argo-cd.fullname" .) .Values.controller.serviceAccount.name }}
+    {{ default (include "argo-cd.controller.fullname" .) .Values.controller.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.controller.serviceAccount.name }}
 {{- end -}}
@@ -82,7 +82,7 @@ Create the name of the dex service account to use
 */}}
 {{- define "argo-cd.dexServiceAccountName" -}}
 {{- if .Values.dex.serviceAccount.create -}}
-    {{ default (include "argo-cd.fullname" .) .Values.dex.serviceAccount.name }}
+    {{ default (include "argo-cd.dex.fullname" .) .Values.dex.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.dex.serviceAccount.name }}
 {{- end -}}
@@ -104,7 +104,7 @@ Create the name of the ArgoCD server service account to use
 */}}
 {{- define "argo-cd.serverServiceAccountName" -}}
 {{- if .Values.server.serviceAccount.create -}}
-    {{ default (include "argo-cd.fullname" .) .Values.server.serviceAccount.name }}
+    {{ default (include "argo-cd.server.fullname" .) .Values.server.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.server.serviceAccount.name }}
 {{- end -}}
@@ -115,7 +115,7 @@ Create the name of the repo-server service account to use
 */}}
 {{- define "argo-cd.repoServerServiceAccountName" -}}
 {{- if .Values.repoServer.serviceAccount.create -}}
-    {{ default (include "argo-cd.fullname" .) .Values.repoServer.serviceAccount.name }}
+    {{ default (include "argo-cd.repoServer.fullname" .) .Values.repoServer.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.repoServer.serviceAccount.name }}
 {{- end -}}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -30,7 +30,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.redis.serviceAccount.automountServiceAccountToken }}
+      serviceAccountName: {{ template "argo-cd.redisServiceAccountName" . }}
       {{- if .Values.redis.securityContext }}
       securityContext: {{- toYaml .Values.redis.securityContext | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/redis/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.redis.enabled .Values.redis.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.redis.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ template "argo-cd.redisServiceAccountName" . }}
+{{- if .Values.redis.serviceAccount.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.redis.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -365,6 +365,14 @@ redis:
     fsGroup: 1000
     runAsNonRoot: true
 
+  serviceAccount:
+    create: false
+    name: ""
+    ## Annotations applied to created service account
+    annotations: {}
+    ## Automount API credentials for the Service Account
+    automountServiceAccountToken: false
+
   resources: {}
   #  limits:
   #    cpu: 200m


### PR DESCRIPTION
Resolves #809

While here, I noticed that there might exist clashing ServiceAccount resources when the default names of `controller`, `dex`, `server` and `repoServer` are cleared. This is an edge case but its fixed now :-)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
