### PR TITLE
fix(argo-cd): Revert initContainers copyUtil param

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.29.2
+version: 3.29.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fix]: repo-server: merge initContainer to one section"
+    - "[Fix]: repo-server: revert initContainer copyutil param"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fix]: repo-server: revert initContainer copyutil param"
+    - "[Fixed]: repo-server: revert initContainer copyutil param"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -316,7 +316,6 @@ NAME: my-release
 | repoServer.clusterRoleRules.rules | list | `[]` | List of custom rules for the Repo server's Cluster Role resource |
 | repoServer.containerPort | int | `8081` | Configures the repo server port |
 | repoServer.containerSecurityContext | object | `{}` | Repo server container-level security context |
-| repoServer.enableCopyutilInitContainer | bool | `true` | Enable the copyutil init container |
 | repoServer.env | list | `[]` | Environment variables to pass to repo server |
 | repoServer.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to repo server |
 | repoServer.extraArgs | list | `[]` | Additional command line arguments to pass to repo server |

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -183,9 +183,7 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
-      {{- if or .Values.repoServer.initContainers .Values.repoServer.enableCopyutilInitContainer }}
       initContainers:
-      {{- if .Values.repoServer.enableCopyutilInitContainer }}
       - command:
         - cp
         - -n
@@ -196,10 +194,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/argocd
           name: var-files
-      {{- end }}
       {{- if .Values.repoServer.initContainers }}
       {{- toYaml .Values.repoServer.initContainers | nindent 6 }}
-      {{- end }}
       {{- end }}
 {{- if .Values.repoServer.priorityClassName }}
       priorityClassName: {{ .Values.repoServer.priorityClassName }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1530,9 +1530,6 @@ repoServer:
   #    name: custom-tools
   #    subPath: helm
 
-  # -- Enable the copyutil init container
-  enableCopyutilInitContainer: true
-
 ## Argo Configs
 configs:
   # -- Provide one or multiple [external cluster credentials]


### PR DESCRIPTION
Revert on parametrising copyUtil iniContainer in #1058 due this is default in upstream Kustomize manifests.

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
