### PR TITLE
fix(argo-cd): use $ as context for repository secret labels

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.17.2
+version: 3.17.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,5 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade argo-cd image to 2.1.1"
-    - "[Fixed]: Reenabling static assets for the argo-cd server"
+    - "[Fixed]: use $ as context for repository secret labels"

--- a/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: argocd-repo-creds-{{ $repo_cred_key }}
   labels:
     argocd.argoproj.io/secret-type: repo-creds
-    {{- include "argo-cd.labels" (dict "context" .) | nindent 4 }}
+    {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
 data:
   {{- range $key, $value := $repo_cred_value }}
   {{ $key }}: {{ $value | toString | b64enc }}

--- a/charts/argo-cd/templates/argocd-configs/repository-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/repository-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: argocd-repo-{{ $repo_key }}
   labels:
     argocd.argoproj.io/secret-type: repository
-    {{- include "argo-cd.labels" (dict "context" .) | nindent 4 }}
+    {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
 data:
   {{- range $key, $value := $repo_value }}
   {{ $key }}: {{ $value | b64enc }}


### PR DESCRIPTION
Without this, templating fails with:

```
Error: template: ArgoCD/charts/argo-cd/templates/argocd-configs/repository-secret.yaml:9:8: executing "ArgoCD/charts/argo-cd/templates/argocd-configs/repository-secret.yaml" at <include "argo-cd.labels" (dict "context" .)>: error calling include: template: ArgoCD/charts/argo-cd/templates/_helpers.tpl:136:18: executing "argo-cd.labels" at <include "argo-cd.chart" .context>: error calling include: template: ArgoCD/charts/argo-cd/templates/_helpers.tpl:129:25: executing "argo-cd.chart" at <.Chart.Name>: nil pointer evaluating interface {}.Name

Use --debug flag to render out invalid YAML
```

Signed-off-by: Raphaël Pinson <raphael.pinson@camptocamp.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
