### PR TITLE
chore(argo-cd): Convert manifests of 'kind: List'

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.3
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.33.1
+version: 3.33.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Consistent annotation quoting across all manifests"
+    - "[Changed]: Convert manifests of 'kind: List' to dashes separated documents."

--- a/charts/argo-cd/templates/argocd-configs/applications.yaml
+++ b/charts/argo-cd/templates/argocd-configs/applications.yaml
@@ -1,46 +1,42 @@
-{{- if .Values.server.additionalApplications }}
-apiVersion: v1
-kind: List
-items:
-  {{- range .Values.server.additionalApplications }}
-  - apiVersion: argoproj.io/v1alpha1
-    kind: Application
-    metadata:
-      {{- with .additionalAnnotations }}
-      annotations:
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      {{- end }}
-      {{- with .additionalLabels }}
-      labels:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      name: {{ .name }}
-      {{- with .namespace }}
-      namespace: {{ . }}
-      {{- end }}
-      {{- with .finalizers }}
-      finalizers:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    spec:
-      project: {{ tpl .project $ }}
-      source:
-        {{- toYaml .source | nindent 8 }}
-      destination:
-        {{- toYaml .destination | nindent 8 }}
-      {{- with .syncPolicy }}
-      syncPolicy:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .ignoreDifferences }}
-      ignoreDifferences:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .info }}
-      info:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- range .Values.server.additionalApplications }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  {{- with .additionalAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- with .additionalLabels }}
+  labels:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  name: {{ .name }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .finalizers }}
+  finalizers:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+spec:
+  project: {{ tpl .project $ }}
+  source:
+    {{- toYaml .source | nindent 8 }}
+  destination:
+    {{- toYaml .destination | nindent 8 }}
+  {{- with .syncPolicy }}
+  syncPolicy:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .ignoreDifferences }}
+  ignoreDifferences:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .info }}
+  info:
+    {{- toYaml . | nindent 8 }}
   {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-configs/projects.yaml
+++ b/charts/argo-cd/templates/argocd-configs/projects.yaml
@@ -1,62 +1,58 @@
-{{- if .Values.server.additionalProjects }}
-apiVersion: v1
-kind: List
-items:
-  {{- range .Values.server.additionalProjects }}
-  - apiVersion: argoproj.io/v1alpha1
-    kind: AppProject
-    metadata:
-      {{- with .additionalAnnotations }}
-      annotations:
-        {{- range $key, $value := . }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      {{- end }}
-      {{- with .additionalLabels }}
-      labels:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      name: {{ .name }}
-      {{- with .namespace }}
-      namespace: {{ . }}
-      {{- end }}
-      {{- with .finalizers }}
-      finalizers:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    spec:
-      description: {{ .description }}
-      sourceRepos:
-        {{- toYaml .sourceRepos | nindent 8 }}
-      destinations:
-        {{- toYaml .destinations | nindent 8 }}
-      {{- with .clusterResourceWhitelist }}
-      clusterResourceWhitelist:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .namespaceResourceBlacklist }}
-      namespaceResourceBlacklist:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .namespaceResourceWhitelist }}
-      namespaceResourceWhitelist:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .orphanedResources }}
-      orphanedResources:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .roles }}
-      roles:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .syncWindows }}
-      syncWindows:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .signatureKeys }}
-      signatureKeys:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- range .Values.server.additionalProjects }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  {{- with .additionalAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  {{- with .additionalLabels }}
+  labels:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  name: {{ .name }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .finalizers }}
+  finalizers:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+spec:
+  description: {{ .description }}
+  sourceRepos:
+    {{- toYaml .sourceRepos | nindent 8 }}
+  destinations:
+    {{- toYaml .destinations | nindent 8 }}
+  {{- with .clusterResourceWhitelist }}
+  clusterResourceWhitelist:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .namespaceResourceBlacklist }}
+  namespaceResourceBlacklist:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .namespaceResourceWhitelist }}
+  namespaceResourceWhitelist:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .orphanedResources }}
+  orphanedResources:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .roles }}
+  roles:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .syncWindows }}
+  syncWindows:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .signatureKeys }}
+  signatureKeys:
+    {{- toYaml . | nindent 8 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Convert manifests of `kind: List` to dashes separated documents

Why?
- > Note that kubectl and other tools sometimes output collections of resources as kind: List. Keep in mind that kind: List is not part of the Kubernetes API; it is exposing an implementation detail from client-side code in those tools, used to handle groups of mixed resources.
  > Source: https://github.com/chrisnegus/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds
- Consistent usage in our repository

Ref:
- https://github.com/bitnami/charts/issues/4559
- https://github.com/kubernetes/kubectl/issues/984
- https://github.com/kubernetes/community/pull/5903
- https://github.com/helm/helm/issues/8615

**Note for the reviewer:** Use "Hide whitespace" when diffing the manifests.

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
