### PR TITLE
fix(argocd-notifications): Use correct names for ConfigMap and Secret

### DIFF
--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.1.1
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.4.3
+version: 1.4.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-notifications.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
   - name: andyfeller
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Use correct chart icon url"
+    - "[Fixed]: Use correct names for ConfigMap and Secret"

--- a/charts/argocd-notifications/templates/configmap.yaml
+++ b/charts/argocd-notifications/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "argocd-notifications.name" . }}-cm
+  name: argocd-notifications-cm
   labels:
     {{- include "argocd-notifications.labels" . | nindent 4 }}
 data:

--- a/charts/argocd-notifications/templates/secret.yaml
+++ b/charts/argocd-notifications/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "argocd-notifications.name" . }}-secret
+  name: argocd-notifications-secret
   labels:
     {{- include "argocd-notifications.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/779 as a workaround.

Support of custom names can be added after 1.12.0 release via `config-map-name` and `secret-name` switches.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
