### PR TITLE
docs(argo-cd): Upgrading notes for ServiceAccount change in 3.8.1

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.4
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.8.1
+version: 3.8.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Cannot create a service account for redis"
+    - "[Changed]: Add important upgrading notes to README concerning potential ServiceAccount renamings introduced in chart version 3.8.1+."

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -34,6 +34,34 @@ Changes in the `CustomResourceDefinition` resources shall be fixed easily by cop
 
 ## Upgrading
 
+### 3.8.1
+
+This bugfix version potentially introduces a rename (and recreation) of one or more ServiceAccounts. It _only happens_ when you use one of these customization:
+
+```yaml
+# Case 1) - only happens when you do not specify a custom name (repoServer.serviceAccount.name)
+repoServer:
+  serviceAccount:
+    create: true
+
+# Case 2)
+controller:
+  serviceAccount:
+    name: "" # or <nil>
+
+# Case 3)
+dex:
+  serviceAccount:
+    name: "" # or <nil>
+
+# Case 4)
+server:
+  serviceAccount:
+    name: "" # or <nil>
+```
+
+Please check if you are affected by one of these cases **before you upgrade**, especially when you use **cloud IAM roles for service accounts.** (eg. IRSA on AWS or Workload Identity for GKE)
+
 ### 3.2.* 
 
 With this minor version we introduced the evaluation for the ingress manifest (depending on the capabilities version), See [Pull Request](https://github.com/argoproj/argo-helm/pull/637).


### PR DESCRIPTION
Related to discussion in PR https://github.com/argoproj/argo-helm/pull/828

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
