### PR TITLE
feat(redis-service-annotations):Create optional serviceAnnotations value in helm chart for redis service

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -14,11 +14,11 @@ maintainers:
   - name: alexmt
   - name: jessesuen
   - name: seanson
-dependencies:
-  - name: redis-ha
-    version: 4.12.17
-    repository: https://dandydeveloper.github.io/charts/
-    condition: redis-ha.enabled
+#dependencies:
+#  - name: redis-ha
+#    version: 4.12.17
+#    repository: https://dandydeveloper.github.io/charts/
+#    condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: repoServer.extraContainers unused"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -14,11 +14,11 @@ maintainers:
   - name: alexmt
   - name: jessesuen
   - name: seanson
-#dependencies:
-#  - name: redis-ha
-#    version: 4.12.17
-#    repository: https://dandydeveloper.github.io/charts/
-#    condition: redis-ha.enabled
+dependencies:
+  - name: redis-ha
+    version: 4.12.17
+    repository: https://dandydeveloper.github.io/charts/
+    condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: repoServer.extraContainers unused"

--- a/charts/argo-cd/templates/redis/service.yaml
+++ b/charts/argo-cd/templates/redis/service.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ template "argo-cd.redis.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
+  {{- with .Values.redis.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.redis.servicePort }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -395,6 +395,9 @@ redis:
   ##
   podAnnotations: {}
 
+  # Annotations to be added to the provisioned service resource
+  serviceAnnotations: {}
+
   ## Labels to be added to the Redis server pods
   ##
   podLabels: {}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [*] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [*] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
