### PR TITLE
fix(argo-cd): Set type of service for gRPC as NodePort.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -22,3 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: Add server.service.sessionAffinity setting of the Service into account when deciding which backend Pod to use"
+    - "[Fix]: Set type of service for grpc as NodePort because this is the default of ALB ingress Controller"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -21,5 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add server.service.sessionAffinity setting of the Service into account when deciding which backend Pod to use"
     - "[Fix]: Set type of service for grpc as NodePort because this is the default of ALB ingress Controller"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.11.2
+version: 3.11.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-server/alb-grpc-service.yaml
+++ b/charts/argo-cd/templates/argocd-server/alb-grpc-service.yaml
@@ -20,5 +20,5 @@ spec:
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 4 }}
   sessionAffinity: None
-  type: ClusterIP
+  type: NodePort
 {{- end -}}


### PR DESCRIPTION
To use AWS Load Balancer Controller, you need to set the service type as NodePort.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [X] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
