### PR TITLE
feat(argo-workflows): Add parameter to enable or disable server and controller roles

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.11.2
+version: 0.12.0
 appVersion: v3.2.9
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version v3.2.9"
+    - "[Added]: Add parameter for enabling roles."

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -67,6 +67,7 @@ Fields to note:
 | controller.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the controller to access ClusterWorkflowTemplates. |
 | controller.containerRuntimeExecutor | string | `"docker"` | Specifies the container runtime interface to use (one of: `docker`, `kubelet`, `k8sapi`, `pns`, `emissary`) |
 | controller.containerRuntimeExecutors | list | `[]` | Specifies the executor to use. This has precedence over `controller.containerRuntimeExecutor`. |
+| createRoles | bool | `true` | Whether to create roles for the controller at all. |
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
@@ -144,6 +145,7 @@ Fields to note:
 | server.baseHref | string | `"/"` | Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. |
 | server.clusterWorkflowTemplates.enableEditing | bool | `true` | Give the server permissions to edit ClusterWorkflowTemplates. |
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |
+| createRoles | bool | `true` | Whether to create roles for the server at all. |
 | server.enabled | bool | `true` | Deploy the Argo Server |
 | server.extraArgs | list | `[]` | Extra arguments to provide to the Argo server binary, such as for disabling authentication. |
 | server.extraContainers | list | `[]` | Extra containers to be added to the server deployment |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -67,7 +67,6 @@ Fields to note:
 | controller.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the controller to access ClusterWorkflowTemplates. |
 | controller.containerRuntimeExecutor | string | `"docker"` | Specifies the container runtime interface to use (one of: `docker`, `kubelet`, `k8sapi`, `pns`, `emissary`) |
 | controller.containerRuntimeExecutors | list | `[]` | Specifies the executor to use. This has precedence over `controller.containerRuntimeExecutor`. |
-| createRoles | bool | `true` | Whether to create roles for the controller at all. |
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
@@ -100,6 +99,7 @@ Fields to note:
 | controller.podSecurityContext | object | `{}` | SecurityContext to set on the controller pods |
 | controller.podWorkers | string | `nil` | Number of pod workers |
 | controller.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages. |
+| controller.rbac.create | bool | `true` | Adds Role and RoleBinding for the controller. |
 | controller.replicas | int | `1` | The number of controller pods to run |
 | controller.resourceRateLimit | object | `{}` | Globally limits the rate at which pods are created. This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of parallel nodes. |
 | controller.resources | object | `{}` | Resource limits and requests for the controller |
@@ -145,7 +145,6 @@ Fields to note:
 | server.baseHref | string | `"/"` | Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. |
 | server.clusterWorkflowTemplates.enableEditing | bool | `true` | Give the server permissions to edit ClusterWorkflowTemplates. |
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |
-| createRoles | bool | `true` | Whether to create roles for the server at all. |
 | server.enabled | bool | `true` | Deploy the Argo Server |
 | server.extraArgs | list | `[]` | Extra arguments to provide to the Argo server binary, such as for disabling authentication. |
 | server.extraContainers | list | `[]` | Extra containers to be added to the server deployment |
@@ -171,6 +170,7 @@ Fields to note:
 | server.podLabels | object | `{}` | Optional labels to add to the UI pods |
 | server.podSecurityContext | object | `{}` | SecurityContext to set on the server pods |
 | server.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages |
+| server.rbac.create | bool | `true` | Adds Role and RoleBinding for the server. |
 | server.replicas | int | `1` | The number of server pods to run |
 | server.resources | object | `{}` | Resource limits and requests for the server |
 | server.secure | bool | `false` | Run the argo server in "secure" mode. Configure this value instead of `--secure` in extraArgs. |

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.createRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: Role
@@ -158,4 +159,5 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.createRoles }}
+{{- if .Values.controller.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: Role

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.createRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding
@@ -37,4 +38,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "argo-workflows.controllerServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.createRoles }}
+{{- if .Values.controller.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if and .Values.server.enabled .Values.server.createRoles}}
 apiVersion: rbac.authorization.k8s.io/v1
   {{- if .Values.singleNamespace }}
 kind: Role

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled .Values.server.createRoles}}
+{{- if and .Values.server.enabled .Values.server.rbac.create}}
 apiVersion: rbac.authorization.k8s.io/v1
   {{- if .Values.singleNamespace }}
 kind: Role

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled .Values.server.serviceAccount.create -}}
+{{- if and .Values.server.enabled .Values.server.serviceAccount.create .Values.server.createRoles -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled .Values.server.serviceAccount.create .Values.server.createRoles -}}
+{{- if and .Values.server.enabled .Values.server.serviceAccount.create .Values.server.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -56,8 +56,9 @@ controller:
     # limit: 10
     # burst: 1
 
-  # -- Whether to create roles and role bindings at all.
-  createRoles: true
+  rbac:
+    # -- Adds Role and RoleBinding for the controller.
+    create: true
 
   # -- Limits the maximum number of incomplete workflows in a namespace
   namespaceParallelism:
@@ -296,8 +297,9 @@ server:
   podLabels: {}
   # -- SecurityContext to set on the server pods
   podSecurityContext: {}
-  # -- Whether to create roles and role bindings at all.
-  createRoles: true
+  rbac:
+    # -- Adds Role and RoleBinding for the server.
+    create: true
   # -- Servers container-level security context
   securityContext:
     readOnlyRootFilesystem: false

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -56,6 +56,9 @@ controller:
     # limit: 10
     # burst: 1
 
+  # -- Whether to create roles and role bindings at all.
+  createRoles: true
+
   # -- Limits the maximum number of incomplete workflows in a namespace
   namespaceParallelism:
   # -- Resolves ongoing, uncommon AWS EKS bug: https://github.com/argoproj/argo-workflows/pull/4224
@@ -293,6 +296,8 @@ server:
   podLabels: {}
   # -- SecurityContext to set on the server pods
   podSecurityContext: {}
+  # -- Whether to create roles and role bindings at all.
+  createRoles: true
   # -- Servers container-level security context
   securityContext:
     readOnlyRootFilesystem: false


### PR DESCRIPTION
Our team is managing a controller / server deployment, but the k8s admins are managing clusterroles, so it was useful to be able to install without creating the roles.

My first commit to the repo, please let me know if something is off!

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
