### PR TITLE
feat(argo-cd): Parameterizing dex ports names due to istio 403 errors

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.13.1
+version: 3.13.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Updated README.md for ArgoCD"
+    - "[Changed]: Parameterized dex service port names for istio-ingress 403 error"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -397,7 +397,9 @@ NAME: my-release
 | dex.serviceAccount.create | Create dex service account | `true` |
 | dex.serviceAccount.name | Dex service account name | `"argocd-dex-server"` |
 | dex.servicePortGrpc | Server GRPC port | `5557` |
+| dex.servicePortGrpcName | Server GRPC port name | `grpc` |
 | dex.servicePortHttp | Server HTTP port | `5556` |
+| dex.servicePortHttpName | Server GRPC port name | `http` |
 | dex.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | dex.volumeMounts | Dex volume mounts | `"/shared"` |
 | dex.volumes | Dex volumes | `{}` |

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -16,11 +16,11 @@ metadata:
 {{- end }}
 spec:
   ports:
-  - name: http
+  - name: {{ .Values.dex.servicePortHttpName }}
     protocol: TCP
     port: {{ .Values.dex.servicePortHttp }}
     targetPort: http
-  - name: grpc
+  - name: {{ .Values.dex.servicePortGrpcName }}
     protocol: TCP
     port: {{ .Values.dex.servicePortGrpc }}
     targetPort: grpc

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -280,7 +280,7 @@ dex:
   ## Dex deployment container ports
   containerPortHttp: 5556
   servicePortHttp: 5556
-  servicePortHttpName: tcp-http
+  servicePortHttpName: http
   containerPortGrpc: 5557
   servicePortGrpc: 5557
   servicePortGrpcName: grpc

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -280,8 +280,10 @@ dex:
   ## Dex deployment container ports
   containerPortHttp: 5556
   servicePortHttp: 5556
+  servicePortHttpName: tcp-http
   containerPortGrpc: 5557
   servicePortGrpc: 5557
+  servicePortGrpcName: grpc
   containerPortMetrics: 5558
   servicePortMetrics: 5558
 


### PR DESCRIPTION
I'm parameterizing dex service ports for istio-ingress. With original 'http' setting it's returning 403.
More info: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
