### PR TITLE
chore(CODEOWNERS): Move mkilchhofer from generic to argo-cd

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,13 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# All charts
-/charts/ @mkilchhofer @oliverbaehler
+# Other and new charts
+/charts/ @oliverbaehler
 
 # Argo Workflows
 /charts/argo-workflows/ @stefansedich @paguos @vladlosev @yann-soubeyrand 
 
 # Argo CD
-/charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1
+/charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1 @mkilchhofer
 
 # Argo Events
 /charts/argo-events/ @jbehling @VaibhavPage 


### PR DESCRIPTION
I want to move myself from the generic `/charts/` section to the Argo CD chart so I don't miss PRs against Argo CD which I mainly use for personal projects and at work.

I introduced this section (in PR #714) by understanding that approvers from this section get extended with the approvers from the specific chart. But CODEOWNERS only picks the most specific rule and does not extend other rules.

/cc: @oliverbaehler You are the only one left in this section.

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
