### PR TITLE
chore(argo-cd): Document how to upgrade CRDs

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.7
+version: 4.5.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Removed]: Drop unneeded static-files volume from argocd-server"
+    - "[Added]: Document how to upgrade CRDs"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -82,6 +82,19 @@ Changes in the `CustomResourceDefinition` resources shall be fixed easily by cop
 
 ## Upgrading
 
+### Custom resource definitions
+
+Helm cannot upgrade custom resource definitions [by design](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations).
+
+Please use `kubectl` to upgrade CRDs manually:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-application.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-applicationset.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-extension.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-project.yaml
+```
+
 ### 4.3.*
 
 With this minor version, the notification notifier's `service.slack` is no longer configured by default.

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -82,6 +82,19 @@ Changes in the `CustomResourceDefinition` resources shall be fixed easily by cop
 
 ## Upgrading
 
+### Custom resource definitions
+
+Helm cannot upgrade custom resource definitions [by design](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations).
+
+Please use `kubectl` to upgrade CRDs manually:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-{{ template "chart.version" . }}/charts/argo-cd/crds/crd-application.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-{{ template "chart.version" . }}/charts/argo-cd/crds/crd-applicationset.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-{{ template "chart.version" . }}/charts/argo-cd/crds/crd-extension.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-{{ template "chart.version" . }}/charts/argo-cd/crds/crd-project.yaml
+```
+
 ### 4.3.*
 
 With this minor version, the notification notifier's `service.slack` is no longer configured by default.


### PR DESCRIPTION
Please advise if you want to keep CRD upgrade section generic with current chart tag version or if you want to place it under each section where CRD upgrade happened.

@mbevc1 @mkilchhofer - Do you bump chart version for documentation change?

Resolves:
- https://github.com/argoproj/argo-helm/issues/1195
- https://github.com/argoproj/argo-helm/issues/1180

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
