### PR TITLE
fix(argo-cd): use global imagePullSecret value for notifications deployment

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -22,4 +22,3 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Use global imagePullSecret value for notfications deployment"
-

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.8
+version: 4.5.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Document how to upgrade CRDs"
+    - "[Fixed]: Use global imagePullSecret value for notfications deployment"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.9
+version: 4.5.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -89,10 +89,10 @@ Helm cannot upgrade custom resource definitions [by design](https://helm.sh/docs
 Please use `kubectl` to upgrade CRDs manually:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-application.yaml
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-applicationset.yaml
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-extension.yaml
-kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.8/charts/argo-cd/crds/crd-project.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-application.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-applicationset.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-extension.yaml
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-helm/argo-cd-4.5.9/charts/argo-cd/crds/crd-project.yaml
 ```
 
 ### 4.3.*

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-    {{- with .Values.notifications.imagePullSecrets }}
+    {{- with .Values.notifications.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
Closes #1252 

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
