### PR TITLE
chore: Require related chart name in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,6 +11,23 @@ body:
   validations:
     required: true
 
+- type: dropdown
+  attributes:
+    label: Related helm chart
+    description: You may select more than one.
+    multiple: true
+    options:
+      - argo-cd
+      - argo-events
+      - argo-rollouts
+      - argo-workflows
+      - argocd-applicationset
+      - argocd-image-updater
+      - argocd-notifications
+      - other
+  validations:
+    required: true
+
 - type: textarea
   attributes:
     label: To Reproduce

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -13,6 +13,23 @@ body:
   validations:
     required: false
 
+- type: dropdown
+  attributes:
+    label: Related helm chart
+    description: You may select more than one.
+    multiple: true
+    options:
+      - argo-cd
+      - argo-events
+      - argo-rollouts
+      - argo-workflows
+      - argocd-applicationset
+      - argocd-image-updater
+      - argocd-notifications
+      - other
+  validations:
+    required: true
+
 - type: textarea
   attributes:
     label: Describe the solution you'd like


### PR DESCRIPTION
This helps to enhance the issue quality from the community as the related helm chart is now a required input.