### PR TITLE
fix(argo-cd): helm3 install does not have flag --name

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.1.6
+appVersion: v2.1.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.26.4
+version: 3.26.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version 2.1.6"
+    - "[Changed]: Update to app version 2.1.7"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.1.7
+appVersion: v2.1.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
 version: 3.26.5
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version 2.1.7"
+    - "[Changed]: README update to reflect correct helm install syntax"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -175,7 +175,7 @@ To install the chart with the release name `my-release`:
 $ helm repo add argo https://argoproj.github.io/argo-helm
 "argo" has been added to your repositories
 
-$ helm install --name my-release argo/argo-cd
+$ helm install my-release argo/argo-cd
 NAME: my-release
 ...
 ```

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -176,7 +176,7 @@ To install the chart with the release name `my-release`:
 $ helm repo add argo https://argoproj.github.io/argo-helm
 "argo" has been added to your repositories
 
-$ helm install --name my-release argo/argo-cd
+$ helm install my-release argo/argo-cd
 NAME: my-release
 ...
 ```


### PR DESCRIPTION
Details:
just fix typo in the readme in the  `## Installing the Chart` part


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
