### PR TITLE
chore: Flag argo-lite chart as deprecated to remove it from Artifact Hub

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6719,6 +6719,7 @@ entries:
   argo-lite:
   - apiVersion: v1
     created: "2021-05-21T13:04:20.329578787Z"
+    deprecated: true
     description: Lighweight workflow engine for Kubernetes
     digest: b83cb7173bcd4259723fd592b3438fc31dbc0a9cac44178b6f522bc75f1591f2
     icon: https://raw.githubusercontent.com/argoproj/argo/master/saas/axops/src/ui/src/assets/favicon/favicon-32x32.png


### PR DESCRIPTION
The chart "argo-lite" does not exist as source anymore. The intent for this PR is to don't list this old chart on Artifact Hub anymore.
IMHO updating the index file manually would be the simplest trick to do this.