### PR TITLE
fix(argo-cd): proper selectors for notifications metrics

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.1
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.0.0
+version: 4.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,5 +21,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to Argo CD v2.3.1"
-    - "[Changed]: Sync CRDs of Argo CD v2.3.1"
+    - "[Fixed]: make notification-metrics service target pods properly"
+    - "[Fixed]: make notification-metrics servicemonitor target service properly"

--- a/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "argo-cd.notifications.fullname" . }}
+  name: {{ template "argo-cd.notifications.fullname" . }}-metrics
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 4 }}
     {{- with .Values.notifications.metrics.service.labels }}

--- a/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "argo-cd.notifications.fullname" . }}-metrics
+  name: {{ template "argo-cd.notifications.fullname" . }}
   labels:
-    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 4 }}
     {{- with .Values.notifications.metrics.service.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 6 }}
+    {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "notifications-controller") | nindent 6 }}
   ports:
   - name: metrics
     port: {{ .Values.notifications.metrics.port }}

--- a/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "notifications-controller") | nindent 6 }}
+    {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.notifications.name) | nindent 6 }}
   ports:
   - name: metrics
     port: {{ .Values.notifications.metrics.port }}

--- a/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -26,5 +26,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 6 }}
+      {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "notifications-controller") | nindent 6 }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Values.notifications.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 4 }}
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
     {{- if .Values.notifications.metrics.serviceMonitor.additionalLabels }}
       {{- toYaml .Values.notifications.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "argo-cd.notifications.fullname" . }}-metrics
+  name: {{ template "argo-cd.notifications.fullname" . }}
   {{- if .Values.notifications.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.notifications.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 4 }}
     {{- if .Values.notifications.metrics.serviceMonitor.additionalLabels }}
       {{- toYaml .Values.notifications.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
@@ -26,5 +26,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "notifications-controller") | nindent 6 }}
+      {{- include "argo-cd.selectorLabels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
The notifications metrics are currently targeting `app.kubernetes.io/name: argocd-metrics` but the pod and service is labeled with `app.kubernetes.io/name: argocd-notifications-controller`. This updates the Service and ServiceMonitor to match.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
