### PR TITLE
Create Initial/Additional Resources on Argo Workflows and Events using values

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.27.1
+version: 3.28.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Mention declarative set up for Argo CD in README.md"
+    - "[Added]: add extensions support"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.7
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.28.0
+version: 3.28.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: add extensions support"
+    - "[Added]: add argocd-extensions resources support"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -399,6 +399,7 @@ NAME: my-release
 | server.extensions.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for extensions |
 | server.extensions.image.repository | string | `"ghcr.io/argoproj-labs/argocd-extensions"` | Repository to use for extensions image |
 | server.extensions.image.tag | string | `"v0.1.0"` | Tag to use for extensions image |
+| server.extensions.resources | object | `{}` | Resource limits and requests for the argocd-extensions container |
 | server.extraArgs | list | `[]` | Additional command line arguments to pass to Argo CD server |
 | server.extraContainers | list | `[]` | Additional containers to be added to the server pod |
 | server.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Argo CD server |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -394,6 +394,11 @@ NAME: my-release
 | server.containerSecurityContext | object | `{}` | Servers container-level security context |
 | server.env | list | `[]` | Environment variables to pass to Argo CD server |
 | server.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to Argo CD server |
+| server.extensions.contents | list | `[]` | Extensions to be loaded into the server |
+| server.extensions.enabled | bool | `false` | Enable support for extensions |
+| server.extensions.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for extensions |
+| server.extensions.image.repository | string | `"ghcr.io/argoproj-labs/argocd-extensions"` | Repository to use for extensions image |
+| server.extensions.image.tag | string | `"v0.1.0"` | Tag to use for extensions image |
 | server.extraArgs | list | `[]` | Additional command line arguments to pass to Argo CD server |
 | server.extraContainers | list | `[]` | Additional containers to be added to the server pod |
 | server.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Argo CD server |

--- a/charts/argo-cd/crds/crd-extension.yaml
+++ b/charts/argo-cd/crds/crd-extension.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: argocdextensions.argoproj.io
+    app.kubernetes.io/part-of: argocd
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  name: argocdextensions.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ArgoCDExtension
+    listKind: ArgoCDExtensionList
+    plural: argocdextensions
+    singular: argocdextension
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ArgoCDExtension is the Schema for the argocdextensions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ArgoCDExtensionSpec defines the desired state of ArgoCDExtension
+            properties:
+              sources:
+                description: Sources specifies where the extension should come from
+                items:
+                  description: ExtensionSource specifies where the extension should
+                    be sourced from
+                  properties:
+                    git:
+                      description: Git is specified if the extension should be sourced
+                        from a git repository
+                      properties:
+                        revision:
+                          description: Revision specifies the revision of the Repository
+                            to fetch
+                          type: string
+                        url:
+                          description: URL specifies the Git repository URL to fetch
+                          type: string
+                      type: object
+                    web:
+                      description: Web is specified if the extension should be sourced
+                        from a web file
+                      properties:
+                        url:
+                          description: URK specifies the remote file URL
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - sources
+            type: object
+          status:
+            description: ArgoCDExtensionStatus defines the observed state of ArgoCDExtension
+            properties:
+              conditions:
+                items:
+                  properties:
+                    message:
+                      description: Message contains human-readable message indicating
+                        details about condition
+                      type: string
+                    status:
+                      description: Boolean status describing if the condition is currently
+                        true
+                      type: string
+                    type:
+                      description: Type is an ArgoCDExtension condition type
+                      type: string
+                  required:
+                  - message
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -75,6 +75,10 @@ spec:
         {{- if .Values.server.volumeMounts }}
 {{- toYaml .Values.server.volumeMounts | nindent 8}}
         {{- end }}
+        {{- if .Values.server.extensions.enabled }}
+        - name: extensions
+          mountPath: /tmp/extensions/
+        {{- end }}
         {{- if .Values.configs.knownHosts }}
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
@@ -132,6 +136,14 @@ spec:
       {{- with .Values.server.extraContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.server.extensions.enabled }}
