### PR TITLE
feat(argo-cd): Add ability to use an external redis instance

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -62,6 +62,13 @@ jobs:
           ## Metrics API not available in kind cluster
           rm charts/argo-cd/ci/ha-autoscaling-values.yaml
 
+      - name: Create an external redis for ArgoCD externalRedis feature
+        if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')
+        run: |
+          kubectl create namespace redis
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm install redis bitnami/redis --wait --namespace redis --set auth.password=argocd --set architecture=standalone
+
       - name: Run chart-testing (install)
         run: ct install --config ./.github/configs/ct-install.yaml
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.3.2
+version: 4.4.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Upgrade dex to v2.30.2"
+    - "[Added]: Ability to use external/existing Redis (eg. a managed cloud service)"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -650,6 +650,10 @@ NAME: my-release
 | redis-ha.redis.config | object | See [values.yaml] | Any valid redis config options in this section will be applied to each server (see `redis-ha` chart) |
 | redis-ha.redis.config.save | string | `"\"\""` | Will save the DB if both the given number of seconds and the given number of write operations against the DB occurred. `""`  is disabled |
 | redis-ha.redis.masterGroupName | string | `"argocd"` | Redis convention for naming the cluster group: must match `^[\\w-\\.]+$` and can be templated |
+| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis credentials (must contain key `redis-password`). When it's set, the `externalRedis.password` parameter is ignored |
+| externalRedis.host | string | `""` | External Redis server host |
+| externalRedis.password | string | `""` | External Redis password |
+| externalRedis.port | int | `6379` | External Redis server port |
 
 ## ApplicationSet
 

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -198,7 +198,7 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 {{- range .Values }}
-  {{- if not (or (hasPrefix "controller" .Key) (hasPrefix "repoServer" .Key) (hasPrefix "server" .Key) (hasPrefix "dex" .Key) (hasPrefix "redis" .Key) (hasPrefix "applicationSet" .Key) (hasPrefix "notifications" .Key) ) }}
+  {{- if not (or (hasPrefix "controller" .Key) (hasPrefix "repoServer" .Key) (hasPrefix "server" .Key) (hasPrefix "dex" .Key) (hasPrefix "redis" .Key) (hasPrefix "externalRedis" .Key) (hasPrefix "applicationSet" .Key) (hasPrefix "notifications" .Key) ) }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
   {{- if hasPrefix "server.additional" .Key }}
@@ -257,6 +257,11 @@ NAME: my-release
 {{- end }}
 {{- range .Values }}
   {{- if hasPrefix "redis-ha" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+{{- range .Values }}
+  {{- if hasPrefix "externalRedis" .Key }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}

--- a/charts/argo-cd/ci/external-redis-values.yaml
+++ b/charts/argo-cd/ci/external-redis-values.yaml
@@ -1,0 +1,9 @@
+redis:
+  enabled: false
+
+redis-ha:
+  enabled: false
+
+externalRedis:
+  host: "redis-master.redis.svc.cluster.local"
+  password: "argocd"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -270,3 +270,17 @@ Create the name of the configmap to use
     {{ default "argocd-notifications-cm" .Values.notifications.cm.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "argo-cd.redisPasswordEnv" -}}
+  {{- if or .Values.externalRedis.password .Values.externalRedis.existingSecret }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.externalRedis.existingSecret }}
+      name: {{ .Values.externalRedis.existingSecret }}
+    {{- else }}
+      name: {{ template "argo-cd.redis.fullname" . }}
+    {{- end }}
+      key: redis-password
+  {{- end }}
+{{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         {{- if or (and .Values.redis.enabled (not $redisHa.enabled)) (and $redisHa.enabled $redisHa.haproxy.enabled) }}
         - --redis
         - {{ template "argo-cd.redis.fullname" . }}:{{ .Values.redis.servicePort }}
+        {{- else if and .Values.externalRedis.host .Values.externalRedis.port }}
+        - --redis
+        - {{ .Values.externalRedis.host }}:{{ .Values.externalRedis.port }}
         {{- end }}
         {{- with .Values.controller.extraArgs }}
         {{- . | toYaml | nindent 8 }}
@@ -75,9 +78,12 @@ spec:
         {{- if .Values.controller.containerSecurityContext }}
         securityContext: {{- toYaml .Values.controller.containerSecurityContext | nindent 10 }}
         {{- end }}
-        {{- if .Values.controller.env }}
+        {{- if or .Values.controller.env .Values.externalRedis.password .Values.externalRedis.existingSecret  }}
         env:
-{{- toYaml .Values.controller.env | nindent 8 }}
+          {{- include "argo-cd.redisPasswordEnv" . | nindent 8 }}
+          {{- with .Values.controller.env }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.controller.envFrom }}
         envFrom: {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.externalRedis.password (not .Values.externalRedis.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "argo-cd.redis.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
+type: Opaque
+data:
+  redis-password: {{ .Values.externalRedis.password | b64enc }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         {{- if or (and .Values.redis.enabled (not $redisHa.enabled)) (and $redisHa.enabled $redisHa.haproxy.enabled) }}
         - --redis
         - {{ template "argo-cd.redis.fullname" . }}:{{ .Values.redis.servicePort }}
+        {{- else if and .Values.externalRedis.host .Values.externalRedis.port }}
+        - --redis
+        - {{ .Values.externalRedis.host }}:{{ .Values.externalRedis.port }}
         {{- end }}
         - --logformat
         - {{ .Values.repoServer.logFormat }}
@@ -65,9 +68,10 @@ spec:
           value: /helm-working-dir
         - name: HELM_DATA_HOME
           value: /helm-working-dir
-        {{- if .Values.repoServer.env }}
-          {{- toYaml .Values.repoServer.env | nindent 8 }}
-        {{- end }}
+          {{- include "argo-cd.redisPasswordEnv" . | nindent 8 }}
+          {{- with .Values.repoServer.env }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
         {{- if .Values.openshift.enabled }}
         - name: USER_NAME
           value: argocd

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -59,6 +59,9 @@ spec:
         {{- if or (and .Values.redis.enabled (not $redisHa.enabled)) (and $redisHa.enabled $redisHa.haproxy.enabled) }}
         - --redis
         - {{ template "argo-cd.redis.fullname" . }}:{{ .Values.redis.servicePort }}
+        {{- else if and .Values.externalRedis.host .Values.externalRedis.port }}
+        - --redis
+        - {{ .Values.externalRedis.host }}:{{ .Values.externalRedis.port }}
         {{- end }}
         {{- with .Values.server.extraArgs }}
         {{- . | toYaml | nindent 8 }}
@@ -66,9 +69,12 @@ spec:
         {{- if .Values.server.containerSecurityContext }}
         securityContext: {{- toYaml .Values.server.containerSecurityContext | nindent 10 }}
         {{- end }}
-        {{- if .Values.server.env }}
+        {{- if or .Values.server.env .Values.externalRedis.password .Values.externalRedis.existingSecret }}
         env:
-{{- toYaml .Values.server.env | nindent 8 }}
+          {{- include "argo-cd.redisPasswordEnv" . | nindent 8 }}
+          {{- with .Values.server.env }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.server.envFrom }}
         envFrom: {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -777,6 +777,18 @@ redis-ha:
     # -- Redis tag
     tag: 6.2.6-alpine
 
+# External Redis parameters
+externalRedis:
+  # -- External Redis server host
+  host: ""
+  # -- External Redis password
+  password: ""
+  # -- External Redis server port
+  port: 6379
+  # -- The name of an existing secret with Redis credentials (must contain key `redis-password`).
+  # When it's set, the `externalRedis.password` parameter is ignored
+  existingSecret: ""
+
 ## Server
 server:
   # -- Argo CD server name


### PR DESCRIPTION
Resolves #1045

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
