### PR TITLE
feat(argocd-applicationset): Add extraArgs

### DIFF
--- a/charts/argocd-applicationset/Chart.yaml
+++ b/charts/argocd-applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationset
 description: A Helm chart for installing ArgoCD ApplicationSet
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: "v0.2.0"
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-applicationset.readthedocs.io/en/stable/assets/logo.png
@@ -14,4 +14,4 @@ maintainers:
   - name: maruina
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Configuration for Pod labels"
+    - "[Added]: Add extraArgs to define additional CLI parameters"

--- a/charts/argocd-applicationset/README.md
+++ b/charts/argocd-applicationset/README.md
@@ -65,6 +65,7 @@ kubectl apply -k https://github.com/argoproj-labs/applicationset.git/manifests/c
 | args.namespace | string | `"argocd"` | The default Argo CD repo namespace |
 | args.policy | string | `"sync"` | How application is synced between the generator and the cluster |
 | args.probeBindAddr | string | `":8081"` | The default health check port |
+| extraArgs | list | `[]` | List of extra cli args to add |
 | extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | extraVolumes | list | `[]` | List of extra volumes to add |
 | fullnameOverride | string | `""` | Override the default fully qualified app name |

--- a/charts/argocd-applicationset/templates/deployment.yaml
+++ b/charts/argocd-applicationset/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             - --policy={{ .Values.args.policy }}
             - --debug={{ .Values.args.debug }}
             - --dry-run={{ .Values.args.dryRun }}
+            {{- with .Values.extraArgs }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/argocd-applicationset/templates/deployment.yaml
+++ b/charts/argocd-applicationset/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - --debug={{ .Values.args.debug }}
             - --dry-run={{ .Values.args.dryRun }}
             {{- with .Values.extraArgs }}
-            {{- . | toYaml | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/argocd-applicationset/values.yaml
+++ b/charts/argocd-applicationset/values.yaml
@@ -113,3 +113,7 @@ extraVolumeMounts: []
 extraVolumes: []
   # - name: foobar
   #   emptyDir: {}
+
+# -- List of extra cli args to add
+extraArgs: []
+  #- --loglevel=warn

--- a/charts/argocd-applicationset/values.yaml
+++ b/charts/argocd-applicationset/values.yaml
@@ -116,4 +116,4 @@ extraVolumes: []
 
 # -- List of extra cli args to add
 extraArgs: []
-  #- --loglevel=warn
+  # - --loglevel=warn


### PR DESCRIPTION
To be forward-compatible, I'm not add args.logLevel, instead adding extraArgs to support all arguments out of the box

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
