### PR TITLE
feat(argo-cd): Allow service monitor relabeling configs

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.15.0
+version: 3.16.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Global configuration for pod annotations and labels"
+    - "[Added]: Service monitor relabelings and metricsRelabelings"
+    - "[Fixed]: Service monitor interval configuration for all components"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -203,6 +203,8 @@ NAME: my-release
 | controller.metrics.service.servicePort | Metrics service port | `8082` |
 | controller.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | controller.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
+| controller.metrics.serviceMonitor.relabelings | Prometheus [RelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before scraping | `[]` |
+| controller.metrics.serviceMonitor.metricRelabelings | Prometheus [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion | `[]`
 | controller.name | Controller name string. | `"application-controller"` |
 | controller.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | controller.podAnnotations | Annotations for the controller pods | `{}` |
@@ -255,6 +257,8 @@ NAME: my-release
 | repoServer.metrics.service.servicePort | Metrics service port | `8082` |
 | repoServer.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | repoServer.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
+| repoServer.metrics.serviceMonitor.relabelings | Prometheus [RelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before scraping | `[]` |
+| repoServer.metrics.serviceMonitor.metricRelabelings | Prometheus [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion | `[]`
 | repoServer.name | Repo server name | `"repo-server"` |
 | repoServer.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | repoServer.podAnnotations | Annotations for the repo server pods | `{}` |
@@ -335,6 +339,8 @@ NAME: my-release
 | server.metrics.service.servicePort | Metrics service port | `8082` |
 | server.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | server.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
+| server.metrics.serviceMonitor.relabelings | Prometheus [RelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before scraping | `[]` |
+| server.metrics.serviceMonitor.metricRelabelings | Prometheus [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion | `[]`
 | server.name | Argo CD server name | `"server"` |
 | server.nodeSelector | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) | `{}` |
 | server.podAnnotations | Annotations for the server pods | `{}` |
@@ -387,6 +393,8 @@ NAME: my-release
 | dex.metrics.service.labels | Metrics service labels | `{}` |
 | dex.metrics.serviceMonitor.enabled | Enable a prometheus ServiceMonitor. | `false` |
 | dex.metrics.serviceMonitor.selector | Prometheus ServiceMonitor selector. | `{}` |
+| dex.metrics.serviceMonitor.relabelings | Prometheus [RelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) to apply to samples before scraping | `[]` |
+| dex.metrics.serviceMonitor.metricRelabelings | Prometheus [MetricRelabelConfigs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) to apply to samples before ingestion | `[]`
 | dex.name | Dex name | `"dex-server"` |
 | dex.env | Environment variables for the Dex server. | `[]` |
 | dex.envFrom | `envFrom` to pass to the Dex server. | `[]` (See [values.yaml](values.yaml)) |

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -3,24 +3,30 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.controller.fullname" . }}
-  {{- if .Values.controller.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  {{- with .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    {{- if .Values.controller.metrics.serviceMonitor.selector }}
-{{- toYaml .Values.controller.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- with .Values.controller.metrics.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
-{{- toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.controller.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
     - port: metrics
-      {{- with .Values.controller.metrics.serviceMonitor.interval }}
-      interval: {{ . }}
-      {{- end }}
       path: /metrics
+      interval: {{ .Values.controller.metrics.serviceMonitor.interval }}
+      {{- with .Values.controller.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
@@ -28,4 +34,3 @@ spec:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.controller.name "name" "metrics") | nindent 6 }}
 {{- end }}
-

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -3,24 +3,30 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.repoServer.fullname" . }}
-  {{- if .Values.repoServer.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.repoServer.metrics.serviceMonitor.namespace }}
+  {{- with .Values.repoServer.metrics.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
-    {{- if .Values.repoServer.metrics.serviceMonitor.selector }}
-{{- toYaml .Values.repoServer.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- with .Values.repoServer.metrics.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.repoServer.metrics.serviceMonitor.additionalLabels }}
-{{- toYaml .Values.repoServer.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.repoServer.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
     - port: metrics
-      {{- with .Values.repoServer.metrics.serviceMonitor.interval }}
-      interval: {{ . }}
-      {{- end }}
       path: /metrics
+      interval: {{ .Values.repoServer.metrics.serviceMonitor.interval }}
+      {{- with .Values.repoServer.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.repoServer.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
@@ -28,4 +34,3 @@ spec:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.repoServer.name "name" (printf "%s-metrics" .Values.repoServer.name)) | nindent 6 }}
 {{- end }}
-

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -8,19 +8,25 @@ metadata:
   {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    {{- if .Values.server.metrics.serviceMonitor.selector }}
-{{- toYaml .Values.server.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- with .Values.server.metrics.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.server.metrics.serviceMonitor.additionalLabels }}
-{{- toYaml .Values.server.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.server.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
     - port: metrics
-      {{- with .Values.controller.metrics.serviceMonitor.interval }}
-      interval: {{ . }}
-      {{- end }}
       path: /metrics
+      interval: {{ .Values.server.metrics.serviceMonitor.interval }}
+      {{- with .Values.server.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
@@ -28,4 +34,3 @@ spec:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.server.name "name" (printf "%s-metrics" .Values.server.name)) | nindent 6 }}
 {{- end }}
-

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -3,24 +3,30 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-cd.dex.fullname" . }}
-  {{- if .Values.dex.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.dex.metrics.serviceMonitor.namespace }}
+  {{- with .Values.dex.metrics.serviceMonitor.namespace }}
+  namespace: {{ . }}
   {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 4 }}
-    {{- if .Values.dex.metrics.serviceMonitor.selector }}
-{{- toYaml .Values.dex.metrics.serviceMonitor.selector | nindent 4 }}
+    {{- with .Values.dex.metrics.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.dex.metrics.serviceMonitor.additionalLabels }}
-{{- toYaml .Values.dex.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.dex.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
     - port: metrics
-      {{- with .Values.controller.metrics.serviceMonitor.interval }}
-      interval: {{ . }}
-      {{- end }}
       path: /metrics
+      interval: {{ .Values.dex.metrics.serviceMonitor.interval }}
+      {{- with .Values.dex.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dex.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . |nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -169,6 +169,8 @@ controller:
     serviceMonitor:
       enabled: false
       interval: 30s
+      relabelings: []
+      metricRelabelings: []
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
@@ -230,6 +232,8 @@ dex:
     serviceMonitor:
       enabled: false
       interval: 30s
+      relabelings: []
+      metricRelabelings: []
       # selector:
       #   prometheus: kube-prometheus
       # namespace: monitoring
@@ -576,6 +580,8 @@ server:
     serviceMonitor:
       enabled: false
       interval: 30s
+      relabelings: []
+      metricRelabelings: []
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring
@@ -961,6 +967,8 @@ repoServer:
     serviceMonitor:
       enabled: false
       interval: 30s
+      relabelings: []
+      metricRelabelings: []
     #   selector:
     #     prometheus: kube-prometheus
     #   namespace: monitoring


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/818

- Fixed incorrect interval path on all ServiceMonitors
- Minor refactoring to keep values DRY

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
