### PR TITLE
feat(argo-cd): Use upstream applicationset binary

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.10
+version: 4.6.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,6 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Use global imagePullPolicy for Dex by default"
-    - "[Fixed]: ApplicationSet imagePullPolicy variable in values.yaml"
-    - "[Fixed]: Use global imagePullPolicy for ApplicationSet by default"
+    - "[Changed]: Use applicationset binary on the upstream image"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -95,6 +95,10 @@ kubectl apply -k https://github.com/argoproj/argo-cd.git/manifests/crds?ref=<app
 kubectl apply -k https://github.com/argoproj/argo-cd.git/manifests/crds?ref=v2.3.3
 ```
 
+### 4.6.0
+
+This version starts to use upstream image with applicationset binary. Start command was changed from `applicationset-controller` to `argocd-applicationset-controller`
+
 ### 4.3.*
 
 With this minor version, the notification notifier's `service.slack` is no longer configured by default.
@@ -689,8 +693,8 @@ NAME: my-release
 | applicationSet.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | applicationSet.extraVolumes | list | `[]` | List of extra volumes to add |
 | applicationSet.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the application set controller |
-| applicationSet.image.repository | string | `"quay.io/argoproj/argocd-applicationset"` | Repository to use for the application set controller |
-| applicationSet.image.tag | string | `"v0.4.1"` | Tag to use for the application set controller |
+| applicationSet.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the application set controller |
+| applicationSet.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the application set controller |
 | applicationSet.imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
 | applicationSet.metrics.enabled | bool | `false` | Deploy metrics service |
 | applicationSet.metrics.service.annotations | object | `{}` | Metrics service annotations |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -95,6 +95,10 @@ kubectl apply -k https://github.com/argoproj/argo-cd.git/manifests/crds?ref=<app
 kubectl apply -k https://github.com/argoproj/argo-cd.git/manifests/crds?ref=v2.3.3
 ```
 
+### 4.6.0
+
+This version starts to use upstream image with applicationset binary. Start command was changed from `applicationset-controller` to `argocd-applicationset-controller`
+
 ### 4.3.*
 
 With this minor version, the notification notifier's `service.slack` is no longer configured by default.

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             {{- toYaml .Values.applicationSet.securityContext | nindent 12 }}
           command:
-            - applicationset-controller
+            - argocd-applicationset-controller
             - --metrics-addr={{ .Values.applicationSet.args.metricsAddr }}
             - --probe-addr={{ .Values.applicationSet.args.probeBindAddr }}
             {{- if or (gt ( .Values.applicationSet.replicaCount | int64) 1) .Values.applicationSet.args.enableLeaderElection }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1890,9 +1890,11 @@ applicationSet:
 
   image:
     # -- Repository to use for the application set controller
-    repository: quay.io/argoproj/argocd-applicationset
+    # @default -- `""` (defaults to global.image.repository)
+    repository: ""
     # -- Tag to use for the application set controller
-    tag: "v0.4.1"
+    # @default -- `""` (defaults to global.image.tag)
+    tag: ""
     # -- Image pull policy for the application set controller
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: ""


### PR DESCRIPTION
Use of ApplicationSet binary that is embedded in upstream [Dockerfile](https://github.com/argoproj/argo-cd/blob/a3a429787e17e1e48fe8fa02e33943d80a6adc25/Dockerfile#L127)

EDIT: Marking this as a draft, because binary will be available with 2.4.x release

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
