### PR TITLE
fix(argo-cd): Add missing NetworkPolicy for AppSet and Notifications

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.1
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.2.0
+version: 4.2.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: added applicationSet.enabled and notifications.enabled to allow to disable them"
+    - "[Fixed]: Add missing NetworkPolicy for ApplicationSet and Notifications"

--- a/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.applicationSet.enabled .Values.global.networkPolicy.create (or .Values.applicationSet.metrics.enabled .Values.applicationSet.webhook.ingress.enabled) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "argo-cd.applicationSet.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
+spec:
+  ingress:
+  {{- if .Values.applicationSet.webhook.ingress.enabled }}
+  - ports:
+    - port: webhook
+  {{- end }}
+  {{- if .Values.applicationSet.metrics.enabled }}
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: metrics
+  {{- end }}
+  podSelector:
+    matchLabels:
+      {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.applicationSet.name) | nindent 6 }}
+  policyTypes:
+  - Ingress
+{{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.notifications.enabled .Values.global.networkPolicy.create .Values.notifications.metrics.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "argo-cd.notifications.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: metrics
+  podSelector:
+    matchLabels:
+      {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.notifications.name) | nindent 6 }}
+  policyTypes:
+  - Ingress
+{{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/networkpolicy.yaml
@@ -14,6 +14,16 @@ spec:
     - podSelector:
         matchLabels:
           {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 10 }}
+    {{- if .Values.notifications.enabled }}
+    - podSelector:
+        matchLabels:
+          {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.notifications.name) | nindent 10 }}
+    {{- end }}
+    {{- if .Values.applicationSet.enabled }}
+    - podSelector:
+        matchLabels:
+          {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.applicationSet.name) | nindent 10 }}
+    {{- end }}
     ports:
     - port: repo-server
       protocol: TCP


### PR DESCRIPTION
The network policies for the new components AppSet and Notifications were missing

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
