### PR TITLE
feat(argo-cd): Add ability to set Notification Services

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.1
+version: 4.5.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Removed status field from ApplicationSet CRD"
+    - "[Feat]: Add ability to set Notification Services"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -776,6 +776,7 @@ NAME: my-release
 | notifications.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | notifications.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | notifications.serviceAccount.name | string | `"argocd-notifications-controller"` | The name of the service account to use. |
+| notifications.services | object | `{}` | The notification services such as slack, email or custom webhook. This will be stored on `notifications.cm.name` ConfigMap. |
 | notifications.subscriptions | list | `[]` | Contains centrally managed global application subscriptions |
 | notifications.templates | object | `{}` | The notification template is used to generate the notification content |
 | notifications.tolerations | list | `[]` | [Tolerations] for use with node taints |

--- a/charts/argo-cd/templates/argocd-notifications/configmap.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/configmap.yaml
@@ -24,4 +24,7 @@ data:
   {{- with .Values.notifications.triggers }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with .Values.notifications.services }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2580,3 +2580,9 @@ notifications:
 
       # -- [Node selector]
       nodeSelector: {}
+
+  # -- The notification services such as slack, email or custom webhook. This will be stored on `notifications.cm.name` ConfigMap.
+  ## For more information: https://argocd-notifications.readthedocs.io/en/stable/services/overview/
+  services: {}
+    # service.slack: |
+    #   token: $slack-token


### PR DESCRIPTION
Signed-off-by: yu-croco <yuki.kita22@gmail.com>

According to [official doc](https://argocd-notifications.readthedocs.io/en/stable/services/overview/), we can set Notification Services on `argocd-notifications-cm` ConfigMap, but there was no configuration against them. So I added them. 🙋 

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-notifications-cm
data:
  service.slack: |
    token: $slack-token
```

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this. 


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
