### PR TITLE
feat(argocd-applicationset): Allow setting extra env vars

### DIFF
--- a/charts/argocd-applicationset/Chart.yaml
+++ b/charts/argocd-applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationset
 description: A Helm chart for installing ArgoCD ApplicationSet
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: "v0.3.0"
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-applicationset.readthedocs.io/en/stable/assets/logo.png

--- a/charts/argocd-applicationset/README.md
+++ b/charts/argocd-applicationset/README.md
@@ -54,65 +54,66 @@ kubectl apply -k https://github.com/argoproj-labs/applicationset.git/manifests/c
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) |
-| apiVersionOverrides.ingress | string | `""` | String to override apiVersion of ingresses rendered by this helm chart |
-| args.argocdRepoServer | string | `"argocd-repo-server:8081"` | The default Argo CD repo server address |
-| args.debug | bool | `false` | Print debug logs |
-| args.dryRun | bool | `false` | Enable dry run mode |
-| args.enableLeaderElection | bool | `false` | The default leader election setting |
-| args.metricsAddr | string | `":8080"` | The default metric address |
-| args.namespace | string | `""` | Namespace where ArgoCD is deployed to (defaults to .Release.Namespace) |
-| args.policy | string | `"sync"` | How application is synced between the generator and the cluster |
-| args.probeBindAddr | string | `":8081"` | The default health check port |
-| extraArgs | list | `[]` | List of extra cli args to add |
-| extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
-| extraVolumes | list | `[]` | List of extra volumes to add |
-| fullnameOverride | string | `""` | Override the default fully qualified app name |
-| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"quay.io/argoproj/argocd-applicationset"` | The image repository |
-| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
-| kubeVersionOverride | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests |
-| metrics.enabled | bool | `false` | Deploy metrics service |
-| metrics.service.annotations | object | `{}` | Metrics service annotations |
-| metrics.service.labels | object | `{}` | Metrics service labels |
-| metrics.service.servicePort | int | `8085` | Metrics service port |
-| metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
-| metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
-| metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
-| metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
-| metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
-| metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
-| mountGPGKeyringVolume | bool | `true` | Mount an emptyDir volume for `gpg-keyring` |
-| mountGPGKeysVolume | bool | `false` | Mount the `argocd-gpg-keys-cm` volume |
-| mountSSHKnownHostsVolume | bool | `true` | Mount the `argocd-ssh-known-hosts-cm` volume |
-| mountTLSCertsVolume | bool | `true` | Mount the `argocd-tls-certs-cm` volume |
-| nameOverride | string | `""` | Provide a name in place of `argocd-applicationset` |
-| nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/) |
-| podAnnotations | object | `{}` | Annotations for the controller pods |
-| podLabels | object | `{}` | Labels for the controller pods |
-| podSecurityContext | object | `{}` | Pod Security Context |
-| priorityClassName | string | `""` | If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default. |
-| rbac.pspEnabled | bool | `true` | Enable Pod Security Policy |
-| replicaCount | int | `1` | The number of controller pods to run |
-| resources | object | `{}` | Resource limits and requests for the controller pods. |
-| securityContext | object | `{}` | Security Context |
-| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| tolerations | list | `[]` | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
-| webhook.ingress.annotations | object | `{}` | Additional ingress annotations |
-| webhook.ingress.enabled | bool | `false` | Enable an ingress resource for Webhooks |
-| webhook.ingress.extraPaths | list | `[]` | Additional ingress paths |
-| webhook.ingress.hosts | list | `[]` | List of ingress hosts |
-| webhook.ingress.ingressClassName | string | `""` | Defines which ingress controller will implement the resource |
-| webhook.ingress.labels | object | `{}` | Additional ingress labels |
-| webhook.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
-| webhook.ingress.paths | list | `["/api/webhook"]` | List of ingress paths |
-| webhook.ingress.tls | list | `[]` | Ingress TLS configuration |
+| Key                                      | Type | Default | Description                                                                                                                    |
+|------------------------------------------|------|---------|--------------------------------------------------------------------------------------------------------------------------------|
+| affinity                                 | object | `{}` | [Assign custom affinity rules to the deployment](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)           |
+| apiVersionOverrides.ingress              | string | `""` | String to override apiVersion of ingresses rendered by this helm chart                                                         |
+| args.argocdRepoServer                    | string | `"argocd-repo-server:8081"` | The default Argo CD repo server address                                                                                        |
+| args.debug                               | bool | `false` | Print debug logs                                                                                                               |
+| args.dryRun                              | bool | `false` | Enable dry run mode                                                                                                            |
+| args.enableLeaderElection                | bool | `false` | The default leader election setting                                                                                            |
+| args.metricsAddr                         | string | `":8080"` | The default metric address                                                                                                     |
+| args.namespace                           | string | `""` | Namespace where ArgoCD is deployed to (defaults to .Release.Namespace)                                                         |
+| args.policy                              | string | `"sync"` | How application is synced between the generator and the cluster                                                                |
+| args.probeBindAddr                       | string | `":8081"` | The default health check port                                                                                                  |
+| extraArgs                                | list | `[]` | List of extra cli args to add                                                                                                  |
+| extraEnvs                                | list | `[]` | List of extra env variables                                                                                                    |
+| extraVolumeMounts                        | list | `[]` | List of extra mounts to add (normally used with extraVolumes)                                                                  |
+| extraVolumes                             | list | `[]` | List of extra volumes to add                                                                                                   |
+| fullnameOverride                         | string | `""` | Override the default fully qualified app name                                                                                  |
+| image.pullPolicy                         | string | `"IfNotPresent"` | Image pull policy                                                                                                              |
+| image.repository                         | string | `"quay.io/argoproj/argocd-applicationset"` | The image repository                                                                                                           |
+| image.tag                                | string | `""` | Overrides the image tag whose default is the chart appVersion.                                                                 |
+| imagePullSecrets                         | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository.                                       |
+| kubeVersionOverride                      | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests                                                   |
+| metrics.enabled                          | bool | `false` | Deploy metrics service                                                                                                         |
+| metrics.service.annotations              | object | `{}` | Metrics service annotations                                                                                                    |
+| metrics.service.labels                   | object | `{}` | Metrics service labels                                                                                                         |
+| metrics.service.servicePort              | int | `8085` | Metrics service port                                                                                                           |
+| metrics.serviceMonitor.additionalLabels  | object | `{}` | Prometheus ServiceMonitor labels                                                                                               |
+| metrics.serviceMonitor.enabled           | bool | `false` | Enable a prometheus ServiceMonitor                                                                                             |
+| metrics.serviceMonitor.interval          | string | `"30s"` | Prometheus ServiceMonitor interval                                                                                             |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion                                                         |
+| metrics.serviceMonitor.namespace         | string | `""` | Prometheus ServiceMonitor namespace                                                                                            |
+| metrics.serviceMonitor.relabelings       | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping                                                                |
+| metrics.serviceMonitor.selector          | object | `{}` | Prometheus ServiceMonitor selector                                                                                             |
+| mountGPGKeyringVolume                    | bool | `true` | Mount an emptyDir volume for `gpg-keyring`                                                                                     |
+| mountGPGKeysVolume                       | bool | `false` | Mount the `argocd-gpg-keys-cm` volume                                                                                          |
+| mountSSHKnownHostsVolume                 | bool | `true` | Mount the `argocd-ssh-known-hosts-cm` volume                                                                                   |
+| mountTLSCertsVolume                      | bool | `true` | Mount the `argocd-tls-certs-cm` volume                                                                                         |
+| nameOverride                             | string | `""` | Provide a name in place of `argocd-applicationset`                                                                             |
+| nodeSelector                             | object | `{}` | [Node selector](https://kubernetes.io/docs/user-guide/node-selection/)                                                         |
+| podAnnotations                           | object | `{}` | Annotations for the controller pods                                                                                            |
+| podLabels                                | object | `{}` | Labels for the controller pods                                                                                                 |
+| podSecurityContext                       | object | `{}` | Pod Security Context                                                                                                           |
+| priorityClassName                        | string | `""` | If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default. |
+| rbac.pspEnabled                          | bool | `true` | Enable Pod Security Policy                                                                                                     |
+| replicaCount                             | int | `1` | The number of controller pods to run                                                                                           |
+| resources                                | object | `{}` | Resource limits and requests for the controller pods.                                                                          |
+| securityContext                          | object | `{}` | Security Context                                                                                                               |
+| serviceAccount.annotations               | object | `{}` | Annotations to add to the service account                                                                                      |
+| serviceAccount.create                    | bool | `true` | Specifies whether a service account should be created                                                                          |
+| serviceAccount.name                      | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template         |
+| tolerations                              | list | `[]` | [Tolerations for use with node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                |
+| webhook.ingress.annotations              | object | `{}` | Additional ingress annotations                                                                                                 |
+| webhook.ingress.enabled                  | bool | `false` | Enable an ingress resource for Webhooks                                                                                        |
+| webhook.ingress.extraPaths               | list | `[]` | Additional ingress paths                                                                                                       |
+| webhook.ingress.hosts                    | list | `[]` | List of ingress hosts                                                                                                          |
+| webhook.ingress.ingressClassName         | string | `""` | Defines which ingress controller will implement the resource                                                                   |
+| webhook.ingress.labels                   | object | `{}` | Additional ingress labels                                                                                                      |
+| webhook.ingress.pathType                 | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`                                                        |
+| webhook.ingress.paths                    | list | `["/api/webhook"]` | List of ingress paths                                                                                                          |
+| webhook.ingress.tls                      | list | `[]` | Ingress TLS configuration                                                                                                      |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs](https://github.com/norwoodj/helm-docs)

--- a/charts/argocd-applicationset/templates/deployment.yaml
+++ b/charts/argocd-applicationset/templates/deployment.yaml
@@ -49,6 +49,12 @@ spec:
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.extraEnv }}
+          env:
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ (split ":" .Values.args.probeBindAddr)._1 }}

--- a/charts/argocd-applicationset/values.yaml
+++ b/charts/argocd-applicationset/values.yaml
@@ -147,6 +147,9 @@ extraVolumes: []
 extraArgs: []
   # - --loglevel=warn
 
+# -- Extra environment variables for argocd-application-set
+extraEnv: []
+
 # -- Override the Kubernetes version, which is used to evaluate certain manifests
 kubeVersionOverride: ""
 


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ x] Any new values are backwards compatible and/or have sensible default.
* [x ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
