### PR TITLE
feat(argo-events): Add aggregate-roles (sync with upstream manifests)

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 1.11.0
+version: 1.12.0
 keywords:
   - argo-events
   - sensor-controller
@@ -17,4 +17,4 @@ icon: https://argoproj.github.io/argo-events/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to Argo Events 1.6.0"
+    - "[Added]: Add aggregate-roles (sync with upstream manifests)"

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -33,8 +33,11 @@ You can install the CRDs manually from `crds` folder.
 |-----|------|---------|-------------|
 | additionalSaNamespaces | list | `[]` | Create service accounts in additional namespaces specified The SA will always be created in the release namespaces |
 | additionalServiceAccountRules | list | (See [values.yaml]) | Additional rules |
+| createAggregateRoles | bool | `true` | Create clusterroles that extend existing clusterroles to interact with argo-events CRDs. Only applies for cluster-wide installation (`singleNamespace: true`) |
+| fullnameOverride | string | `""` | String to fully override "argo-events.fullname" template |
 | imagePullPolicy | string | `"Always"` | The image pull policy |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
+| nameOverride | string | `""` | String to partially override "argo-events.fullname" template |
 | registry | string | `"quay.io"` | docker registry |
 | securityContext | object | `{"runAsNonRoot":true,"runAsUser":9731}` | Common PodSecurityContext for all controllers |
 | serviceAccount | string | `"argo-events-sa"` | ServiceAccount to use for running controller. |

--- a/charts/argo-events/templates/_helpers.tpl
+++ b/charts/argo-events/templates/_helpers.tpl
@@ -1,16 +1,26 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "argo-events.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "argo-events.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/argo-events/templates/aggregate-roles.yaml
+++ b/charts/argo-events/templates/aggregate-roles.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.createAggregateRoles (not .Values.singleNamespace) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: {{ include "argo-events.fullname" . }}-aggregate-to-admin
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - sensors
+      - sensors/finalizers
+      - sensors/status
+      - eventsources
+      - eventsources/finalizers
+      - eventsources/status
+      - eventbus
+      - eventbus/finalizers
+      - eventbus/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: {{ include "argo-events.fullname" . }}-aggregate-to-edit
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - sensors
+      - sensors/finalizers
+      - sensors/status
+      - eventsources
+      - eventsources/finalizers
+      - eventsources/status
+      - eventbus
+      - eventbus/finalizers
+      - eventbus/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: {{ include "argo-events.fullname" . }}-aggregate-to-view
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - sensors
+      - sensors/finalizers
+      - sensors/status
+      - eventsources
+      - eventsources/finalizers
+      - eventsources/status
+      - eventbus
+      - eventbus/finalizers
+      - eventbus/status
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -1,3 +1,9 @@
+# -- String to partially override "argo-events.fullname" template
+nameOverride: ""
+
+# -- String to fully override "argo-events.fullname" template
+fullnameOverride: ""
+
 # -- docker registry
 registry: quay.io
 
@@ -35,6 +41,10 @@ additionalServiceAccountRules:
     - watch
   resources:
     - customresourcedefinitions
+
+# -- Create clusterroles that extend existing clusterroles to interact with argo-events CRDs.
+# Only applies for cluster-wide installation (`singleNamespace: true`)
+createAggregateRoles: true
 
 # -- Whether to run in namespaced scope.
 # Set `singleNamespace` to false to have the controllers


### PR DESCRIPTION
While here,
- The two template functions were not in use until now. Let's align them with the current skeleton of helm 3.x

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
