### PR TITLE
fix: added application-controller required metrics port

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.33.6
+version: 3.33.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Fix typo of policy.csv comment in values"
+    - "[Fixed]: Added missing 'metrics' port to application-controller deployment"

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -86,6 +86,11 @@ spec:
         - name: controller
           containerPort: {{ .Values.controller.containerPort }}
           protocol: TCP
+        {{ if .Values.controller.metrics.enabled }}
+        - name: metrics
+          containerPort: 8083
+          protocol: TCP
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Enabling `application-controller` metrics via `controller.metrics.enabled` does not work.
I noticed that it works for the `api-server`, so I compared the deployment and found a missing port.
I got metrics working by adding it in my cluster.
This PR incorporates the fix into the argo-cd helm chart.


Signed-off-by: Didrik Finnøy <djfinnoy@protonmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
