### PR TITLE
fix(argocd-image-updater): Update to app version v0.11.2

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.6.0
-appVersion: v0.11.0
+version: 0.6.1
+appVersion: v0.11.2
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -16,3 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: Mount ssh-known-hosts from argocd"
+    - "[Changed]: Bump image tag to 11.2"

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -15,5 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Mount ssh-known-hosts from argocd"
     - "[Changed]: Bump image tag to v0.11.2"

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: Mount ssh-known-hosts from argocd"
-    - "[Changed]: Bump image tag to 11.2"
+    - "[Changed]: Bump image tag to v0.11.2"


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
