### PR TITLE
fix(argo-workflows): Add missing list verb to secret

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: v3.2.9
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -16,3 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Added]: Add encryptionOptions for S3 based artifactRepository"
+    - "[Fixed]: Add missing list verb to secret"

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -15,5 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add encryptionOptions for S3 based artifactRepository"
     - "[Fixed]: Add missing list verb to secret"

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -62,6 +62,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 {{- if .Values.server.sso }}
   {{- if .Values.server.sso.rbac }}
     {{- with .Values.server.sso.rbac.secretWhitelist }}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.

## Issue:
When deploying argo-worflows using chart version 0.13.0, argo-workflows v3.3.x, getting this error, same as #1171 
```
Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:argo:argo-server" cannot list resource "secrets" in API group "" at the cluster scope
```

## Fix:
Add list verb to secret