### PR TITLE
fix(argo-workflows): pod status pending issue

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "v3.0.7"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/crds/argoproj.io_workflows.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_workflows.yaml
@@ -36,9 +36,11 @@ spec:
           spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+            x-kubernetes-map-type: atomic
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+            x-kubernetes-map-type: atomic
         required:
         - metadata
         - spec


### PR DESCRIPTION
This is the implementation of the accepted solution to this argo-workflows issue: https://github.com/argoproj/argo-workflows/issues/6256

The solution comes from https://github.com/kubernetes/kubernetes/issues/102749 and solves the problem (in Kubernetes v1.19.10+ and v1.20+) of pod completing and argo not being able to retrieve their updates statuses, instead giving:

```
Error updating workflow: Timeout: request did not complete within requested timeout 34s Timeout
```
Signed-off-by: kostas-theo <ktheo@oneconcern.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
