### PR TITLE
fix(argo-cd): Add custom volume as Helm working dir

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.3
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.32.0
+version: 3.32.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,5 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to Argo-CD v2.2.3"
-    - "[Changed]: Update Redis to v6.2.6"
+    - "[Fixed]: Add custom volume as Helm working dir (sync with upstream manifests)"

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -54,16 +54,20 @@ spec:
         {{- if .Values.repoServer.containerSecurityContext }}
         securityContext: {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
         {{- end }}
-{{- if or (.Values.repoServer.env) (.Values.openshift.enabled) }}
         env:
-{{- if .Values.repoServer.env }}
-{{- toYaml .Values.repoServer.env | nindent 8 }}
-{{- end }}
-{{- if .Values.openshift.enabled }}
+        - name: HELM_CACHE_HOME
+          value: /helm-working-dir
+        - name: HELM_CONFIG_HOME
+          value: /helm-working-dir
+        - name: HELM_DATA_HOME
+          value: /helm-working-dir
+        {{- if .Values.repoServer.env }}
+          {{- toYaml .Values.repoServer.env | nindent 8 }}
+        {{- end }}
+        {{- if .Values.openshift.enabled }}
         - name: USER_NAME
           value: argocd
-{{- end }}
-{{- end }}
+        {{- end }}
         {{- with .Values.repoServer.envFrom }}
         envFrom: {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -87,6 +91,8 @@ spec:
           name: argocd-repo-server-tls
         - mountPath: /tmp
           name: tmp-dir
+        - mountPath: /helm-working-dir
+          name: helm-working-dir
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
         ports:
@@ -166,6 +172,8 @@ spec:
           name: argocd-tls-certs-cm
         name: tls-certs
       {{- end }}
+      - name: helm-working-dir
+        emptyDir: {}
       - name: argocd-repo-server-tls
         secret:
           items:


### PR DESCRIPTION
Sync with upstream manifests.
Related upstream issues:
- https://github.com/argoproj/argo-cd/pull/7162
- https://github.com/argoproj/argo-cd/issues/7144

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
