### PR TITLE
docs: Rename argocd references to argoworkflows in workflow chart

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "v3.0.7"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Pods stuck in pending phase due to workflow update timeouts."
+    - "[Changed]: Argo workflows values file no longer has examples referencing ArgoCD"

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "v3.0.7"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -279,7 +279,7 @@ server:
     ##
     hosts:
       []
-      # - argocd.example.com
+      # - argoworkflows.example.com
     paths:
       - /
     extraPaths:
@@ -298,9 +298,9 @@ server:
       #         name: use-annotation
     tls:
       []
-      # - secretName: argocd-example-tls
+      # - secretName: argoworkflows-example-tls
       #   hosts:
-      #     - argocd.example.com
+      #     - argoworkflows.example.com
     https: false
 
   clusterWorkflowTemplates:


### PR DESCRIPTION
Small documentation change of the values.yaml of the argo workflows chart.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
