### PR TITLE
feat(argo-workflows): Add volume and volumeMount parameters to controller

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Workflow Controller Volumes and VolumeMounts paramaters"
+    - "[Added]: Workflow Controller Volumes and VolumeMounts parameters"

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.10.1
+version: 0.11.0
 appVersion: v3.2.7
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version v3.2.7"
+    - "[Added]: Workflow Controller Volumes and VolumeMounts paramaters"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -118,6 +118,8 @@ Fields to note:
 | controller.telemetryConfig.servicePort | int | `8081` | telemetry service port |
 | controller.telemetryConfig.servicePortName | string | `"telemetry"` | telemetry service port name |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
+| controller.volumeMounts | list | `[]` | Additional volume mounts to the controller main container |
+| controller.volumes | list | `[]` | Additional volumes to the controller pod |
 | controller.workflowDefaults | object | `{}` | Default values that will apply to all Workflows from this controller, unless overridden on the Workflow-level. Only valid for 2.7+ |
 | controller.workflowNamespaces | list | `["default"]` | Specify all namespaces where this workflow controller instance will manage workflows. This controls where the service account and RBAC resources will be created. Only valid when singleNamespace is false. |
 | controller.workflowRestrictions | object | `{}` | Restricts the Workflows that the controller will process. Only valid for 2.9+ |

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -74,6 +74,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
+          volumeMounts:
+          {{- with .Values.controller.volumeMounts }}
+            {{- toYaml . | nindent 10}}
+          {{- end }}
           ports:
             - name: {{ .Values.controller.metricsConfig.portName }}
               containerPort: {{ .Values.controller.metricsConfig.port }}
@@ -85,6 +89,10 @@ spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- with .Values.controller.volumes }}
+        {{- toYaml . | nindent 6}}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -74,9 +74,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
-          volumeMounts:
           {{- with .Values.controller.volumeMounts }}
-            {{- toYaml . | nindent 10}}
+          volumeMounts:
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
             - name: {{ .Values.controller.metricsConfig.portName }}
@@ -90,9 +90,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
       {{- with .Values.controller.volumes }}
-        {{- toYaml . | nindent 6}}
+      volumes:
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -223,6 +223,10 @@ controller:
 
   # -- Extra arguments to be added to the controller
   extraArgs: []
+  # -- Additional volume mounts to the controller main container
+  volumeMounts: []
+  # -- Additional volumes to the controller pod
+  volumes: []
   # -- The number of controller pods to run
   replicas: 1
 


### PR DESCRIPTION
Simple feature to add volume and volumeMount features to the Argo Workflows controller.

Not sure if there is a particular reason these parameters are not already in place for controller (unlike the server), but current expected use case is to add CA certs (from AWS RDS) when using persistence with SSL mode set to ```verify-ca```. It is convenient to pass CA certs as configfile volumes to ```/etc/ssl/certs/some-cert.pem```. Server and controller both use the SSL configuration and happily use added CA certs in ```etc/ssl/certs``` but no known existing way to easily pass the CA cert to the controller, so controller will fail to start.

Volumes and volumeMounts default to empty as expected. Minor bump version for new parameters.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
