### PR TITLE
fix(argo-cd): Replace server.staticAssets.enabled with automation

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.11.1
+version: 3.11.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Set server.staticAssets.enabled=true since Argo CD 2.0.5 still needs it"
+    - "[Changed]: Replace server.staticAssets.enabled with semverCompare based check"

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.server.image.imagePullPolicy }}
         command:
         - argocd-server
-        {{ if .Values.server.staticAssets.enabled }}
+        {{- if semverCompare "< 2.1.0-0" (default .Values.global.image.tag .Values.server.image.tag) }}
         - --staticassets
         - /shared/app
         {{ end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -431,10 +431,6 @@ server:
   extraArgs: []
   #  - --insecure
 
-  # This flag is used to either remove or pass the CLI flag --staticassets /shared/app to the argocd-server app
-  staticAssets:
-    enabled: true
-
   ## Environment variables to pass to argocd-server
   ##
   env: []


### PR DESCRIPTION
This PR considers introducing the `server.staticAssets.enable` flag a bug and doesn't try to keep backwards compatibility ala #850.

Given that the flag was only available for a short time and the `semverCompare` solution is what i would consider the safe way forward, this might be a better fix for #843.

I put it in it's own pr since both versions would be viable from my POV.

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Fixes #843
Fixes #850