### PR TITLE
fix(argo-rollouts): Add missing liveness and readiness probe

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.0.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 1.0.3
+version: 1.0.4
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.0.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
 version: 1.0.4
-icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
   - name: alexmt
@@ -12,3 +12,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Add missing liveness and readiness probes"
+    - "[Changed]: Fix icon url"

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Initialize Changelog"
+    - "[Fixed]: Add missing liveness and readiness probes"

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -39,6 +39,10 @@ spec:
         ports:
         - containerPort: 8090
           name: metrics
+        livenessProbe:
+          {{- .Values.controller.livenessProbe | toYaml | nindent 10 }}
+        readinessProbe:
+          {{- .Values.controller.readinessProbe | toYaml | nindent 10 }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         resources:

--- a/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
+++ b/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml
@@ -40,9 +40,9 @@ spec:
         - containerPort: 8090
           name: metrics
         livenessProbe:
-          {{- .Values.controller.livenessProbe | toYaml | nindent 10 }}
+          {{- toYaml .Values.controller.livenessProbe | nindent 10 }}
         readinessProbe:
-          {{- .Values.controller.readinessProbe | toYaml | nindent 10 }}
+          {{- toYaml .Values.controller.readinessProbe | nindent 10 }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         resources:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -31,6 +31,26 @@ controller:
       additionalLabels: {}
       additionalAnnotations: {}
 
+  ## Readiness and liveness probes for rollouts controller
+  livenessProbe:
+    httpGet:
+      path: /metrics
+      port: 8090
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /metrics
+      port: 8090
+    initialDelaySeconds: 15
+    periodSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 4
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Signed-off-by: Hui Kang <hui.kang@salesforce.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
