### PR TITLE
fix: Add missing image registry for eventbus controller

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.10.2
+version: 1.10.3
 keywords:
   - argo-events
   - sensor-controller
@@ -17,4 +17,4 @@ icon: https://argoproj.github.io/argo-events/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Consistent .helmignore"
+    - "[Fixed]: Add missing image registry for eventbus controller"

--- a/charts/argo-events/templates/eventbus-controller/deployment.yaml
+++ b/charts/argo-events/templates/eventbus-controller/deployment.yaml
@@ -45,9 +45,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: NATS_STREAMING_IMAGE
-              value: {{ .Values.eventbusController.natsStreamingImage }}
+              value: "{{ .Values.registry }}/{{ .Values.eventbusController.natsStreamingImage }}"
             - name: NATS_METRICS_EXPORTER_IMAGE
-              value: {{ .Values.eventbusController.natsMetricsExporterImage }}
+              value: "{{ .Values.registry }}/{{ .Values.eventbusController.natsMetricsExporterImage }}"
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
