### PR TITLE
feat(argo-cd): support initContainers on all pods

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.26.11
+version: 3.26.12
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: add flag and labels for application labels"
+    - "[Added]: add custom initContainers support to all Deployments"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -249,6 +249,7 @@ NAME: my-release
 | controller.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the application controller |
 | controller.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the application controller |
 | controller.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the application controller |
+| controller.initContainers | list | `[]` | Init containers to add to the application controller pod |
 | controller.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | controller.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | controller.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
@@ -417,6 +418,7 @@ NAME: my-release
 | server.ingressGrpc.pathType | string | `"Prefix"` | Ingress path type for dedicated [gRPC-ingress]. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | server.ingressGrpc.paths | list | `["/"]` | List of ingress paths for dedicated [gRPC-ingress] |
 | server.ingressGrpc.tls | list | `[]` | Ingress TLS configuration for dedicated [gRPC-ingress] |
+| server.initContainers | list | `[]` | Init containers to add to the server pod |
 | server.lifecycle | object | `{}` | Specify postStart and preStop lifecycle hooks for your argo-cd-server container |
 | server.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | server.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
@@ -499,6 +501,7 @@ NAME: my-release
 | dex.image.imagePullPolicy | string | `"IfNotPresent"` | Dex imagePullPolicy |
 | dex.image.repository | string | `"ghcr.io/dexidp/dex"` | Dex image repository |
 | dex.image.tag | string | `"v2.30.0"` | Dex image tag |
+| dex.initContainers | list | `[]` | Init containers to add to the dex pod |
 | dex.initImage.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Argo CD init image imagePullPolicy |
 | dex.initImage.repository | string | `""` (defaults to global.image.repository) | Argo CD init image repository |
 | dex.initImage.tag | string | `""` (defaults to global.image.tag) | Argo CD init image tag |
@@ -559,6 +562,7 @@ NAME: my-release
 | redis.image.imagePullPolicy | string | `"IfNotPresent"` | Redis imagePullPolicy |
 | redis.image.repository | string | `"redis"` | Redis repository |
 | redis.image.tag | string | `"6.2.4-alpine"` | Redis tag |
+| redis.initContainers | list | `[]` | Init containers to add to the redis pod |
 | redis.metrics.containerPort | int | `9121` | Port to use for redis-exporter sidecar |
 | redis.metrics.enabled | bool | `false` | Deploy metrics service and redis-exporter sidecar |
 | redis.metrics.image.imagePullPolicy | string | `"IfNotPresent"` | redis-exporter image PullPolicy |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -160,6 +160,10 @@ spec:
       {{- with .Values.controller.volumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.controller.initContainers }}
