### PR TITLE
fix(argo-rollouts): use `image.tag` in labels if provided

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.0.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.0.1
+version: 2.0.2
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -11,4 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: ServiceMonitor selector labels match metrics Service"
+    - "[Fixed]: use image.tag in app labels if provided"

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Common labels
 helm.sh/chart: {{ include "argo-rollouts.chart" . }}
 {{ include "argo-rollouts.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ default .Chart.AppVersion $.Values.controller.image.tag | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: argo-rollouts


### PR DESCRIPTION
We are using `{{default .Chart.AppVersion .Values.controller.image.tag}}` for image tag in [deployment.yaml](https://github.com/argoproj/argo-helm/blob/master/charts/argo-rollouts/templates/argo-rollouts-deployment.yaml#L34).  But in `_helpers.tpl` we are using `app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}` causing two out of sync information about the application's version



* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).