### PR TITLE
feat(argo-cd): Add support for argocd-extensions resources

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.28.0
+version: 3.28.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: add extensions support"
+    - "[Added]: add argocd-extensions resources support"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -399,7 +399,7 @@ NAME: my-release
 | server.extensions.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for extensions |
 | server.extensions.image.repository | string | `"ghcr.io/argoproj-labs/argocd-extensions"` | Repository to use for extensions image |
 | server.extensions.image.tag | string | `"v0.1.0"` | Tag to use for extensions image |
-| server.extensions.resources | object | `{}` | Resource limits and requests for the argocd-extensions pods |
+| server.extensions.resources | object | `{}` | Resource limits and requests for the argocd-extensions container |
 | server.extraArgs | list | `[]` | Additional command line arguments to pass to Argo CD server |
 | server.extraContainers | list | `[]` | Additional containers to be added to the server pod |
 | server.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Argo CD server |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -399,6 +399,7 @@ NAME: my-release
 | server.extensions.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for extensions |
 | server.extensions.image.repository | string | `"ghcr.io/argoproj-labs/argocd-extensions"` | Repository to use for extensions image |
 | server.extensions.image.tag | string | `"v0.1.0"` | Tag to use for extensions image |
+| server.extensions.resources | object | `{}` | Resource limits and requests for the argocd-extensions pods |
 | server.extraArgs | list | `[]` | Additional command line arguments to pass to Argo CD server |
 | server.extraContainers | list | `[]` | Additional containers to be added to the server pod |
 | server.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Argo CD server |

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -143,6 +143,8 @@ spec:
         volumeMounts:
           - name: extensions
             mountPath: /tmp/extensions/
+        resources:
+          {{- toYaml .Values.server.extensions.resources | nindent 10 }}
       {{- end }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1289,6 +1289,15 @@ server:
       # -- Image pull policy for extensions
       imagePullPolicy: IfNotPresent
 
+    # -- Resource limits and requests for the argocd-extensions pods
+    resources: {}
+    #  limits:
+    #    cpu: 50m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 10m
+    #    memory: 64Mi
+
     # -- Extensions to be loaded into the server
     contents: []
     # - name: argo-rollouts

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1289,7 +1289,7 @@ server:
       # -- Image pull policy for extensions
       imagePullPolicy: IfNotPresent
 
-    # -- Resource limits and requests for the argocd-extensions pods
+    # -- Resource limits and requests for the argocd-extensions container
     resources: {}
     #  limits:
     #    cpu: 50m


### PR DESCRIPTION
Added ability to set up the argocd-extensions resources.

Signed-off-by: Yevhen Luhovtsov <yevhen.luhovtsov@intapp.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
