### PR TITLE
chore!: Deprecate argocd-applicationset and argocd-notifications

### DIFF
--- a/charts/argocd-applicationset/Chart.yaml
+++ b/charts/argocd-applicationset/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v2
 name: argocd-applicationset
 description: A Helm chart for installing ArgoCD ApplicationSet
+deprecated: true
 type: application
-version: 1.12.0
+version: 1.12.1
 appVersion: "v0.4.1"
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-applicationset.readthedocs.io/en/stable/assets/logo.png
@@ -14,4 +15,4 @@ maintainers:
   - name: maruina
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: updated application version for v0.4.1 and its CRD for support of skipCrds in applications"
+    - "[Deprecated]: This chart is now deprecated and will be removed soon. Please upgrade to Argo CD 2.3+ (chart version 4.x) which includes ApplicationSet."

--- a/charts/argocd-notifications/Chart.yaml
+++ b/charts/argocd-notifications/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 appVersion: v1.2.1
 description: A Helm chart for ArgoCD notifications, an add-on to ArgoCD.
+deprecated: true
 name: argocd-notifications
 type: application
-version: 1.8.0
+version: 1.8.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argocd-notifications.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -15,4 +16,4 @@ maintainers:
   - name: andyfeller
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Ability to define security context for Slack bot deployment"
+    - "[Deprecated]: This chart is now deprecated and will be removed soon. Please upgrade to Argo CD 2.3+ (chart version 4.x) which includes Argo CD Notifications."


### PR DESCRIPTION
Resolves #1219

/cc: Initial chart contributor @maruina (https://github.com/argoproj/argo-helm/pull/577), @andyfeller (https://github.com/argoproj/argo-helm/pull/365)

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
