### PR TITLE
feat(argo-rollouts): Allow additional containers in controller deployment

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -11,5 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support for extraArgs for controller and dashboard"
     - "[Added]: Support for extraContainers for controller deployment"

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.1.0"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.3.0
+version: 2.3.1
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -12,3 +12,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: Support for extraArgs for controller and dashboard"
+    - "[Added]: Support for extraContainers for controller deployment"

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.1.0"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.3.1
+version: 2.4.0
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -39,6 +39,7 @@ If dashboard is installed by `--set dashboard.enabled=true`, checkout the argo-r
 | controller.image.repository | string | `"argoproj/argo-rollouts"` | Repository to use |
 | controller.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | controller.extraArgs | list | `[]` | Additional arguments for the controller. A list of flags. |
+| controller.extraContainers | list | `[]` | Literal yaml for extra containers to be added to controller deployment. |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.tolerations | list | `[]` | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | controller.affinity | object | `{}` | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -52,6 +52,9 @@ spec:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
+      {{- if .Values.controller.extraContainers }}
+      {{- toYaml .Values.controller.extraContainers | nindent 6 }}
+      {{- end }}
       {{- if .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.controller.nodeSelector | nindent 8 }}

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -52,8 +52,8 @@ spec:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
-      {{- if .Values.controller.extraContainers }}
-      {{- toYaml .Values.controller.extraContainers | nindent 6 }}
+      {{- with .Values.controller.extraContainers }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- if .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -21,6 +21,10 @@ controller:
   ##
   extraArgs: []
 
+  ## Additional containers to add to the rollouts controller deployment
+  ## This will be rendered as the literal yaml
+  extraContainers: []
+
   resources: {}
   #  limits:
   #    cpu: 100m


### PR DESCRIPTION
Our local metrics setup uses an extra container for the controller
deployment. Adding this in case others have a similar use case.

Signed-off-by: Brian Johnson <b2jrock@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
