### PR TITLE
feat(argo-cd): Add support for topologySpreadConstraints

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.17.5
+version: 3.17.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Make AWS ALB GRPC backend protocol version configurable"
+    - "[Changed]: Add support for topologySpreadConstraints"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -181,6 +181,7 @@ NAME: my-release
 | Parameter | Description | Default |
 |-----|---------|-------------|
 | controller.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| controller.topologySpreadConstraints | [Assign custom topologySpreadConstraints rules to the deployment](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) | `[]` |
 | controller.args.operationProcessors | define the controller `--operation-processors` | `"10"` |
 | controller.args.appResyncPeriod | define the controller `--app-resync` | `"180"` |
 | controller.args.selfHealTimeout | define the controller `--self-heal-timeout-seconds` | `"5"` |
@@ -236,6 +237,7 @@ NAME: my-release
 | Property | Description | Default |
 |-----|---------|-------------|
 | repoServer.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| repoServer.topologySpreadConstraints | [Assign custom topologySpreadConstraints rules to the deployment](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) | `[]` |
 | repoServer.autoscaling.enabled | Enable Horizontal Pod Autoscaler ([HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)) for the repo server | `false` |
 | repoServer.autoscaling.minReplicas | Minimum number of replicas for the repo server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `1` |
 | repoServer.autoscaling.maxReplicas | Maximum number of replicas for the repo server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `5` |
