### PR TITLE
chore: Configure issue template chooser to disallow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Chat on Slack
+    url: https://argoproj.github.io/community/join-slack
+    about: Maybe chatting with the community can help


### PR DESCRIPTION
Let's use the same config as upstream Argoproj projects do:
- ArgoCD: https://github.com/argoproj/argo-cd/blob/master/.github/ISSUE_TEMPLATE/config.yml
- Argo Workflows: https://github.com/argoproj/argo-workflows/blob/v3.2.9/.github/ISSUE_TEMPLATE/config.yml

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
