### PR TITLE
feat(argo-workflows): Add controller containerRuntimeExecutors param to configmap

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -15,5 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add controller namespaceParallelism param to configmap"
     - "[Added]: Add controller containerRuntimeExecutors param to configmap"

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "v3.1.8"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -16,3 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: Add controller namespaceParallelism param to configmap"
+    - "[Added]: Add controller containerRuntimeExecutors param to configmap"

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -14,6 +14,10 @@ data:
       {{- end }}
     {{- end }}
     containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
+    {{- with .Values.controller.containerRuntimeExecutors }}
+    containerRuntimeExecutors:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- if .Values.controller.parallelism }}
     parallelism: {{ .Values.controller.parallelism }}
     {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -113,6 +113,11 @@ controller:
   workflowNamespaces:
     - default
   containerRuntimeExecutor: docker
+  # containerRuntimeExecutors:
+  #   - name: emissary
+  #     selector:
+  #       matchLabels:
+  #         workflows.argoproj.io/container-runtime-executor: emissary
   instanceID:
     # `instanceID.enabled` configures the controller to filter workflow submissions
     # to only those which have a matching instanceID attribute.


### PR DESCRIPTION
Hi,

This PR adds the controller `containerRuntimeExecutors` params to the configuration map. In my case I needed it to partially enable the Emissary executor on some workflows according to the [upgrade guide](https://github.com/argoproj/argo-workflows/blob/master/docs/upgrading.md#ab361667a-featcontroller-emissary-executor--4925).

Default value does not change the current behaviour. However, a commented version of the documentation has been linked. Don't know whether or not you will find it useful.

Thanks in advance for considering this change.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
