### PR TITLE
feat: Enable HA deployment for Dex component

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.0.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.12.1
+version: 3.13.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,6 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: redis-ha.nameOverride / redis-ha.fullnameOverride breaks the ArgoCD helm chart"
+    - "[Added]: Allow to set number of Dex server replicas"
+    - "[Added]: Allow to enable auto-scaling for Dex server"
+    - "[Fixed]: Dex server uses liveness and readiness probe"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -68,6 +68,13 @@ Create argocd repo-server name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create argocd dex-server name and version as used by the chart label.
+*/}}
+{{- define "argo-cd.dex.fullname" -}}
+{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.dex.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create the name of the controller service account to use
 */}}
 {{- define "argo-cd.controllerServiceAccountName" -}}
@@ -174,7 +181,7 @@ Return the target Kubernetes version
   {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}
 {{- end -}}
 
-{{/* 
+{{/*
 Argo Configuration Preset Values (Incluenced by Values configuration)
 */}}
 {{- define "argo-cd.config.presets" -}}
@@ -183,7 +190,7 @@ ui.cssurl: "./custom/custom.styles.css"
   {{- end }}
 {{- end -}}
 
-{{/* 
+{{/*
 Merge Argo Configuration with Preset Configuration
 */}}
 {{- define "argo-cd.config" -}}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.dex.name) | nindent 6 }}
+  revisionHistoryLimit: 5
+  replicas: {{ .Values.dex.replicas }}
   template:
     metadata:
       {{- if .Values.dex.podAnnotations }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -78,6 +78,14 @@ spec:
           containerPort: {{ .Values.dex.containerPortMetrics }}
           protocol: TCP
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: {{ .Values.dex.containerPortMetrics }}
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: {{ .Values.dex.containerPortMetrics }}
         volumeMounts:
         - mountPath: /tmp
           name: tmp-dir

--- a/charts/argo-cd/templates/dex/hpa.yaml
+++ b/charts/argo-cd/templates/dex/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.dex.enabled .Values.dex.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" (printf "%s-hpa" .Values.dex.name)) | nindent 4 }}
+  name: {{ template "argo-cd.dex.fullname" . }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "argo-cd.dex.fullname" . }}
+  minReplicas: {{ .Values.dex.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.dex.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.dex.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.dex.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -218,6 +218,8 @@ dex:
   enabled: true
   name: dex-server
 
+  replicas: 1
+
   metrics:
     enabled: false
     service:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -220,6 +220,13 @@ dex:
 
   replicas: 1
 
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
   metrics:
     enabled: false
     service:


### PR DESCRIPTION
This PR allows to scale Dex deployment for high availability. It also adds missing liveness / readiness probes so K8s can restart container in case Dex server is not responding for some reason. Implementation is inspired by [Dex chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex)

## Open questions

When looking into deployment I was wondering on following implementation. If you can please respond to following.

1) Why are the container ports configurable via values.yaml? Only reason I can see is in case user would provide custom image, however init container that uses [argocd-dex](https://github.com/argoproj/argo-cd/blob/b37eee1054e42c873699460dd5e2447c2f9fe5a6/util/dex/config.go#L12) will always generate configuration with hardcoded port numbers. Maybe fixed port numbers should be used in deployment instead so user cannot make deployment non-functioning.

2) Why is port for metrics / telemetry hidden in deployment via `metrics.enable`? This endpoint is always running in container so I would expect that the port is also present in Deployment / Service. Maybe following approach to auto-detect Prometheus on ServiceMonitor can be used as another improvement?

```yaml
{{- if and metrics.enabled .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
```