+      initContainers:
+      {{- toYaml .Values.controller.initContainers | nindent 6 }}
+      {{- end }}
 {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -179,7 +179,7 @@ spec:
         name: tmp-dir
       {{- if .Values.repoServer.initContainers }}
       initContainers:
-{{- toYaml .Values.repoServer.initContainers | nindent 6 }}
+      {{- toYaml .Values.repoServer.initContainers | nindent 6 }}
       {{- end }}
 {{- if .Values.repoServer.priorityClassName }}
       priorityClassName: {{ .Values.repoServer.priorityClassName }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -198,6 +198,10 @@ spec:
             path: ca.crt
           optional: true
           secretName: argocd-repo-server-tls
+      {{- if .Values.server.initContainers }}
+      initContainers:
+      {{- toYaml .Values.server.initContainers | nindent 6 }}
+      {{- end }}
 {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName }}
 {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -143,6 +143,10 @@ spec:
       {{- if .Values.dex.extraVolumes }}
       {{- toYaml .Values.dex.extraVolumes | nindent 6 }}
       {{- end }}
+      {{- if .Values.dex.initContainers }}
+      initContainers:
+      {{- toYaml .Values.dex.initContainers | nindent 6 }}
+      {{- end }}
 {{- if .Values.dex.priorityClassName }}
       priorityClassName: {{ .Values.dex.priorityClassName }}
 {{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -112,6 +112,10 @@ spec:
       volumes:
 {{- toYaml .Values.redis.volumes | nindent 8}}
 {{- end }}
+      {{- if .Values.redis.initContainers }}
+      initContainers:
+      {{- toYaml .Values.redis.initContainers | nindent 6 }}
+      {{- end }}
 {{- if .Values.redis.priorityClassName }}
       priorityClassName: {{ .Values.redis.priorityClassName }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -296,7 +296,7 @@ controller:
 
   # -- Init containers to add to the application controller pod
   ## If your target Kubernetes cluster(s) require a custom auth provider executable
-  ## you could use this (and the same in the server pod) to bootstrap 
+  ## you could use this (and the same in the server pod) to bootstrap
   ## that executable into your ArgoCD container
   initContainers: []
   #  - name: download-tools
@@ -1255,7 +1255,7 @@ server:
 
   # -- Init containers to add to the server pod
   ## If your target Kubernetes cluster(s) require a custom auth provider executable
-  ## you could use this (and the same in the application controller pod) to bootstrap 
+  ## you could use this (and the same in the application controller pod) to bootstrap
   ## that executable into your ArgoCD container
   initContainers: []
   #  - name: download-tools

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -294,6 +294,25 @@ controller:
   # -- Additional containers to be added to the application controller pod
   extraContainers: []
 
+  # -- Init containers to add to the application controller pod
+  ## If your target Kubernetes cluster(s) require a custom auth provider executable
+  ## you could use this (and the same in the server pod) to bootstrap 
+  ## that executable into your ArgoCD container
+  initContainers: []
+  #  - name: download-tools
+  #    image: alpine:3.8
+  #    command: [sh, -c]
+  #    args:
+  #      - wget -qO- https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz | tar -xvzf - &&
+  #        mv linux-amd64/helm /custom-tools/
+  #    volumeMounts:
+  #      - mountPath: /custom-tools
+  #        name: custom-tools
+  #  volumeMounts:
+  #  - mountPath: /usr/local/bin/helm
+  #    name: custom-tools
+  #    subPath: helm
+
 ## Dex
 dex:
   # -- Enable dex
@@ -472,6 +491,22 @@ dex:
   # -- Additional containers to be added to the dex pod
   extraContainers: []
 
+  # -- Init containers to add to the dex pod
+  initContainers: []
+  #  - name: download-tools
+  #    image: alpine:3.8
+  #    command: [sh, -c]
+  #    args:
+  #      - wget -qO- https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz | tar -xvzf - &&
+  #        mv linux-amd64/helm /custom-tools/
+  #    volumeMounts:
+  #      - mountPath: /custom-tools
+  #        name: custom-tools
+  #  volumeMounts:
+  #  - mountPath: /usr/local/bin/helm
+  #    name: custom-tools
+  #    subPath: helm
+
 ## Redis
 redis:
   # -- Enable redis
@@ -571,6 +606,22 @@ redis:
 
   # -- Additional containers to be added to the redis pod
   extraContainers: []
+
+  # -- Init containers to add to the redis pod
+  initContainers: []
+  #  - name: download-tools
+  #    image: alpine:3.8
+  #    command: [sh, -c]
+  #    args:
+  #      - wget -qO- https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz | tar -xvzf - &&
+  #        mv linux-amd64/helm /custom-tools/
+  #    volumeMounts:
+  #      - mountPath: /custom-tools
+  #        name: custom-tools
+  #  volumeMounts:
+  #  - mountPath: /usr/local/bin/helm
+  #    name: custom-tools
+  #    subPath: helm
 
   service:
     # -- Redis service annotations
@@ -1201,6 +1252,25 @@ server:
   #   volumeMounts:
   #   - name: copy-portal-skins
   #     mountPath: /srv/var/lib/lemonldap-ng/portal/skins
+
+  # -- Init containers to add to the server pod
+  ## If your target Kubernetes cluster(s) require a custom auth provider executable
+  ## you could use this (and the same in the application controller pod) to bootstrap 
+  ## that executable into your ArgoCD container
+  initContainers: []
+  #  - name: download-tools
+  #    image: alpine:3.8
+  #    command: [sh, -c]
+  #    args:
+  #      - wget -qO- https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz | tar -xvzf - &&
+  #        mv linux-amd64/helm /custom-tools/
+  #    volumeMounts:
+  #      - mountPath: /custom-tools
+  #        name: custom-tools
+  #  volumeMounts:
+  #  - mountPath: /usr/local/bin/helm
+  #    name: custom-tools
+  #    subPath: helm
 
 ## Repo Server
 repoServer:


### PR DESCRIPTION
Signed-off-by: Mark Pim <j.mark.pim@gmail.com>

This adds support for custom initContainers for all pods, not just the repo-server. I think giving users control over initContainers for all deployments adds some handy flexibility at a low cost, hopefully you agree!

My particular use case, for the record, is we have a custom K8s auth provider for our clusters, and so I need to deploy that auth provider binary to the Application Controller and Server pods, so that it's available in the container when ArgoCD attempts to connect to the remote clusters. So far I've been building a custom ArgoCD image containing our binary, but that makes the process of upgrading ArgoCD more work, and so copying it at runtime via an initContainer would simplify that.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
