### PR TITLE
fix(argo-cd applicationset): add extraContainers to deployment

### DIFF
--- a/charts/argocd-applicationset/Chart.yaml
+++ b/charts/argocd-applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationset
 description: A Helm chart for installing ArgoCD ApplicationSet
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: "v0.3.0"
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-applicationset.readthedocs.io/en/stable/assets/logo.png
@@ -14,4 +14,4 @@ maintainers:
   - name: maruina
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Consistent .helmignore"
+    - "[Added]: extraContainers support in Deployment resource"

--- a/charts/argocd-applicationset/README.md
+++ b/charts/argocd-applicationset/README.md
@@ -67,6 +67,7 @@ kubectl apply -k https://github.com/argoproj-labs/applicationset.git/manifests/c
 | args.policy | string | `"sync"` | How application is synced between the generator and the cluster |
 | args.probeBindAddr | string | `":8081"` | The default health check port |
 | extraArgs | list | `[]` | List of extra cli args to add |
+| extraContainers | list | `[]` | Additional containers to be added to the applicationset controller pod |
 | extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | extraVolumes | list | `[]` | List of extra volumes to add |
 | fullnameOverride | string | `""` | Override the default fully qualified app name |

--- a/charts/argocd-applicationset/templates/deployment.yaml
+++ b/charts/argocd-applicationset/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
             {{- with .Values.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.extraContainers }}
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
       volumes:
       - emptyDir: {}
         name: tmp-dir

--- a/charts/argocd-applicationset/values.yaml
+++ b/charts/argocd-applicationset/values.yaml
@@ -31,6 +31,9 @@ args:
   # -- Enable dry run mode
   dryRun: false
 
+# -- Additional containers to be added to the applicationset controller pod
+extraContainers: []
+
   ## Metrics service configuration
 metrics:
   # -- Deploy metrics service


### PR DESCRIPTION
Adds `extraContainers` similar to the other charts. I use this to inject a sidecar into certain ArgoCD components.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
