### PR TITLE
fix: move extraArgs to container args

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -16,4 +16,3 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: extraArgs not recognized"
-    - "[Added]: Ability to provide custom environment variables"

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: v0.10.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -15,4 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
+    - "[Fixed]: extraArgs not recognized"
     - "[Added]: Ability to provide custom environment variables"

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -28,8 +28,8 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command: 
-            - /usr/local/bin/argocd-image-updater
+          command: ["/usr/local/bin/argocd-image-updater"]
+          args:
             - run
             {{- with .Values.extraArgs }}
               {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

Attempt to fix #936 

When I tried to use the flag `--git-commit-email john@doe.com` in `extraArgs`, the logs will show `--git-commit-email john@doe.com` not recognized as valid flags.
Moving `extraArgs` values to `args` fixes it.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
