### PR TITLE
fix(argo-cd): Make argocd-server /home/argocd/.aws writeable when using readOnlyRootFilesystem=false security context

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.6
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.26.5
+version: 3.26.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: README update to reflect correct helm install syntax"
+    - "[Changed]: Make argocd-server /home/argocd/.aws writeable when using readOnlyRootFilesystem=false security context"

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -90,6 +90,10 @@ spec:
           subPath: "custom.styles.css"
           name: custom-styles
         {{- end }}
+        {{- if .Values.server.containerSecurityContext.readOnlyRootFilesystem }}
+        - mountPath: /home/argocd/.aws
+          name: aws-config
+        {{- end }}
         - mountPath: /tmp
           name: tmp-dir
         ports:
@@ -164,6 +168,10 @@ spec:
         name: static-files
       - emptyDir: {}
         name: tmp-dir
+      {{- if .Values.server.containerSecurityContext.readOnlyRootFilesystem }}
+      - emptyDir: {}
+        name: aws-config
+      {{- end }}
       {{- if .Values.configs.styles }}
       - configMap:
           name: argocd-custom-styles


### PR DESCRIPTION
## Context
We are running argo with `containerSecurityContext.readOnlyRootFilesystem` set to `true`.

However, a bunch of things are not loading on the ArgoCD Dashboard (logs, events, manifests, ...) when doing so.  When looking at the argocd server logs, we found the following error:

```
[Errno 30] Read-only file system: '/home/argocd/.aws'
{"error":"Get \"https://{REDACTED}.eks.amazonaws.com/api/v1?timeout=32s\": getting credentials: exec: executable aws failed with exit code 255","grpc.code":"Unknown","grpc.method":"DeleteResource","grpc.service":"application.ApplicationService","grpc.start_time":"2021-10-28T20:31:02Z","grpc.time_ms":495.752,"level":"error","msg":"finished unary call with code Unknown","span.kind":"server","system":"grpc","time":"2021-10-28T20:31:02Z"}
```

The reason is that ArgoCD server is calling the AWS CLI, and AWS CLI needs to store some credentials under `~/.aws/cache/*.json`. Note that this `~/.aws/cache` folder is [not configurable with AWS](https://stackoverflow.com/questions/65996836/aws-cli-cache-incorrect-location) (other than updating `$HOME`, which would impact ArgoCD), so we can't just use some environment variables like `AWS_CONFIG_FILE` to make AWS CLI write stuff under `/tmp`.

Our current workaround is to set the following helm values:

```
      volumes = [
        {
          "name" = "aws-config",
          "emptyDir" = {}
        }
      ]

      volumeMounts = [
        {
          "name" = "aws-config",
          "mountPath" = "/home/argocd/.aws"
        }
      ]
```

We were thinking that it might be useful to directly set these when enabling `server.readOnlyRootFilesystem` since others might run in the same issue.

## Testing
I followed the testing steps in the contributing guidelines, once with `server.readOnlyRootFilesystem` set to false, and another time with `server.readOnlyRootFilesystem`.

In both cases, I verified the configuration with `kubectl describe pods` and SSH'd into the server container to verify the volume configuration.

## Checklist

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
