### PR TITLE
fix(argo-workflows): Add missing WorkflowTasksets RBAC to controller

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: v3.2.4
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Changed default GCP keyFormat"
+    - "[Fixed]: Added missing WorkflowTaskSets RBAC to controller"

--- a/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
@@ -68,6 +68,8 @@ rules:
   - workflows/finalizers
   - workfloweventbindings
   - workfloweventbindings/finalizers
+  - workflowtasksets
+  - workflowtasksets/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -42,6 +42,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workflowtasksets
+  - workflowtasksets/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION
Closes #997 

Signed-off-by: Paul Ayling <paulayling.dev@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
