### PR TITLE
feat(argo-rollouts): Default to keeping CRD's on helm uninstall

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.0.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.0.1
+version: 2.1.0
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -11,4 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: ServiceMonitor selector labels match metrics Service"
+    - "[Added]: Keep CRDs on Helm uninstall by default, add corresponding option"

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -48,6 +48,7 @@ If dashboard is installed by `--set dashboard.enabled=true`, checkout the argo-r
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Labels to be added to the ServiceMonitor |
 | imagePullSecrets | list | `[]` | Registry secret names as an array |
 | installCRDs | bool | `true` | Install and upgrade CRDs |
+| keepCRDs | bool | `true` | Keep CRD's on helm uninstall |
 | crdAnnotations | object | `{}` | Annotations to be added to all CRDs |
 | podAnnotations | object | `{}` | Annotations to be added to the Rollout pods |
 | podLabels | object | `{}` | Labels to be added to the Rollout pods |

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    {{- if .Values.keepCRDs }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     {{- if .Values.crdAnnotations }}
     {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    {{- if .Values.keepCRDs }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     {{- if .Values.crdAnnotations }}
     {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    {{- if .Values.keepCRDs }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     {{- if .Values.crdAnnotations }}
     {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    {{- if .Values.keepCRDs }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     {{- if .Values.crdAnnotations }}
     {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
+    {{- if .Values.keepCRDs }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
     {{- if .Values.crdAnnotations }}
     {{- toYaml .Values.crdAnnotations | nindent 4 }}
     {{- end }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -1,4 +1,5 @@
 installCRDs: true
+keepCRDs: true
 
 clusterInstall: true
 


### PR DESCRIPTION
This reduces risk when upgrading the controller by keeping CRD's by default. This will leave Rollouts in a degraded state but at least they will keep serving.

Scenario this avoids:
- Incompatible upgrade needed between major versions requiring 'helm uninstall'
- `helm uninstall` is performed and ALL the rollouts on the cluster get deleted due to CRD deletion

This should be backwards compatible as this keeps the CRD managed (unlike hook annotations).
Feature also provides an opt-out if needed.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
