### PR TITLE
fix(argo-cd): create service account for repo server by default

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.35.2
+version: 3.35.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Quote clusterResources value to avoid invalid Secret manifest"
+    - "[Fixed]: Create service account for repo server by default"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -369,7 +369,7 @@ NAME: my-release
 | repoServer.service.portName | string | `"https-repo-server"` | Repo server service port name |
 | repoServer.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | repoServer.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
-| repoServer.serviceAccount.create | bool | `false` | Create repo server service account |
+| repoServer.serviceAccount.create | bool | `true` | Create repo server service account |
 | repoServer.serviceAccount.name | string | `""` | Repo server service account name |
 | repoServer.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | repoServer.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the repo server |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1588,7 +1588,7 @@ repoServer:
   ## If create is set to true, make sure to uncomment the name and update the rbac section below
   serviceAccount:
     # -- Create repo server service account
-    create: false
+    create: true
     # -- Repo server service account name
     name: "" # "argocd-repo-server"
     # -- Annotations applied to created service account


### PR DESCRIPTION
This PR enables the creation of a service account for repo server by default.
