### PR TITLE
feat(argo-cd): Add extraVolumes Dex server

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.1.3
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.24.0
+version: 3.25.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-cd/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Use Istio port name naming convention for redis"
+    - "[Added]: Uses extraVolumes and extraVolumeMounts for dex server"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -445,6 +445,8 @@ NAME: my-release
 | dex.tolerations | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `[]` |
 | dex.volumeMounts | Dex volume mounts | `"/shared"` |
 | dex.volumes | Dex volumes | `{}` |
+| dex.extraVolumeMounts | Extra dex volume mounts | `[]` |
+| dex.extraVolumes | Extra dex volumes | `[]` |
 
 ## Redis
 

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -98,6 +98,9 @@ spec:
         {{- if .Values.dex.volumeMounts }}
         {{- toYaml .Values.dex.volumeMounts | nindent 8 }}
         {{- end }}
+        {{- if .Values.dex.extraVolumeMounts }}
+        {{- toYaml .Values.dex.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.dex.resources | nindent 10 }}
       {{- with .Values.dex.extraContainers }}
@@ -136,6 +139,9 @@ spec:
         name: tmp-dir
       {{- if .Values.dex.volumes }}
       {{- toYaml .Values.dex.volumes | nindent 6 }}
+      {{- end }}
+      {{- if .Values.dex.extraVolumes }}
+      {{- toYaml .Values.dex.extraVolumes | nindent 6 }}
       {{- end }}
 {{- if .Values.dex.priorityClassName }}
       priorityClassName: {{ .Values.dex.priorityClassName }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -314,6 +314,12 @@ dex:
     - name: static-files
       emptyDir: {}
 
+  ## Extra volumes to the controller pod.
+  extraVolumes: []
+
+  ## Extra volumeMounts to the controller pod.
+  extraVolumeMounts: []
+
   ## Dex deployment container ports
   containerPortHttp: 5556
   servicePortHttp: 5556


### PR DESCRIPTION
Related to https://github.com/argoproj/argo-helm/issues/960

Add extraVolumes and extraVolumeMounts for dex server

Signed-off-by: Iago Santos <iago.santos.pardo@adfinis.com>

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
