### PR TITLE
fix(argo-workflows): Fix controller Role/ClusterRole to work with InstanceID

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "v3.0.7"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Initialize Changelog"
+    - "[Fixed]: Controller Role/ClusterRole to work with InstanceID"

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -121,8 +121,18 @@ rules:
   resources:
   - leases
   resourceNames:
+  {{- if .Values.controller.instanceID.enabled }}
+    {{- if .Values.controller.instanceID.useReleaseName }}
+  - workflow-controller-{{ .Release.Name }}
+  - workflow-controller-lease-{{ .Release.Name }}
+    {{- else }}
+  - workflow-controller-{{ .Values.controller.instanceID.explicitID }}
+  - workflow-controller-lease-{{ .Values.controller.instanceID.explicitID }}
+    {{- end }}
+  {{- else }}
   - workflow-controller
   - workflow-controller-lease
+  {{- end }}
   verbs:
   - get
   - watch

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -7,11 +7,11 @@ metadata:
 data:
   config: |
     {{- if .Values.controller.instanceID.enabled }}
-    {{- if .Values.controller.instanceID.useReleaseName }}
+      {{- if .Values.controller.instanceID.useReleaseName }}
     instanceID: {{ .Release.Name }}
-    {{- else }}
+      {{- else }}
     instanceID: {{ .Values.controller.instanceID.explicitID }}
-    {{- end }}
+      {{- end }}
     {{- end }}
     containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
     {{- if .Values.controller.parallelism }}


### PR DESCRIPTION
Signed-off-by: kobejn-jb jakubbielawski89@gmail.com

This PR comes with the following changes:

    It allows for the controller to work with InstanceID while using leases
    It fixes a controller Role/ClusterRole, now it allows to read and update leases with names ending with -<your instance ID> when controller is set to use InstanceID


This PR intends to solve the following use case. In case when controller is set to use InstanceID controller role does not allow to get/watch/update/path/delete leases with names different from "workflow-controller-lease" and "workflow-controller-lease" but controller tries to use lease named "workflow-controller-lease-<provided InstanceID>". Now trying to use controller with InstanceID it results with error:

`E0713 13:43:58.014735       1 leaderelection.go:325] error retrieving resource lock argo-test/workflow-controller-argo-controller: leases.coordination.k8s.io "workflow-controller-argo-controller" is forbidden: User "system:serviceaccount:argo-test:argo" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "argo-test"`

This PR changes Role/ClusterRole template, when InstanceID is enabled names of leases listed in permissions in Roles will contain that name at the end


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
