### PR TITLE
fix(argo-cd): Add ArgoCDExtension CRD again

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.1
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.29.3
+version: 3.29.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: repo-server: revert initContainer copyutil param"
+    - "[Fixed]: Add ArgoCDExtension CRD again. It was removed in chart version 3.29.0 by mistake."

--- a/charts/argo-cd/crds/crd-extension.yaml
+++ b/charts/argo-cd/crds/crd-extension.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: argocdextensions.argoproj.io
+    app.kubernetes.io/part-of: argocd
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: argocdextensions.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ArgoCDExtension
+    listKind: ArgoCDExtensionList
+    plural: argocdextensions
+    singular: argocdextension
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ArgoCDExtension is the Schema for the argocdextensions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ArgoCDExtensionSpec defines the desired state of ArgoCDExtension
+            properties:
+              sources:
+                description: Sources specifies where the extension should come from
+                items:
+                  description: ExtensionSource specifies where the extension should
+                    be sourced from
+                  properties:
+                    git:
+                      description: Git is specified if the extension should be sourced
+                        from a git repository
+                      properties:
+                        revision:
+                          description: Revision specifies the revision of the Repository
+                            to fetch
+                          type: string
+                        url:
+                          description: URL specifies the Git repository URL to fetch
+                          type: string
+                      type: object
+                    web:
+                      description: Web is specified if the extension should be sourced
+                        from a web file
+                      properties:
+                        url:
+                          description: URK specifies the remote file URL
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - sources
+            type: object
+          status:
+            description: ArgoCDExtensionStatus defines the observed state of ArgoCDExtension
+            properties:
+              conditions:
+                items:
+                  properties:
+                    message:
+                      description: Message contains human-readable message indicating
+                        details about condition
+                      type: string
+                    status:
+                      description: Boolean status describing if the condition is currently
+                        true
+                      type: string
+                    type:
+                      description: Type is an ArgoCDExtension condition type
+                      type: string
+                  required:
+                  - message
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
The CRD was removed by mistake in https://github.com/argoproj/argo-helm/pull/1055

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
