### PR TITLE
feat(argo-cd): Bump dex dependency for CVE-2021-3450

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Updated]: Updated dex image 2.28.1 -> 2.30.0"
+    - "[Security]: Updated dex image 2.28.1 -> 2.30.0"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.12.1
+version: 3.12.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: redis-ha.nameOverride / redis-ha.fullnameOverride breaks the ArgoCD helm chart"
+    - "[Updated]: Updated dex image 2.28.1 -> 2.30.0"

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -233,7 +233,7 @@ dex:
 
   image:
     repository: ghcr.io/dexidp/dex
-    tag: v2.28.1
+    tag: v2.30.0
     imagePullPolicy: IfNotPresent
   initImage:
     repository:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.3.0
-appVersion: "v3.0.7"
+version: 0.4.0
+appVersion: "v3.1.5"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support for extraContainers in controller/server"
+    - "[Changed]: Bump appVersion to 3.1.5"

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.1.1
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
   - name: andyfeller
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Initialize Changelog"
+    - "[Added]: Example for 'defaultTriggers'"

--- a/charts/argocd-notifications/values.yaml
+++ b/charts/argocd-notifications/values.yaml
@@ -346,6 +346,10 @@ triggers:
   #     send:
   #     - app-sync-succeeded
   #     when: app.status.operationState.phase in ['Succeeded']
+  #
+  # For more information: https://argocd-notifications.readthedocs.io/en/stable/triggers/#default-triggers
+  # defaultTriggers: |
+  #   - on-sync-status-unknown
 
 bots:
   # For more information: https://argocd-notifications.readthedocs.io/en/stable/bots/overview/

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,7 @@ docker run \
      -v "$SRCROOT:/workdir" \
      --entrypoint /bin/sh \
      quay.io/helmpack/chart-testing:v3.3.1 \
-     -c cd /workdir \ 
+     -c cd /workdir \
      ct lint \
      --config .github/configs/ct-lint.yaml \
      --lint-conf .github/configs/lintconf.yaml \


### PR DESCRIPTION
Updates the dex image to address CVE-2021-3450.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