+      - name: argocd-extensions
+        image: {{ .Values.server.extensions.image.repository }}:{{ .Values.server.extensions.image.tag }}
+        imagePullPolicy: {{ .Values.server.extensions.image.imagePullPolicy }}
+        volumeMounts:
+          - name: extensions
+            mountPath: /tmp/extensions/
+      {{- end }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:
 {{- toYaml .Values.server.nodeSelector | nindent 8 }}
@@ -163,6 +175,10 @@ spec:
       volumes:
       {{- if .Values.server.volumes }}
 {{- toYaml .Values.server.volumes | nindent 6}}
+      {{- end }}
+      {{- if .Values.server.extensions.enabled }}
+      - name: extensions
+        emptyDir: {}
       {{- end }}
       - emptyDir: {}
         name: static-files

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -143,6 +143,8 @@ spec:
         volumeMounts:
           - name: extensions
             mountPath: /tmp/extensions/
+        resources:
+          {{- toYaml .Values.server.extensions.resources | nindent 10 }}
       {{- end }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:

--- a/charts/argo-cd/templates/argocd-server/extensions-rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/extensions-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.server.extensions.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+  name: argocd-server-extensions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-server-extensions
+subjects:
+- kind: ServiceAccount
+  name: argocd-server
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/extensions.yaml
+++ b/charts/argo-cd/templates/argocd-server/extensions.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.server.extensions.enabled }}
+{{- range $extension := .Values.server.extensions.contents }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCDExtension
+metadata:
+  name: {{ $extension.name }}
+  finalizers:
+    - extensions-finalizer.argocd.argoproj.io
+  labels:
+    {{- include "argo-cd.labels" (dict "context" $ "component" $.Values.server.name "name" (printf "%s-extensions" $.Values.server.name)) | nindent 4 }}
+spec:
+  sources:
+  - web:
+      url: {{ $extension.url }}
+{{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/extentions-role.yaml
+++ b/charts/argo-cd/templates/argocd-server/extentions-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.server.extensions.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+  name: argocd-server-extensions
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - argocdextensions
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - patch
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1276,6 +1276,24 @@ server:
   #    name: custom-tools
   #    subPath: helm
 
+  extensions:
+    # -- Enable support for extensions
+    ## This function in tech preview stage, do expect unstability or breaking changes in newer versions. Bump image.tag if necessary.
+    enabled: false
+
+    image:
+      # -- Repository to use for extensions image
+      repository: "ghcr.io/argoproj-labs/argocd-extensions"
+      # -- Tag to use for extensions image
+      tag: "v0.1.0"
+      # -- Image pull policy for extensions
+      imagePullPolicy: IfNotPresent
+
+    # -- Extensions to be loaded into the server
+    contents: []
+    # - name: argo-rollouts
+    #   url: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.1.0/extension.tar
+
 ## Repo Server
 repoServer:
   # -- Repo server name

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1289,6 +1289,15 @@ server:
       # -- Image pull policy for extensions
       imagePullPolicy: IfNotPresent
 
+    # -- Resource limits and requests for the argocd-extensions container
+    resources: {}
+    #  limits:
+    #    cpu: 50m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 10m
+    #    memory: 64Mi
+
     # -- Extensions to be loaded into the server
     contents: []
     # - name: argo-rollouts

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.8.0
+version: 1.10.2
 keywords:
   - argo-events
   - sensor-controller
@@ -12,7 +12,7 @@ sources:
 maintainers:
   - name: VaibhavPage
   - name: whynowy
-appVersion: v1.5.0
+appVersion: v1.5.6
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 annotations:

--- a/charts/argo-events/templates/resources/event_bus.yaml
+++ b/charts/argo-events/templates/resources/event_bus.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.server.additionalEventBuses }}
+{{- if .Values.additionalEventBuses }}
 apiVersion: v1
 kind: List
 items:
-  {{- range .Values.server.additionalEventBuses }}
+  {{- range .Values.additionalEventBuses }}
   - apiVersion: argoproj.io/v1alpha1
     kind: EventBus
     metadata:

--- a/charts/argo-events/templates/resources/event_bus.yaml
+++ b/charts/argo-events/templates/resources/event_bus.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalEventBuses }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalEventBuses }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: EventBus
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-events/templates/resources/event_sources.yaml
+++ b/charts/argo-events/templates/resources/event_sources.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalEventSources }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalEventSources }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: EventSource
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-events/templates/resources/event_sources.yaml
+++ b/charts/argo-events/templates/resources/event_sources.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.server.additionalEventSources }}
+{{- if .Values.additionalEventSources }}
 apiVersion: v1
 kind: List
 items:
-  {{- range .Values.server.additionalEventSources }}
+  {{- range .Values.additionalEventSources }}
   - apiVersion: argoproj.io/v1alpha1
     kind: EventSource
     metadata:

--- a/charts/argo-events/templates/resources/sensor.yaml
+++ b/charts/argo-events/templates/resources/sensor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalSensors }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalSensors }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: Sensor
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-events/templates/resources/sensor.yaml
+++ b/charts/argo-events/templates/resources/sensor.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.server.additionalSensors }}
+{{- if .Values.additionalSensors }}
 apiVersion: v1
 kind: List
 items:
