### PR TITLE
fix(argo-cd): AWS GRPC Service Type

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.11.4
+version: 3.11.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -312,6 +312,7 @@ NAME: my-release
 | server.ingressGrpc.ingressClassName | Defines which ingress controller will implement the resource [gRPC-ingress] | `""` |
 | server.ingressGrpc.tls | Ingress TLS configuration for dedicated [gRPC-ingress] | `[]` |
 | server.ingressGrpc.isAWSALB | Setup up GRPC ingress to work with an AWS ALB | `false` |
+| server.ingressGrpc.awsALB.serviceType | Service type for the AWS ALB GRPC service | `NodePort` |
 | server.route.enabled | Enable a OpenShift route for the server | `false` |
 | server.route.hostname | Hostname of OpenShift route | `""` |
 | server.lifecycle | PostStart and PreStop hooks configuration | `{}` |
@@ -454,5 +455,7 @@ server:
   ingressGrpc:
     enabled: true
     isAWSALB: true
+    awsALB:
+      serviceType: ClusterIP
       
 ```

--- a/charts/argo-cd/templates/argocd-server/alb-grpc-service.yaml
+++ b/charts/argo-cd/templates/argocd-server/alb-grpc-service.yaml
@@ -20,5 +20,5 @@ spec:
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 4 }}
   sessionAffinity: None
-  type: NodePort
+  type: {{ .Values.server.ingressGrpc.awsALB.serviceType }}
 {{- end -}}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -611,6 +611,15 @@ server:
     labels: {}
     ingressClassName: ""
 
+    ## Service Type if isAWSALB is set to true
+    ## Can be of type NodePort or ClusterIP depending on which mode you are
+    ## are running. Instance mode needs type NodePort, IP mode needs type
+    ## ClusterIP
+    ## Ref: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/how-it-works/#ingress-traffic
+    ##
+    awsALB:
+      serviceType: NodePort
+
     ## Argo Ingress.
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace


### PR DESCRIPTION
The Service Type needed depends on the annotation `alb.ingress.kubernetes.io/target-type` on the ingress. This PR allows users to set the service type to Cluster IP if they are using IP Mode for the ingress. By default the target type is instance and requires the service to be of type NodePort.

https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/how-it-works/#ingress-traffic

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
