### PR TITLE
fix(argo-workflows): Avoid "namespace: null" when singleNamespace is true

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: v3.2.7
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Workflow Controller Volumes and VolumeMounts parameters"
+    - "[Fixed]: Avoid "namespace: null" when singleNamespace is true"

--- a/charts/argo-workflows/templates/controller/workflow-rb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-rb.yaml
@@ -5,7 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "argo-workflows.fullname" $ }}-workflow
-  namespace: {{ $namespace }}
+    {{- with $namespace }}
+  namespace: {{ . }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
When singleNamespace is true,  empty namespace is generated.

```
# Source: argo-workflows/templates/controller/workflow-rb.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: hoge-argo-workflows-workflow
  namespace:                                  <- here
```

This PR fixes it.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
