### PR TITLE
fix(argo-cd): Quote clusterResources value to avoid invalid Secret manifest

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.35.1
+version: 3.35.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Use upstream entrypoint.sh for argocd-repo-server"
+    - "[Fixed]: Quote clusterResources value to avoid invalid Secret manifest"

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -23,7 +23,7 @@ stringData:
   {{- if .namespaces }}
   namespaces: {{ .namespaces }}
     {{- if .clusterResources }}
-  clusterResources: {{ .clusterResources }}
+  clusterResources: {{ .clusterResources | quote }}
     {{- end }}
   {{- end }}
   config: |


### PR DESCRIPTION
Signed-off-by: Matthias Lisin <ml@visu.li>

I did not ensure in my previous PR that the value inside `stringData` is quoted
and never templated as a boolean, which ofc is not valid here.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
