### PR TITLE
feat(argo-image-updater): add podSecurityPolicy and rbac permission

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.10.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -16,3 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: First chart release"
+    - "[Added]: PodSecurityPolicy and RBAC permissions for usage"

--- a/charts/argocd-image-updater/templates/podsecuritypolicy.yaml
+++ b/charts/argocd-image-updater/templates/podsecuritypolicy.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.rbac.psp.create }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "argocd-image-updater.fullname" . }}-psp
+  labels:
+  {{ include "argocd-image-updater.labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    {{- if .Values.rbac.psp.useAppArmor }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  {{- end }}
+  {{- with .Values.rbac.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  privileged: {{ .Values.rbac.psp.privileged }}
+  allowPrivilegeEscalation: {{ .Values.rbac.psp.allowPrivilegeEscalation }}
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - '*'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: {{ .Values.rbac.psp.readOnlyRootFilesystem }}
+  {{- end }}

--- a/charts/argocd-image-updater/templates/rbac.yaml
+++ b/charts/argocd-image-updater/templates/rbac.yaml
@@ -31,6 +31,14 @@ rules:
       - events
     verbs:
       - create
+  - apiGroups:
+      - policy
+    resourceNames:
+      - {{ include "argocd-image-updater.fullname" . }}-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -86,8 +86,16 @@ securityContext: {}
   # runAsUser: 1000
 
 rbac:
+  # -- Annotations to add to rbac manifests
+  annotations: { }
   # -- Enable RBAC creation
   enabled: true
+  psp:
+    create: false
+    privileged: false
+    allowPrivilegeEscalation: false
+    useAppArmor: false
+    readOnlyRootFilesystem: true
 
 # -- Pod memory and cpu resource settings for the deployment
 resources: {}


### PR DESCRIPTION
We have the problem that for image writeback the argocd-image-updater needs to access its rootFS. Our Pods are running unprivileged and not in kube-system namespace, so iam not be able to change `readOnlyRootFilesystem` in the values.yml to `true`.

Errors:

```
time="2021-09-15T14:52:10Z" level=info msg="Processing results: applications=1 images_considered=1 images_skipped=0 images_updated=0 errors=1"
time="2021-09-15T14:52:10Z" level=error msg="Could not update application spec: mkdir /tmp/git-XXXXXXXXXX: read-only file system" application=XXXXX
```

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.