### PR TITLE
fix(argo-cd): Merge duplicate initContainer entries introduced in 3.29.0

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.0
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.29.0
+version: 3.29.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: add argocd-extensions resources support"
+    - "[Fix]: repo-server: merge initContainer to one section"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.2.0
+appVersion: v2.2.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.29.1
+version: 3.29.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -316,6 +316,7 @@ NAME: my-release
 | repoServer.clusterRoleRules.rules | list | `[]` | List of custom rules for the Repo server's Cluster Role resource |
 | repoServer.containerPort | int | `8081` | Configures the repo server port |
 | repoServer.containerSecurityContext | object | `{}` | Repo server container-level security context |
+| repoServer.enableCopyutilInitContainer | bool | `true` | Enable the copyutil init container |
 | repoServer.env | list | `[]` | Environment variables to pass to repo server |
 | repoServer.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to repo server |
 | repoServer.extraArgs | list | `[]` | Additional command line arguments to pass to repo server |

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -34,17 +34,6 @@ spec:
       {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}
-      initContainers:
-      - command:
-        - cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
-        name: copyutil
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
       containers:
       - name: {{ .Values.repoServer.name }}
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
@@ -194,8 +183,18 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      {{- if .Values.repoServer.initContainers }}
       initContainers:
+      - command:
+        - cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd-cmp-server
+        image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
+        name: copyutil
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      {{- if .Values.repoServer.initContainers }}
       {{- toYaml .Values.repoServer.initContainers | nindent 6 }}
       {{- end }}
 {{- if .Values.repoServer.priorityClassName }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -183,7 +183,9 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      {{- if or .Values.repoServer.initContainers .Values.repoServer.enableCopyutilInitContainer }}
       initContainers:
+      {{- if .Values.repoServer.enableCopyutilInitContainer }}
       - command:
         - cp
         - -n
@@ -194,8 +196,10 @@ spec:
         volumeMounts:
         - mountPath: /var/run/argocd
           name: var-files
+      {{- end }}
       {{- if .Values.repoServer.initContainers }}
       {{- toYaml .Values.repoServer.initContainers | nindent 6 }}
+      {{- end }}
       {{- end }}
 {{- if .Values.repoServer.priorityClassName }}
       priorityClassName: {{ .Values.repoServer.priorityClassName }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1530,6 +1530,9 @@ repoServer:
   #    name: custom-tools
   #    subPath: helm
 
+  # -- Enable the copyutil init container
+  enableCopyutilInitContainer: true
+
 ## Argo Configs
 configs:
   # -- Provide one or multiple [external cluster credentials]

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v1.2.0
+appVersion: v1.2.1
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
 name: argocd-notifications
 type: application
-version: 1.6.0
+version: 1.6.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-notifications.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
   - name: andyfeller
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version v1.2.0"
+    - "[Changed]: Update to app version v1.2.1"


### PR DESCRIPTION
Hello,

The recent version pushed a change that introduced a second `intiContainers` entry in the `deployment.yaml` file.

There should be only one entry in this file. This PR merges them into one section. Otherwise, this file is not valid according to the YAML spec and should not work in setups that already utilize init containers.

https://github.com/argoproj/argo-helm/blob/6d872cb02fff53644546f0dfe3197bbad2fa2f88/charts/argo-cd/templates/argocd-repo-server/deployment.yaml#L37-L47

https://github.com/argoproj/argo-helm/blob/6d872cb02fff53644546f0dfe3197bbad2fa2f88/charts/argo-cd/templates/argocd-repo-server/deployment.yaml#L198-L200

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.

Resolves #1060