### PR TITLE
fix(argo-cd): Remove ArgoCD repo server entrypoint script from command block and drop --staticassets field 

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -22,3 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Remove ArgoCD Repo Server entrypoint file from command block. Defers to entrypoint defined in the Dockerfile"
+    - "[Fixed]: Remove deprecated static assets flag"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 2.0.5
+appVersion: 2.1.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.12.1
+version: 3.13.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: redis-ha.nameOverride / redis-ha.fullnameOverride breaks the ArgoCD helm chart"
+    - "[Fixed]: Remove ArgoCD Repo Server entrypoint file from command block. Defers to entrypoint defined in the Dockerfile"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -34,6 +34,10 @@ Changes in the `CustomResourceDefinition` resources shall be fixed easily by cop
 
 ## Upgrading
 
+### 3.13.0
+
+This release removes the flag `--staticassets` from argocd server as it has been dropped upstream. If this flag needs to be enabled e.g for older releases of ArgoCD, it can be passed via the `extraArgs` field 
+
 ### 3.10.2
 
 ArgoCD has recently deprecated the flag `--staticassets` and from chart version `3.10.2` has been disabled by default

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -40,8 +40,7 @@ spec:
       - name: {{ .Values.repoServer.name }}
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default .Values.global.image.tag .Values.repoServer.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
-        command:
-        - uid_entrypoint.sh
+        args:
         - argocd-repo-server
         {{- if or (and .Values.redis.enabled (not $redisHa.enabled)) (and $redisHa.enabled $redisHa.haproxy.enabled) }}
         - --redis

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -42,10 +42,6 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.server.image.imagePullPolicy }}
         command:
         - argocd-server
-        {{ if .Values.server.staticAssets.enabled }}
-        - --staticassets
-        - /shared/app
-        {{ end }}
         - --repo-server
         - {{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
         {{- if .Values.dex.enabled }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -8,7 +8,7 @@ kubeVersionOverride: ""
 global:
   image:
     repository: quay.io/argoproj/argocd
-    tag: v2.0.5
+    tag: v2.1.0
     imagePullPolicy: IfNotPresent
   securityContext: {}
   #  runAsUser: 999

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -435,10 +435,6 @@ server:
   extraArgs: []
   #  - --insecure
 
-  # This flag is used to either remove or pass the CLI flag --staticassets /shared/app to the argocd-server app
-  staticAssets:
-    enabled: true
-
   ## Environment variables to pass to argocd-server
   ##
   env: []


### PR DESCRIPTION
A quick and tiny PR to fix ArgoCD Repo Server failing to due the entrypoint script rename on v2.1.0

Per @davidkarlsen suggestion, I've removed entrypoint.sh from the command block to defer to the entrypoint defined in the Dockerfile 

This PR also removes the `--staticassets` conditional block I introduced for an older ArgoCD server release

(Creating this PR to unblock anyone trying to use v.2.1.0, noticed #884 was inactive for the past 2 days)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
