### PR TITLE
fix(argo-cd): re-enable not yet deprecated staticassets flag

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.11.0
+version: 3.11.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,6 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Updated]: Updated redis-ha chart dependency 4.12.14 -> 4.12.17"
-    - "[Updated]: Updated dex image 2.27.0 -> 2.28.1"
-    - "[Updated]: Updated redis alpine image 6.2.2 -> 6.2.4"
+    - "[Changed]: Set server.staticAssets.enabled=true since Argo CD 2.0.5 still needs it"

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -433,7 +433,7 @@ server:
 
   # This flag is used to either remove or pass the CLI flag --staticassets /shared/app to the argocd-server app
   staticAssets:
-    enabled: false
+    enabled: true
 
   ## Environment variables to pass to argocd-server
   ##


### PR DESCRIPTION
Enable `server.staticAssets.enabled` by default (was disabled in #846). It looks like neither https://github.com/argoproj/argo-cd/commit/561452ac943a8f83e17c66eb72200f4a66ee3ae3 or https://github.com/argoproj/argo-cd/commit/e68618d168b1eeeec1b60af562922d5791197e02 have made it into a release yet so the default should stick to enabled for now.

Signed-off-by: Lucas Bickel <lucas.bickel@adfinis.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.

Does not address  #843 but adresses all the comments from people getting hit by this.