### PR TITLE
fix(argo-rollouts): bump to v1.1.1

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v1.1.0"
+appVersion: "v1.1.1"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.8.0
+version: 2.8.1
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -11,5 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Ability to specify LoadBalancer settings for dashboard svc"
-    - "[Added]: Ability to specify external IPs for dashboard svc"
+    - "[Updated]: Updated Argo Rollouts to v1.1.1"


### PR DESCRIPTION
Argo Rollouts Releasenotes: https://github.com/argoproj/argo-rollouts/releases/tag/v1.1.1

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
