### PR TITLE
fix: update service name reference in argo-rollout ingress

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.1.1"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.9.0
+version: 2.9.1
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -11,4 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Dashboard ingress support"
+    - "[Fixed]: Updated dashboard ingress service name reference"

--- a/charts/argo-rollouts/templates/dashboard/ingress.yaml
+++ b/charts/argo-rollouts/templates/dashboard/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.dashboard.enabled .Values.dashboard.ingress.enabled -}}
-{{- $serviceName := include "argo-rollouts.fullname" . -}}
+{{- $serviceName := printf "%s-dashboard" (include "argo-rollouts.fullname" .) -}}
 {{- $servicePort := .Values.dashboard.service.port -}}
 {{- $paths := .Values.dashboard.ingress.paths -}}
 {{- $extraPaths := .Values.dashboard.ingress.extraPaths -}}


### PR DESCRIPTION
Updates the service name in the argo-rollouts dashboard to match the naming convention of the dashboard service.  Without this change requests to the dashboard fail.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
