### PR TITLE
feat(argo-workflows): Allow setting the metrics port name

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: "v3.1.8"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add controller initialDelay param to configmap"
+    - "[Added]: Add controller metricsConfig.portName parameter"

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.5.3
+version: 0.6.0
 appVersion: "v3.1.8"
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -75,7 +75,7 @@ spec:
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           ports:
-            - name: metrics
+            - name: {{ .Values.controller.metricsConfig.portName }}
               containerPort: {{ .Values.controller.metricsConfig.port }}
             - containerPort: 6060
           livenessProbe: {{ .Values.controller.livenessProbe | toYaml | nindent 12 }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -57,6 +57,7 @@ controller:
     enabled: false
     path: /metrics
     port: 9090
+    portName: metrics
     servicePort: 8080
     servicePortName: metrics
   # the controller container's securityContext


### PR DESCRIPTION
Here, we scrape every pod that has a .*-metrics port here
But the helm chart is locked to `metrics` which our Prometheus doesn't see

This PR will make it configurable with a default value of `metrics`

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
