### PR TITLE
fix(argo-cd): Use global imagePullPolicy for Dex

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -23,3 +23,4 @@ annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Use global imagePullPolicy for Dex by default"
     - "[Fixed]: ApplicationSet imagePullPolicy variable in values.yaml"
+    - "[Fixed]: Use global imagePullicy for ApplicationSet by default"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -22,3 +22,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Use global imagePullPolicy for Dex by default"
+    - "[Fixed]: ApplicationSet imagePullPolicy variable in values.yaml"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.7
+version: 4.5.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Removed]: Drop unneeded static-files volume from argocd-server"
+    - "[Fixed]: Use global imagePullPolicy for Dex by default"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.8
+version: 4.5.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -23,4 +23,4 @@ annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Use global imagePullPolicy for Dex by default"
     - "[Fixed]: ApplicationSet imagePullPolicy variable in values.yaml"
-    - "[Fixed]: Use global imagePullicy for ApplicationSet by default"
+    - "[Fixed]: Use global imagePullPolicy for ApplicationSet by default"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.9
+version: 4.5.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -675,7 +675,7 @@ NAME: my-release
 | applicationSet.extraEnvFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the controller |
 | applicationSet.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | applicationSet.extraVolumes | list | `[]` | List of extra volumes to add |
-| applicationSet.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the application set controller |
+| applicationSet.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for the application set controller |
 | applicationSet.image.repository | string | `"quay.io/argoproj/argocd-applicationset"` | Repository to use for the application set controller |
 | applicationSet.image.tag | string | `"v0.4.1"` | Tag to use for the application set controller |
 | applicationSet.imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -535,7 +535,7 @@ NAME: my-release
 | dex.extraContainers | list | `[]` | Additional containers to be added to the dex pod |
 | dex.extraVolumeMounts | list | `[]` | Extra volumeMounts to the dex pod |
 | dex.extraVolumes | list | `[]` | Extra volumes to the dex pod |
-| dex.image.imagePullPolicy | string | `"IfNotPresent"` | Dex imagePullPolicy |
+| dex.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Dex imagePullPolicy |
 | dex.image.repository | string | `"ghcr.io/dexidp/dex"` | Dex image repository |
 | dex.image.tag | string | `"v2.30.2"` | Dex image tag |
 | dex.initContainers | list | `[]` | Init containers to add to the dex pod |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -89,10 +89,10 @@ Helm cannot upgrade custom resource definitions [by design](https://helm.sh/docs
 Please use `kubectl` to upgrade CRDs manually:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-application.yaml
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-applicationset.yaml
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-extension.yaml
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-project.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-application.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-applicationset.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-extension.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-project.yaml
 ```
 
 ### 4.3.*

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -675,9 +675,9 @@ NAME: my-release
 | applicationSet.extraEnvFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the controller |
 | applicationSet.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | applicationSet.extraVolumes | list | `[]` | List of extra volumes to add |
-| applicationSet.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for the application set controller |
-| applicationSet.image.repository | string | `"quay.io/argoproj/argocd-applicationset"` | Repository to use for the application set controller |
-| applicationSet.image.tag | string | `"v0.4.1"` | Tag to use for the application set controller |
+| applicationSet.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the application set controller |
+| applicationSet.image.repository | string | `quay.io/argoproj/argocd-applicationset` (defaults to global.image.repository) | Repository to use for the application set controller |
+| applicationSet.image.tag | string | `v0.4.1` (defaults to global.image.tag) | Tag to use for the application set controller |
 | applicationSet.imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
 | applicationSet.metrics.enabled | bool | `false` | Deploy metrics service |
 | applicationSet.metrics.service.annotations | object | `{}` | Metrics service annotations |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -689,8 +689,8 @@ NAME: my-release
 | applicationSet.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | applicationSet.extraVolumes | list | `[]` | List of extra volumes to add |
 | applicationSet.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the application set controller |
-| applicationSet.image.repository | string | `quay.io/argoproj/argocd-applicationset` (defaults to global.image.repository) | Repository to use for the application set controller |
-| applicationSet.image.tag | string | `v0.4.1` (defaults to global.image.tag) | Tag to use for the application set controller |
+| applicationSet.image.repository | string | `"quay.io/argoproj/argocd-applicationset"` | Repository to use for the application set controller |
+| applicationSet.image.tag | string | `"v0.4.1"` | Tag to use for the application set controller |
 | applicationSet.imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
 | applicationSet.metrics.enabled | bool | `false` | Deploy metrics service |
 | applicationSet.metrics.service.annotations | object | `{}` | Metrics service annotations |

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -52,7 +52,7 @@ spec:
       containers:
       - name: {{ .Values.dex.name }}
         image: {{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}
-        imagePullPolicy: {{ .Values.dex.image.imagePullPolicy }}
+        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.image.imagePullPolicy }}
         command:
         - /shared/argocd-dex
         - rundex

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1892,7 +1892,7 @@ applicationSet:
     # -- Repository to use for the application set controller
     repository: quay.io/argoproj/argocd-applicationset
     # -- Image pull policy for the application set controller
-    pullPolicy: IfNotPresent
+    imagePullPolicy: IfNotPresent
     # -- Tag to use for the application set controller
     tag: "v0.4.1"
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1890,10 +1890,8 @@ applicationSet:
 
   image:
     # -- Repository to use for the application set controller
-    # @default -- `quay.io/argoproj/argocd-applicationset` (defaults to global.image.repository)
     repository: quay.io/argoproj/argocd-applicationset
     # -- Tag to use for the application set controller
-    # @default -- `v0.4.1` (defaults to global.image.tag)
     tag: "v0.4.1"
     # -- Image pull policy for the application set controller
     # @default -- `""` (defaults to global.image.imagePullPolicy)

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1890,11 +1890,14 @@ applicationSet:
 
   image:
     # -- Repository to use for the application set controller
+    # @default -- `quay.io/argoproj/argocd-applicationset` (defaults to global.image.repository)
     repository: quay.io/argoproj/argocd-applicationset
-    # -- Image pull policy for the application set controller
-    imagePullPolicy: IfNotPresent
     # -- Tag to use for the application set controller
+    # @default -- `v0.4.1` (defaults to global.image.tag)
     tag: "v0.4.1"
+    # -- Image pull policy for the application set controller
+    # @default -- `""` (defaults to global.image.imagePullPolicy)
+    imagePullPolicy: ""
 
   args:
     # -- The default metric address

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -397,7 +397,8 @@ dex:
     # -- Dex image tag
     tag: v2.30.2
     # -- Dex imagePullPolicy
-    imagePullPolicy: IfNotPresent
+    # @default -- `""` (defaults to global.image.imagePullPolicy)
+    imagePullPolicy: ""
   initImage:
     # -- Argo CD init image repository
     # @default -- `""` (defaults to global.image.repository)


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Resolves:
- https://github.com/argoproj/argo-helm/issues/1226
- https://github.com/argoproj/argo-helm/issues/1225

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