-  {{- range .Values.server.additionalSensors }}
+  {{- range .Values.additionalSensors }}
   - apiVersion: argoproj.io/v1alpha1
     kind: Sensor
     metadata:

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -97,3 +97,7 @@ eventbusController:
 securityContext:
   runAsNonRoot: true
   runAsUser: 9731
+
+additionalEventSources: []
+additionalEventBuses: []
+additionalSensors: []

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.1.0"
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.5.0
+version: 2.6.0
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:
@@ -11,4 +11,4 @@ maintainers:
   - name: jessesuen
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Updated ClusterRole with new rules"
+    - "[Added]: Ability to set the type of Service on the dashboard Service"

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -24,9 +24,14 @@ To install the chart with the release name `my-release`:
 $ helm repo add argo https://argoproj.github.io/argo-helm
 $ helm install my-release argo/argo-rollouts
 ```
+### UI Dashboard
 
 If dashboard is installed by `--set dashboard.enabled=true`, checkout the argo-rollouts dashboard by
 `kubectl port-forward service/argo-rollouts-dashboard 31000:3100` and pointing the browser to `localhost:31000`
+
+| :warning: WARNING when the Service type is set to LoadBalancer or NodePort |
+|:---------------------------------------------------------------------------|
+| The chart provides an option to change the service type (`dashboard.service.type`). Dashboard was never intended to be exposed as an administrative console -- it started out as a local view available via CLI. It should be protected by something (e.g. network access or even better an oauth proxy). |
 
 ## Chart Values
 
@@ -67,6 +72,7 @@ If dashboard is installed by `--set dashboard.enabled=true`, checkout the argo-r
 | dashboard.image.tag | string | `""` | Overrides the image tag (default is the chart appVersion) |
 | dashboard.extraArgs | list | `[]` | Additional arguments for the dashboard. A list of flags. |
 | dashboard.resources | object | `{}` | Resource limits and requests for the dashboard pods. |
+| dashboard.service.type | string | `ClusterIP` | Sets the type of the Service |
 | dashboard.tolerations | list | `[]` | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | dashboard.affinity | object | `{}` | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
 | dashboard.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) |

--- a/charts/argo-rollouts/templates/dashboard/service.yaml
+++ b/charts/argo-rollouts/templates/dashboard/service.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  type: {{ .Values.dashboard.service.type }}
   ports:
   - name: dashboard
     protocol: TCP

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -125,6 +125,8 @@ dashboard:
   podSecurityContext:
     runAsNonRoot: true
   containerSecurityContext: {}
+  service:
+    type: ClusterIP
   serviceAccount:
     create: true
     annotations: {}

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.9.3
-appVersion: v3.2.4
+version: 0.9.5
+appVersion: v3.2.6
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/templates/resources/clusterworkflowtemplates.yaml
+++ b/charts/argo-workflows/templates/resources/clusterworkflowtemplates.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalClusterWorkflowTemplates }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalClusterWorkflowTemplates }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: ClusterWorkflowTemplate
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/resources/cronworkflows.yaml
+++ b/charts/argo-workflows/templates/resources/cronworkflows.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalCronWorkflows }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalCronWorkflows }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: CronWorkflow
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/resources/workfloweventbindings.yaml
+++ b/charts/argo-workflows/templates/resources/workfloweventbindings.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalWorkflowEventBindings }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalWorkflowEventBindings }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowEventBinding
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/resources/workflows.yaml
+++ b/charts/argo-workflows/templates/resources/workflows.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalWorkflows }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalWorkflows }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/resources/workflowtasksets.yaml
+++ b/charts/argo-workflows/templates/resources/workflowtasksets.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalWorkflowTaskSets }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalWorkflowTaskSets }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTaskSet
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/resources/workflowtemplates.yaml
+++ b/charts/argo-workflows/templates/resources/workflowtemplates.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.server.additionalWorkflowTemplates }}
+apiVersion: v1
+kind: List
+items:
+  {{- range .Values.server.additionalWorkflowTemplates }}
+  - apiVersion: argoproj.io/v1alpha1
+    kind: WorkflowTemplate
+    metadata:
+      {{- with .additionalAnnotations }}
+      annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .additionalLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .finalizers }}
+      finalizers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- toYaml .spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -454,6 +454,18 @@ server:
   # -- Extra containers to be added to the server deployment
   extraContainers: []
 
+  additionalClusterWorkflowTemplates: []
+
+  additionalCronWorkflows: []
+
+  additionalWorkflowEventBindings: []
+
+  additionalWorkflows: []
+
+  additionalWorkflowTaskSets: []
+
+  additionalWorkflowTemplates: []
+
 # -- Influences the creation of the ConfigMap for the workflow-controller itself.
 useDefaultArtifactRepo: false
 # -- Use static credentials for S3 (eg. when not using AWS IRSA)
@@ -494,3 +506,4 @@ artifactRepository:
   # serviceAccountKeySecret:
   # name: my-gcs-credentials
   # key: serviceAccountKey
+

--- a/charts/argocd-applicationset/Chart.yaml
+++ b/charts/argocd-applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationset
 description: A Helm chart for installing ArgoCD ApplicationSet
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "v0.2.0"
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-applicationset.readthedocs.io/en/stable/assets/logo.png
@@ -14,5 +14,4 @@ maintainers:
   - name: maruina
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Install the chart into a kind cluster during the chart testing process"
-    - "[Changed]: Parameter 'args.namespace' now defaults to the namespace where you install the chart to"
+    - "[Added]: Add resources metrics-service and servicemonitor, not enabled by default."

--- a/charts/argocd-applicationset/README.md
+++ b/charts/argocd-applicationset/README.md
@@ -73,6 +73,17 @@ kubectl apply -k https://github.com/argoproj-labs/applicationset.git/manifests/c
 | image.repository | string | `"quay.io/argoproj/argocd-applicationset"` | The image repository |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
+| metrics.enabled | bool | `false` | Deploy metrics service |
+| metrics.service.annotations | object | `{}` | Metrics service annotations |
+| metrics.service.labels | object | `{}` | Metrics service labels |
+| metrics.service.servicePort | int | `8085` | Metrics service port |
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
+| metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
+| metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
+| metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
+| metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | mountGPGKeyringVolume | bool | `true` | Mount an emptyDir volume for `gpg-keyring` |
 | mountGPGKeysVolume | bool | `false` | Mount the `argocd-gpg-keys-cm` volume |
 | mountSSHKnownHostsVolume | bool | `true` | Mount the `argocd-ssh-known-hosts-cm` volume |

--- a/charts/argocd-applicationset/ci/servicemonitor-values.yaml
+++ b/charts/argocd-applicationset/ci/servicemonitor-values.yaml
@@ -1,0 +1,7 @@
+metrics:
+  enabled: true
+
+# Disable mounts of ArgoCD related ConfigMaps as ArgoCD isn't installed during chart testing
+mountSSHKnownHostsVolume: false
+mountTLSCertsVolume: false
+mountGPGKeysVolume: false

--- a/charts/argocd-applicationset/templates/deployment.yaml
+++ b/charts/argocd-applicationset/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             - name: http
               containerPort: {{ (split ":" .Values.args.probeBindAddr)._1 }}
               protocol: TCP
+            - name: metrics
+              containerPort: {{ (split ":" .Values.args.metricsAddr)._1 }}
+              protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/argocd-applicationset/templates/metrics-service.yaml
+++ b/charts/argocd-applicationset/templates/metrics-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.metrics.service.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.metrics.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "argo-applicationset.labels" . | nindent 4 }}
+    {{- with .Values.metrics.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "argo-applicationset.fullname" . }}-metrics
+spec:
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: {{ .Values.metrics.service.servicePort }}
+    targetPort: metrics
+  selector:
+    {{- include "argo-applicationset.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/argocd-applicationset/templates/servicemonitor.yaml
+++ b/charts/argocd-applicationset/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "argo-applicationset.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "argo-applicationset.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.selector }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "argo-applicationset.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/argocd-applicationset/values.yaml
+++ b/charts/argocd-applicationset/values.yaml
@@ -31,6 +31,35 @@ args:
   # -- Enable dry run mode
   dryRun: false
 
+  ## Metrics service configuration
+metrics:
+  # -- Deploy metrics service
+  enabled: false
+  service:
+    # -- Metrics service annotations
+    annotations: {}
+    # -- Metrics service labels
+    labels: {}
+    # -- Metrics service port
+    servicePort: 8085
+  serviceMonitor:
+    # -- Enable a prometheus ServiceMonitor
+    enabled: false
+    # -- Prometheus ServiceMonitor interval
+    interval: 30s
+    # -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestion
+    metricRelabelings: []
+    # -- Prometheus ServiceMonitor selector
+    selector: {}
+      # prometheus: kube-prometheus
+
+    # -- Prometheus ServiceMonitor namespace
+    namespace: "" # monitoring
+    # -- Prometheus ServiceMonitor labels
+    additionalLabels: {}
+
 # -- If defined, uses a Secret to pull an image from a private Docker registry or repository.
 imagePullSecrets: []
 # -- Provide a name in place of `argocd-applicationset`


### PR DESCRIPTION
We needed to install the helm chart along with some default workflows and events resources.  

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [ x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ x] Any new values are backwards compatible and/or have sensible default.
* [ x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
