### PR TITLE
feat(argo-cd): Update to the latest redis-ha chart which defaults to redis 6.2.5

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.12.17
-digest: sha256:ad1833436031e3578165d48646c90323040fa1bc00d9235fe7ba7c67b20094ec
-generated: "2021-07-27T16:35:27.2509236-04:00"
+  version: 4.13.0
+digest: sha256:0a737818ba9445a77b2a2267ee2579aa17e5208912fdc837360d823b4095680e
+generated: "2021-09-01T09:26:57.1130296-04:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.17.5
+version: 3.18.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -16,9 +16,9 @@ maintainers:
   - name: seanson
 dependencies:
   - name: redis-ha
-    version: 4.12.17
+    version: 4.13.0
     repository: https://dandydeveloper.github.io/charts/
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Make AWS ALB GRPC backend protocol version configurable"
+    - "[Changed]: Update to the latest redis-ha chart which defaults to redis 6.2.5"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -447,7 +447,7 @@ through `xxx.extraArgs`
 | redis.enabled | Enable redis | `true` |
 | redis.image.imagePullPolicy | Redis imagePullPolicy | `"IfNotPresent"` |
 | redis.image.repository | Redis repository | `"redis"` |
-| redis.image.tag | Redis tag | `"6.2.1-alpine"` |
+| redis.image.tag | Redis tag | `"6.2.5-alpine"` |
 | redis.extraArgs | Additional arguments for the `redis-server`. A list of flags. | `[]` |
 | redis.name | Redis name | `"redis"` |
 | redis.env | Environment variables for the Redis server. | `[]` |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -346,7 +346,7 @@ redis:
 
   image:
     repository: redis
-    tag: 6.2.4-alpine
+    tag: 6.2.5-alpine
     imagePullPolicy: IfNotPresent
 
   ## Additional command line arguments to pass to redis-server
@@ -437,7 +437,7 @@ redis-ha:
     metrics:
       enabled: true
   image:
-    tag: 6.2.4-alpine
+    tag: 6.2.5-alpine
 
 ## Server
 server:


### PR DESCRIPTION
See - https://github.com/DandyDeveloper/charts/tree/master/charts/redis-ha

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [X] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