@@ -290,6 +292,7 @@ NAME: my-release
 | Parameter | Description | Default |
 |-----|---------|-------------|
 | server.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| server.topologySpreadConstraints | [Assign custom topologySpreadConstraints rules to the deployment](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) | `[]` |
 | server.autoscaling.enabled | Enable Horizontal Pod Autoscaler ([HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)) for the server | `false` |
 | server.autoscaling.minReplicas | Minimum number of replicas for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `1` |
 | server.autoscaling.maxReplicas | Maximum number of replicas for the server [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `5` |
@@ -385,6 +388,7 @@ NAME: my-release
 | Property | Description | Default |
 |-----|---------|-------------|
 | dex.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| dex.topologySpreadConstraints | [Assign custom topologySpreadConstraints rules to the deployment](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) | `[]` |
 | dex.containerPortGrpc | GRPC container port | `5557` |
 | dex.containerPortHttp | HTTP container port | `5556` |
 | dex.enabled | Enable dex | `true` |
@@ -443,6 +447,7 @@ through `xxx.extraArgs`
 | Parameter | Description | Default |
 |-----|---------|-------------|
 | redis.affinity | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}` |
+| redis.topologySpreadConstraints | [Assign custom topologySpreadConstraints rules to the deployment](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) | `[]` |
 | redis.containerPort | Redis container port | `6379` |
 | redis.enabled | Enable redis | `true` |
 | redis.image.imagePullPolicy | Redis imagePullPolicy | `"IfNotPresent"` |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -118,6 +118,17 @@ spec:
       affinity:
 {{- toYaml .Values.controller.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range $constraint := .Values.controller.topologySpreadConstraints }}
+      - {{ $constraint | toYaml | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "argo-cd.selectorLabels" (dict "context" $ "name" $.Values.controller.name) | nindent 12 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "argo-cd.controllerServiceAccountName" . }}
 {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -118,10 +118,10 @@ spec:
       affinity:
 {{- toYaml .Values.controller.affinity | nindent 8 }}
     {{- end }}
-    {{- if .Values.controller.topologySpreadConstraints }}
+    {{- with .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range $constraint := .Values.controller.topologySpreadConstraints }}
-      - {{ $constraint | toYaml | nindent 8 | trim }}
+      {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
         {{- if not $constraint.labelSelector }}
         labelSelector:
           matchLabels:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -126,6 +126,17 @@ spec:
       affinity:
 {{- toYaml .Values.repoServer.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.repoServer.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range $constraint := .Values.repoServer.topologySpreadConstraints }}
+      - {{ $constraint | toYaml | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "argo-cd.selectorLabels" (dict "context" $ "name" $.Values.repoServer.name) | nindent 12 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "argo-cd.repoServerServiceAccountName" . }}
 {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -126,10 +126,10 @@ spec:
       affinity:
 {{- toYaml .Values.repoServer.affinity | nindent 8 }}
     {{- end }}
-    {{- if .Values.repoServer.topologySpreadConstraints }}
+    {{- with .Values.repoServer.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range $constraint := .Values.repoServer.topologySpreadConstraints }}
-      - {{ $constraint | toYaml | nindent 8 | trim }}
+      {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
         {{- if not $constraint.labelSelector }}
         labelSelector:
           matchLabels:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -140,10 +140,10 @@ spec:
       affinity:
 {{- toYaml .Values.server.affinity | nindent 8 }}
     {{- end }}
-    {{- if .Values.server.topologySpreadConstraints }}
+    {{- with .Values.server.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range $constraint := .Values.server.topologySpreadConstraints }}
-      - {{ $constraint | toYaml | nindent 8 | trim }}
+      {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
         {{- if not $constraint.labelSelector }}
         labelSelector:
           matchLabels:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -140,6 +140,17 @@ spec:
       affinity:
 {{- toYaml .Values.server.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range $constraint := .Values.server.topologySpreadConstraints }}
+      - {{ $constraint | toYaml | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "argo-cd.selectorLabels" (dict "context" $ "name" $.Values.server.name) | nindent 12 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "argo-cd.serverServiceAccountName" . }}
 {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -112,6 +112,17 @@ spec:
       affinity:
 {{- toYaml .Values.dex.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.dex.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range $constraint := .Values.dex.topologySpreadConstraints }}
+      - {{ $constraint | toYaml | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            {{- include "argo-cd.selectorLabels" (dict "context" $ "name" $.Values.dex.name) | nindent 12 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "argo-cd.dexServiceAccountName" . }}
       volumes:
       - emptyDir: {}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -112,10 +112,10 @@ spec:
       affinity:
 {{- toYaml .Values.dex.affinity | nindent 8 }}
     {{- end }}
-    {{- if .Values.dex.topologySpreadConstraints }}
+    {{- with .Values.dex.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range $constraint := .Values.dex.topologySpreadConstraints }}
-      - {{ $constraint | toYaml | nindent 8 | trim }}
+      {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
         {{- if not $constraint.labelSelector }}
         labelSelector:
           matchLabels:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -76,10 +76,10 @@ spec:
       affinity:
 {{- toYaml .Values.redis.affinity | nindent 8 }}
     {{- end }}
-    {{- if .Values.redis.topologySpreadConstraints }}
+    {{- with .Values.redis.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range $constraint := .Values.redis.topologySpreadConstraints }}
-      - {{ $constraint | toYaml | nindent 8 | trim }}
+      {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
         {{- if not $constraint.labelSelector }}
         labelSelector:
           matchLabels:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -76,6 +76,17 @@ spec:
       affinity:
 {{- toYaml .Values.redis.affinity | nindent 8 }}
     {{- end }}
+    {{- if .Values.redis.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- range $constraint := .Values.redis.topologySpreadConstraints }}
+      - {{ $constraint | toYaml | nindent 8 | trim }}
+        {{- if not $constraint.labelSelector }}
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: {{ include "argo-cd.name" $ }}-{{ $.Values.redis.name }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 {{- if .Values.redis.volumes }}
       volumes:
 {{- toYaml .Values.redis.volumes | nindent 8}}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -143,6 +143,14 @@ controller:
   tolerations: []
   affinity: {}
 
+  # Pod Topology Spread Constraints
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # If labelSelector is left out, it will default to the labelSelector configuration of the deployment
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+
   priorityClassName: ""
 
   resources: {}
@@ -321,6 +329,14 @@ dex:
   tolerations: []
   affinity: {}
 
+  # Pod Topology Spread Constraints
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # If labelSelector is left out, it will default to the labelSelector configuration of the deployment
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+
   priorityClassName: ""
 
   ## Labels to set container specific security contexts
@@ -384,6 +400,14 @@ redis:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+  # Pod Topology Spread Constraints
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # If labelSelector is left out, it will default to the labelSelector configuration of the deployment
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
 
   priorityClassName: ""
 
@@ -526,6 +550,14 @@ server:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+  # Pod Topology Spread Constraints
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # If labelSelector is left out, it will default to the labelSelector configuration of the deployment
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
 
   priorityClassName: ""
 
@@ -939,6 +971,14 @@ repoServer:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+  # Pod Topology Spread Constraints
+  # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # If labelSelector is left out, it will default to the labelSelector configuration of the deployment
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
 
   priorityClassName: ""
 


### PR DESCRIPTION
Signed-off-by: Sander van Schie <sandervanschie@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.

Pod Topology Spread Constraints can be useful when you want to enforce spread of pods, but want to spin up more pods than you have different topologies. For example if you want to spread 6 pods across your 3 availability zones, it will place 2 in every zone. With podAntiAffinity it would only be able to spin up 3 pods (when using requiredDuringSchedulingIgnoredDuringExecution).

I implemented some logic for the labelSelector so you don't have to hard-code it in the values file. It will default to the same selector as the deployment, but it can be overwritten. If you'd like to see this different please feel free to let me know 😄 