### PR TITLE
fix controller cluster role configuration when instanceID is enabled

### DIFF
--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -121,7 +121,15 @@ rules:
   resources:
   - leases
   resourceNames:
+{{- if .Values.controller.instanceID.enabled }}
+{{- if .Values.controller.instanceID.useReleaseName }}
+  - workflow-controller-{{ .Release.Name }}
+{{- else }}
+  - workflow-controller-{{ .Values.controller.instanceID.explicitID }}
+{{- end }}
+{{- else }}
   - workflow-controller
+{{- end }}
   - workflow-controller-lease
   verbs:
   - get


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
