### PR TITLE
fix(argo-cd): ArgoCD application controller - metrics application labels

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.2.5
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 3.35.3
+version: 3.35.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Create service account for repo server by default"
+    - "[Fixed]: ArgoCD application controller metric application label templating"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -263,7 +263,7 @@ NAME: my-release
 | controller.logFormat | string | `"text"` | Application controller log format. Either `text` or `json` |
 | controller.logLevel | string | `"info"` | Application controller log level |
 | controller.metrics.applicationLabels.enabled | bool | `false` | Enables additional labels in argocd_app_labels metric |
-| controller.metrics.applicationLabels.labels | object | `{}` | Additional labels |
+| controller.metrics.applicationLabels.labels | list | `[]` | Additional labels |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
 | controller.metrics.rules.enabled | bool | `false` | Deploy a PrometheusRule for the application controller |
 | controller.metrics.rules.spec | list | `[]` | PrometheusRule.Spec for the application controller |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -57,9 +57,9 @@ spec:
         - --loglevel
         - {{ .Values.controller.logLevel }}
         {{- if .Values.controller.metrics.applicationLabels.enabled }}
-        - --metrics-application-labels
         {{- range .Values.controller.metrics.applicationLabels.labels }}
-        - {{- toYaml . | nindent 8 }}
+        - --metrics-application-labels
+        - {{ . }}
         {{- end }}
         {{- end }}
         {{- if or (and .Values.redis.enabled (not $redisHa.enabled)) (and $redisHa.enabled $redisHa.haproxy.enabled) }}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -57,8 +57,8 @@ spec:
         - --loglevel
         - {{ .Values.controller.logLevel }}
         {{- if .Values.controller.metrics.applicationLabels.enabled }}
-        {{- range .Values.controller.metrics.applicationLabels.labels }}
         - --metrics-application-labels
+        {{- range .Values.controller.metrics.applicationLabels.labels }}
         - {{ . }}
         {{- end }}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -57,8 +57,8 @@ spec:
         - --loglevel
         - {{ .Values.controller.logLevel }}
         {{- if .Values.controller.metrics.applicationLabels.enabled }}
-        - --metrics-application-labels
         {{- range .Values.controller.metrics.applicationLabels.labels }}
+        - --metrics-application-labels
         - {{ . }}
         {{- end }}
         {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -251,7 +251,7 @@ controller:
       # -- Enables additional labels in argocd_app_labels metric
       enabled: false
       # -- Additional labels
-      labels: {}
+      labels: []
     service:
       # -- Metrics service annotations
       annotations: {}


### PR DESCRIPTION
Previously, ArgoCD application controller application labels metric was incorrectly templated.
This PR changes `.Values.controller.metrics.applicationLabels.labels` from a map to a list and updates the templating to set the correct arguments as seen [here](https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#exposing-application-labels-as-prometheus-metrics).

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
