### PR TITLE
fix(argo-cd): Update changelog for recent PR #844

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1588,7 +1588,7 @@ entries:
   argo-cd:
   - annotations:
       artifacthub.io/changes: |
-        - "[Added]: Support AWS ALB Ingress with gRPC"
+        - "[Changed]: Bump default version to v2.0.5"
     apiVersion: v2
     appVersion: 2.0.5
     created: "2021-07-27T01:33:25.726492544Z"
@@ -8250,4 +8250,4 @@ entries:
     urls:
     - argocd-notifications-1.0.0.tgz
     version: 1.0.0
-generated: "2021-07-27T01:33:25.738140755Z"
+generated: "2021-07-27T06:51:00.738140755Z"


### PR DESCRIPTION
In recent PR https://github.com/argoproj/argo-helm/pull/844 the changelog was not updated. To fulfil what was requested in issue #735 we update the changelog in post :-)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
