### PR TITLE
feat(argo-cd): Use semverCompare to set server.staticAssets.enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.11.1
+version: 3.12.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Set server.staticAssets.enabled=true since Argo CD 2.0.5 still needs it"
+    - "[Changed]: Use semverCompare to decide if the staticassets flag should be passed if server.staticAssets.enabled is nil"
+    - "[Changed]: Set server.staticAssets.enabled=~ to use the default semverCompare"

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -42,10 +42,15 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.server.image.imagePullPolicy }}
         command:
         - argocd-server
-        {{ if .Values.server.staticAssets.enabled }}
+        {{- if .Values.server.staticAssets.enabled }}
         - --staticassets
         - /shared/app
-        {{ end }}
+        {{- else if eq (toString .Values.server.staticAssets.enabled) "<nil>" }}
+        {{- if semverCompare "< 2.1.0-0" (default .Values.global.image.tag .Values.server.image.tag) }}
+        - --staticassets
+        - /shared/app
+        {{- end }}
+        {{- end }}
         - --repo-server
         - {{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
         {{- if .Values.dex.enabled }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -432,8 +432,9 @@ server:
   #  - --insecure
 
   # This flag is used to either remove or pass the CLI flag --staticassets /shared/app to the argocd-server app
+  # If a nil value (~) is specified the chart uses semverCompare to enable the flag based on the argocd-server version
   staticAssets:
-    enabled: true
+    enabled: ~
 
   ## Environment variables to pass to argocd-server
   ##


### PR DESCRIPTION
Now that [Argo CD 2.1.0-rc1 is tagged](https://github.com/argoproj/argo-cd/releases/tag/v2.1.0-rc1) and contains the static assets change, we can move forward with supporting it in the Helm chart.

This defaults `server.staticAssets.enabled` to `nil` and uses `semverCompare` to decide if the `--staticassets` flag needs to be added when it is `nil`. Setting it to `true`/`false` will work like before for backwards compatibility.

I'm not 100% sure if `toString` based matching to figure out if the flag is `nil` is the way to go. Let me know if you have any better suggestions. The main alternative I came up with is dropping the flag alltogether and bumping the chart to 4.0.0.

Fixes #843 

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).
* [ ] simplify else/else if clause https://github.com/argoproj/argo-helm/pull/850#discussion_r679391798
