### PR TITLE
fix(argo-cd): Adding repo-server securityContext to its copyutil init container

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.33.7
+version: 3.33.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: dex-server extraArgs"
+    - "[Fixed]: repo-server copyutil init container has no securityContext"

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -203,6 +203,9 @@ spec:
         name: copyutil
         resources:
           {{- toYaml .Values.repoServer.copyutil.resources | nindent 10 }}
+        {{- if .Values.repoServer.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /var/run/argocd
           name: var-files


### PR DESCRIPTION
The repo-server main container has an option for securityContext, not the copyutils init container, which makes it fail in my context.
Added the same securityContext as the main container, if it exists.

Signed-off-by: Eric Durand <eric_p_durand@yahoo.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [ x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ x] Any new values are backwards compatible and/or have sensible default.
* [ x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
