### PR TITLE
feat(argo-workflows): Add support for extra containers in server & controller deployment

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.2.7
+version: 0.3.0
 appVersion: "v3.0.7"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Initialize Changelog"
+    - "[Added]: Support for extraContainers in controller/server"

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -79,8 +79,8 @@ spec:
               containerPort: {{ .Values.controller.metricsConfig.port }}
             - containerPort: 6060
           livenessProbe: {{ .Values.controller.livenessProbe | toYaml | nindent 12 }}
-        {{- if .Values.controller.extraContainers }}
-        {{ toYaml .Values.controller.extraContainers | nindent 8}}
+        {{- with .Values.controller.extraContainers }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -79,6 +79,9 @@ spec:
               containerPort: {{ .Values.controller.metricsConfig.port }}
             - containerPort: 6060
           livenessProbe: {{ .Values.controller.livenessProbe | toYaml | nindent 12 }}
+        {{- if .Values.controller.extraContainers }}
+        {{ toYaml .Values.controller.extraContainers | nindent 8}}
+        {{- end }}
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -80,6 +80,9 @@ spec:
           {{- with .Values.server.volumeMounts }}
             {{- toYaml . | nindent 10}}
           {{- end }}
+        {{- if .Values.server.extraContainers }}
+        {{ toYaml .Values.server.extraContainers | nindent 8}}
+        {{- end }}
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -80,8 +80,8 @@ spec:
           {{- with .Values.server.volumeMounts }}
             {{- toYaml . | nindent 10}}
           {{- end }}
-        {{- if .Values.server.extraContainers }}
-        {{ toYaml .Values.server.extraContainers | nindent 8}}
+        {{- with .Values.server.extraContainers }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -171,6 +171,8 @@ controller:
   clusterWorkflowTemplates:
     # Create a ClusterRole and CRB for the controller to access ClusterWorkflowTemplates.
     enabled: true
+  # Extra containers to be added to the controller deployment
+  extraContainers: []
 
 # executor controls how the init and wait container should be customized
 executor:
@@ -337,6 +339,8 @@ server:
     ## decisions.
     # scopes:
     # - groups
+  # Extra containers to be added to the server deployment
+  extraContainers: []
 
 # Influences the creation of the ConfigMap for the workflow-controller itself.
 useDefaultArtifactRepo: false


### PR DESCRIPTION
My use-case for this is using persistence with a GCP CloudSQL database, using the sidecar pattern for the cloud-sql-proxy

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
