### PR TITLE
chore(argo-rollouts): Define two separate tests

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.0.2"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.1.0
+version: 2.1.1
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -11,4 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Keep CRDs on Helm uninstall by default, add corresponding option"
+    - "[Added]: Two separate tests. One for default values and one for dashboard enabled."

--- a/charts/argo-rollouts/ci/default-values.yaml
+++ b/charts/argo-rollouts/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Test with default values

--- a/charts/argo-rollouts/ci/enable-dashboard-values.yaml
+++ b/charts/argo-rollouts/ci/enable-dashboard-values.yaml
@@ -1,0 +1,6 @@
+# Test with dashboard enabled
+# Do not deploy the CRDs as they are already present from the previous test
+installCRDs: false
+
+dashboard:
+  enabled: true

--- a/charts/argo-rollouts/ci/test-values.yaml
+++ b/charts/argo-rollouts/ci/test-values.yaml
@@ -1,2 +1,0 @@
-dashboard:
-  enabled: true


### PR DESCRIPTION
These two tests runs independently:
1. Install with default values
2. Install wich dashboard enabled

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
