### PR TITLE
fix(argo-cd): Correct ApplicationSet controller port

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -21,5 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Correct ArgoCD notification subscriptions type"
     - "[Fixed]: Correct ArgoCD applicationset controller port"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.2
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.2.3
+version: 4.2.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -22,3 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Correct ArgoCD notification subscriptions type"
+    - "[Fixed]: Correct ArgoCD applicationset controller port"

--- a/charts/argo-cd/templates/argocd-applicationset/service.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/service.yaml
@@ -15,7 +15,7 @@ spec:
   ports:
   - name: {{ .Values.applicationSet.service.portName }}
     port: {{ .Values.applicationSet.service.port }}
-    targetPort: 7000
+    targetPort: webhook
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.applicationSet.name) | nindent 4 }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/service.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/service.yaml
@@ -15,7 +15,7 @@ spec:
   ports:
   - name: {{ .Values.applicationSet.service.portName }}
     port: {{ .Values.applicationSet.service.port }}
-    targetPort: {{ .Values.applicationSet.containerPort }}
+    targetPort: 7000
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.applicationSet.name) | nindent 4 }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1896,7 +1896,7 @@ applicationSet:
   # -- Additional containers to be added to the applicationset controller pod
   extraContainers: []
 
-    ## Metrics service configuration
+  ## Metrics service configuration
   metrics:
     # -- Deploy metrics service
     enabled: false


### PR DESCRIPTION
This PR propose a fix for the #1199.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
