### PR TITLE
feat(argo-cd): Make metrics and serviceMonitors usable on an istio service mesh

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.11
+version: 4.5.12
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Use global imagePullSecret value for notfications deployment"
+    - "[Added]: Metrics service name can now be changed"
+    - "[Added]: ServiceMonitor now support tlsConfig"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.5.13
+version: 4.6.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -23,3 +23,4 @@ annotations:
   artifacthub.io/changes: |
     - "[Added]: Metrics service name can now be changed"
     - "[Added]: ServiceMonitor now support tlsConfig"
+    - "[Changed]: All metrics Service ports were renamed from 'metrics' to 'http-metrics' (istio compatibility)"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -299,7 +299,7 @@ NAME: my-release
 | controller.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | controller.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | controller.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| controller.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| controller.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | controller.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | controller.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | controller.name | string | `"application-controller"` | Application controller name string |
@@ -372,7 +372,7 @@ NAME: my-release
 | repoServer.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | repoServer.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | repoServer.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| repoServer.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| repoServer.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | repoServer.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | repoServer.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | repoServer.name | string | `"repo-server"` | Repo server name |
@@ -490,7 +490,7 @@ NAME: my-release
 | server.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | server.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | server.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| server.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| server.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | server.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | server.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | server.name | string | `"server"` | Argo CD server name |
@@ -580,7 +580,7 @@ NAME: my-release
 | dex.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | dex.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | dex.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| dex.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| dex.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | dex.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | dex.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | dex.name | string | `"dex-server"` | Dex name |
@@ -646,7 +646,7 @@ NAME: my-release
 | redis.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | redis.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | redis.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| redis.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| redis.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | redis.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | redis.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | redis.name | string | `"redis"` | Redis name |
@@ -717,7 +717,7 @@ NAME: my-release
 | applicationSet.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | applicationSet.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | applicationSet.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
-| applicationSet.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| applicationSet.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | applicationSet.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | applicationSet.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | applicationSet.name | string | `"applicationset-controller"` | Application Set controller name string |
@@ -792,7 +792,7 @@ NAME: my-release
 | notifications.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | notifications.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | notifications.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
-| notifications.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
+| notifications.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | notifications.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | notifications.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | notifications.name | string | `"notifications-controller"` | Notifications controller name string |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -291,6 +291,7 @@ NAME: my-release
 | controller.metrics.rules.spec | list | `[]` | PrometheusRule.Spec for the application controller |
 | controller.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | controller.metrics.service.labels | object | `{}` | Metrics service labels |
+| controller.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | controller.metrics.service.servicePort | int | `8082` | Metrics service port |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -298,7 +299,9 @@ NAME: my-release
 | controller.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | controller.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | controller.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| controller.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | controller.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| controller.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | controller.name | string | `"application-controller"` | Application controller name string |
 | controller.nodeSelector | object | `{}` | [Node selector] |
 | controller.pdb.annotations | object | `{}` | Annotations to be added to application controller pdb |
@@ -361,6 +364,7 @@ NAME: my-release
 | repoServer.metrics.enabled | bool | `false` | Deploy metrics service |
 | repoServer.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | repoServer.metrics.service.labels | object | `{}` | Metrics service labels |
+| repoServer.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | repoServer.metrics.service.servicePort | int | `8084` | Metrics service port |
 | repoServer.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | repoServer.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -368,7 +372,9 @@ NAME: my-release
 | repoServer.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | repoServer.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | repoServer.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| repoServer.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | repoServer.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| repoServer.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | repoServer.name | string | `"repo-server"` | Repo server name |
 | repoServer.nodeSelector | object | `{}` | [Node selector] |
 | repoServer.pdb.annotations | object | `{}` | Annotations to be added to Repo server pdb |
@@ -476,6 +482,7 @@ NAME: my-release
 | server.metrics.enabled | bool | `false` | Deploy metrics service |
 | server.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | server.metrics.service.labels | object | `{}` | Metrics service labels |
+| server.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | server.metrics.service.servicePort | int | `8083` | Metrics service port |
 | server.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | server.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -483,7 +490,9 @@ NAME: my-release
 | server.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | server.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | server.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| server.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | server.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| server.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | server.name | string | `"server"` | Argo CD server name |
 | server.nodeSelector | object | `{}` | [Node selector] |
 | server.pdb.annotations | object | `{}` | Annotations to be added to server pdb |
@@ -564,13 +573,16 @@ NAME: my-release
 | dex.metrics.enabled | bool | `false` | Deploy metrics service |
 | dex.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | dex.metrics.service.labels | object | `{}` | Metrics service labels |
+| dex.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | dex.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | dex.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | dex.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | dex.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | dex.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | dex.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| dex.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | dex.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| dex.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | dex.name | string | `"dex-server"` | Dex name |
 | dex.nodeSelector | object | `{}` | [Node selector] |
 | dex.pdb.annotations | object | `{}` | Annotations to be added to Dex server pdb |
@@ -634,7 +646,9 @@ NAME: my-release
 | redis.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | redis.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | redis.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| redis.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | redis.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| redis.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | redis.name | string | `"redis"` | Redis name |
 | redis.nodeSelector | object | `{}` | [Node selector] |
 | redis.pdb.annotations | object | `{}` | Annotations to be added to Redis server pdb |
@@ -695,6 +709,7 @@ NAME: my-release
 | applicationSet.metrics.enabled | bool | `false` | Deploy metrics service |
 | applicationSet.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | applicationSet.metrics.service.labels | object | `{}` | Metrics service labels |
+| applicationSet.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | applicationSet.metrics.service.servicePort | int | `8085` | Metrics service port |
 | applicationSet.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | applicationSet.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -702,7 +717,9 @@ NAME: my-release
 | applicationSet.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | applicationSet.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | applicationSet.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| applicationSet.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | applicationSet.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| applicationSet.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | applicationSet.name | string | `"applicationset-controller"` | Application Set controller name string |
 | applicationSet.nodeSelector | object | `{}` | [Node selector] |
 | applicationSet.podAnnotations | object | `{}` | Annotations for the controller pods |
@@ -772,9 +789,12 @@ NAME: my-release
 | notifications.metrics.port | int | `9001` | Metrics port |
 | notifications.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | notifications.metrics.service.labels | object | `{}` | Metrics service labels |
+| notifications.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | notifications.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | notifications.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
+| notifications.metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | notifications.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| notifications.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | notifications.name | string | `"notifications-controller"` | Notifications controller name string |
 | notifications.nodeSelector | object | `{}` | [Node selector] |
 | notifications.notifiers | object | See [values.yaml] | Configures notification services such as slack, email or custom webhook |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -291,7 +291,7 @@ NAME: my-release
 | controller.metrics.rules.spec | list | `[]` | PrometheusRule.Spec for the application controller |
 | controller.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | controller.metrics.service.labels | object | `{}` | Metrics service labels |
-| controller.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| controller.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | controller.metrics.service.servicePort | int | `8082` | Metrics service port |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -364,7 +364,7 @@ NAME: my-release
 | repoServer.metrics.enabled | bool | `false` | Deploy metrics service |
 | repoServer.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | repoServer.metrics.service.labels | object | `{}` | Metrics service labels |
-| repoServer.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| repoServer.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | repoServer.metrics.service.servicePort | int | `8084` | Metrics service port |
 | repoServer.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | repoServer.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -482,7 +482,7 @@ NAME: my-release
 | server.metrics.enabled | bool | `false` | Deploy metrics service |
 | server.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | server.metrics.service.labels | object | `{}` | Metrics service labels |
-| server.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| server.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | server.metrics.service.servicePort | int | `8083` | Metrics service port |
 | server.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | server.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -573,7 +573,7 @@ NAME: my-release
 | dex.metrics.enabled | bool | `false` | Deploy metrics service |
 | dex.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | dex.metrics.service.labels | object | `{}` | Metrics service labels |
-| dex.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| dex.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | dex.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | dex.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | dex.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
@@ -637,7 +637,7 @@ NAME: my-release
 | redis.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | redis.metrics.service.clusterIP | string | `"None"` | Metrics service clusterIP. `None` makes a "headless service" (no virtual IP) |
 | redis.metrics.service.labels | object | `{}` | Metrics service labels |
-| redis.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| redis.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | redis.metrics.service.servicePort | int | `9121` | Metrics service port |
 | redis.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | redis.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
@@ -709,7 +709,7 @@ NAME: my-release
 | applicationSet.metrics.enabled | bool | `false` | Deploy metrics service |
 | applicationSet.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | applicationSet.metrics.service.labels | object | `{}` | Metrics service labels |
-| applicationSet.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| applicationSet.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | applicationSet.metrics.service.servicePort | int | `8085` | Metrics service port |
 | applicationSet.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | applicationSet.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -789,7 +789,7 @@ NAME: my-release
 | notifications.metrics.port | int | `9001` | Metrics port |
 | notifications.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | notifications.metrics.service.labels | object | `{}` | Metrics service labels |
-| notifications.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
+| notifications.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | notifications.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | notifications.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | notifications.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -291,7 +291,7 @@ NAME: my-release
 | controller.metrics.rules.spec | list | `[]` | PrometheusRule.Spec for the application controller |
 | controller.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | controller.metrics.service.labels | object | `{}` | Metrics service labels |
-| controller.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| controller.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | controller.metrics.service.servicePort | int | `8082` | Metrics service port |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -364,7 +364,7 @@ NAME: my-release
 | repoServer.metrics.enabled | bool | `false` | Deploy metrics service |
 | repoServer.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | repoServer.metrics.service.labels | object | `{}` | Metrics service labels |
-| repoServer.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| repoServer.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | repoServer.metrics.service.servicePort | int | `8084` | Metrics service port |
 | repoServer.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | repoServer.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -482,7 +482,7 @@ NAME: my-release
 | server.metrics.enabled | bool | `false` | Deploy metrics service |
 | server.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | server.metrics.service.labels | object | `{}` | Metrics service labels |
-| server.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| server.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | server.metrics.service.servicePort | int | `8083` | Metrics service port |
 | server.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | server.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -573,7 +573,7 @@ NAME: my-release
 | dex.metrics.enabled | bool | `false` | Deploy metrics service |
 | dex.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | dex.metrics.service.labels | object | `{}` | Metrics service labels |
-| dex.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| dex.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | dex.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | dex.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | dex.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
@@ -637,7 +637,7 @@ NAME: my-release
 | redis.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | redis.metrics.service.clusterIP | string | `"None"` | Metrics service clusterIP. `None` makes a "headless service" (no virtual IP) |
 | redis.metrics.service.labels | object | `{}` | Metrics service labels |
-| redis.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| redis.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | redis.metrics.service.servicePort | int | `9121` | Metrics service port |
 | redis.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | redis.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
@@ -709,7 +709,7 @@ NAME: my-release
 | applicationSet.metrics.enabled | bool | `false` | Deploy metrics service |
 | applicationSet.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | applicationSet.metrics.service.labels | object | `{}` | Metrics service labels |
-| applicationSet.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| applicationSet.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | applicationSet.metrics.service.servicePort | int | `8085` | Metrics service port |
 | applicationSet.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | applicationSet.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
@@ -789,7 +789,7 @@ NAME: my-release
 | notifications.metrics.port | int | `9001` | Metrics port |
 | notifications.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | notifications.metrics.service.labels | object | `{}` | Metrics service labels |
-| notifications.metrics.service.portName | string | `"metrics"` | Metrics service port name |
+| notifications.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | notifications.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | notifications.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | notifications.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |

--- a/charts/argo-cd/templates/argocd-application-controller/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
   name: {{ template "argo-cd.controller.fullname" . }}-metrics
 spec:
   ports:
-  - name: metrics
+  - name: {{ .Values.controller.metrics.service.portName }}
     protocol: TCP
     port: {{ .Values.controller.metrics.service.servicePort }}
     targetPort: controller

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: {{ .Values.controller.metrics.service.portName }}
       {{- with .Values.controller.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -27,6 +27,13 @@ spec:
       {{- end }}
       {{- with .Values.controller.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:

--- a/charts/argo-cd/templates/argocd-applicationset/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
   name: {{ template "argo-cd.applicationSet.fullname" . }}-metrics
 spec:
   ports:
-  - name: metrics
+  - name:  {{ .Values.applicationSet.metrics.service.portName }}
     protocol: TCP
     port: {{ .Values.applicationSet.metrics.service.servicePort }}
     targetPort: metrics

--- a/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
@@ -30,10 +30,10 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      {{- with .Values.applicationSet.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      {{- with .Values.applicationSet.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: {{ .Values.applicationSet.metrics.service.portName }}
       {{- with .Values.applicationSet.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -28,6 +28,13 @@ spec:
       {{- end }}
       {{- with .Values.applicationSet.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:

--- a/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/service-metrics.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.notifications.name) | nindent 6 }}
   ports:
-  - name: metrics
+  - name: {{ .Values.notifications.metrics.service.portName }}
     port: {{ .Values.notifications.metrics.port }}
     targetPort: {{ .Values.notifications.metrics.port }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -16,13 +16,20 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: {{ .Values.notifications.metrics.service.portName }}
       path: /metrics
       {{- if .Values.notifications.metrics.serviceMonitor.interval }}
       interval: {{ .Values.notifications.metrics.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.notifications.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.notifications.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -24,10 +24,10 @@ spec:
       {{- if .Values.notifications.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.notifications.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      {{- with .Values.notifications.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      {{- with .Values.notifications.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
   name: {{ template "argo-cd.repoServer.fullname" . }}-metrics
 spec:
   ports:
-  - name: metrics
+  - name: {{ .Values.repoServer.metrics.service.portName }}
     protocol: TCP
     port: {{ .Values.repoServer.metrics.service.servicePort }}
     targetPort: metrics

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -29,10 +29,10 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      {{- with .Values.repoServer.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      {{- with .Values.repoServer.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: {{ .Values.repoServer.metrics.service.portName }}
       {{- with .Values.repoServer.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -27,6 +27,13 @@ spec:
       {{- end }}
       {{- with .Values.repoServer.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:

--- a/charts/argo-cd/templates/argocd-server/metrics-service.yaml
+++ b/charts/argo-cd/templates/argocd-server/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
   name: {{ template "argo-cd.server.fullname" . }}-metrics
 spec:
   ports:
-  - name: metrics
+  - name: {{ .Values.server.metrics.service.portName }}
     protocol: TCP
     port: {{ .Values.server.metrics.service.servicePort }}
     targetPort: metrics

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: {{ .Values.server.metrics.service.portName }}
       {{- with .Values.server.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -27,6 +27,13 @@ spec:
       {{- end }}
       {{- with .Values.server.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -29,10 +29,10 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      {{- with .Values.server.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      {{- with .Values.server.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -76,14 +76,14 @@ spec:
         - name: grpc
           containerPort: {{ .Values.dex.containerPortGrpc }}
           protocol: TCP
-        - name: {{ .Values.dex.metrics.service.portName }}
+        - name: metrics
           containerPort: {{ .Values.dex.containerPortMetrics }}
           protocol: TCP
         {{- if .Values.dex.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /healthz/live
-            port: {{ .Values.dex.metrics.service.portName }}
+            port: metrics
           {{- with .Values.dex.livenessProbe }}
             {{- omit . "enabled" | toYaml | nindent 10 }}
           {{- end }}
@@ -92,7 +92,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz/ready
-            port: {{ .Values.dex.metrics.service.portName }}
+            port: metrics
           {{- with .Values.dex.readinessProbe }}
             {{- omit . "enabled" | toYaml | nindent 10 }}
           {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -76,14 +76,14 @@ spec:
         - name: grpc
           containerPort: {{ .Values.dex.containerPortGrpc }}
           protocol: TCP
-        - name: metrics
+        - name: {{ .Values.dex.metrics.service.portName }}
           containerPort: {{ .Values.dex.containerPortMetrics }}
           protocol: TCP
         {{- if .Values.dex.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /healthz/live
-            port: metrics
+            port: {{ .Values.dex.metrics.service.portName }}
           {{- with .Values.dex.livenessProbe }}
             {{- omit . "enabled" | toYaml | nindent 10 }}
           {{- end }}
@@ -92,7 +92,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz/ready
-            port: metrics
+            port: {{ .Values.dex.metrics.service.portName }}
           {{- with .Values.dex.readinessProbe }}
             {{- omit . "enabled" | toYaml | nindent 10 }}
           {{- end }}

--- a/charts/argo-cd/templates/dex/service.yaml
+++ b/charts/argo-cd/templates/dex/service.yaml
@@ -25,7 +25,7 @@ spec:
     port: {{ .Values.dex.servicePortGrpc }}
     targetPort: grpc
 {{- if .Values.dex.metrics.enabled }}
-  - name: metrics
+  - name: {{ .Values.dex.metrics.service.portName }}
     protocol: TCP
     port: {{ .Values.dex.servicePortMetrics }}
     targetPort: metrics

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: {{ .Values.dex.metrics.service.portName }}
       {{- with .Values.dex.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -28,6 +28,13 @@ spec:
       {{- with .Values.dex.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
         {{- toYaml . |nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -29,10 +29,10 @@ spec:
       metricRelabelings:
         {{- toYaml . |nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      {{- with .Values.dex.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      {{- with .Values.dex.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/redis/servicemonitor.yaml
+++ b/charts/argo-cd/templates/redis/servicemonitor.yaml
@@ -30,10 +30,10 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      {{- with .Values.redis.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
-      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      {{- with .Values.redis.metrics.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-cd/templates/redis/servicemonitor.yaml
+++ b/charts/argo-cd/templates/redis/servicemonitor.yaml
@@ -30,6 +30,13 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -274,7 +274,7 @@ controller:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -395,7 +395,7 @@ dex:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -745,7 +745,7 @@ redis:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -1023,7 +1023,7 @@ server:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -1606,7 +1606,7 @@ repoServer:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -1969,7 +1969,7 @@ applicationSet:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -2226,7 +2226,7 @@ notifications:
       # interval: 30s
       # scrapeTimeout: 10s
       # -- Prometheus ServiceMonitor scheme
-      scheme: "" 
+      scheme: ""
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -274,7 +274,7 @@ controller:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -395,7 +395,7 @@ dex:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -745,7 +745,7 @@ redis:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -1023,7 +1023,7 @@ server:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -1606,7 +1606,7 @@ repoServer:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -1969,7 +1969,7 @@ applicationSet:
         # prometheus: kube-prometheus
 
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
@@ -2226,7 +2226,7 @@ notifications:
       # interval: 30s
       # scrapeTimeout: 10s
       # -- Prometheus ServiceMonitor scheme
-      scheme: https 
+      scheme: "" 
       # -- Prometheus ServiceMonitor tlsConfig
       tlsConfig: {}
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -258,6 +258,8 @@ controller:
       labels: {}
       # -- Metrics service port
       servicePort: 8082
+      # -- Metrics service port name
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -271,6 +273,10 @@ controller:
       selector: {}
         # prometheus: kube-prometheus
 
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
       namespace: "" # "monitoring"
       # -- Prometheus ServiceMonitor labels
@@ -373,6 +379,8 @@ dex:
       annotations: {}
       # -- Metrics service labels
       labels: {}
+      # -- Metrics service port name
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -386,6 +394,10 @@ dex:
       selector: {}
         # prometheus: kube-prometheus
 
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
       namespace: "" # "monitoring"
       # -- Prometheus ServiceMonitor labels
@@ -732,6 +744,10 @@ redis:
       selector: {}
         # prometheus: kube-prometheus
 
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
       namespace: "" # "monitoring"
       # -- Prometheus ServiceMonitor labels
@@ -991,6 +1007,8 @@ server:
       labels: {}
       # -- Metrics service port
       servicePort: 8083
+      # -- Metrics service port name
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1004,6 +1022,10 @@ server:
       selector: {}
         # prometheus: kube-prometheus
 
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
       namespace: ""  # monitoring
       # -- Prometheus ServiceMonitor labels
@@ -1568,6 +1590,8 @@ repoServer:
       labels: {}
       # -- Metrics service port
       servicePort: 8084
+      # -- Metrics service port name
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1581,6 +1605,10 @@ repoServer:
       selector: {}
         # prometheus: kube-prometheus
 
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
       namespace: "" # "monitoring"
       # -- Prometheus ServiceMonitor labels
@@ -1925,6 +1953,8 @@ applicationSet:
       labels: {}
       # -- Metrics service port
       servicePort: 8085
+      # -- Metrics service port name
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1938,6 +1968,10 @@ applicationSet:
       selector: {}
         # prometheus: kube-prometheus
 
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
       # -- Prometheus ServiceMonitor namespace
       namespace: ""  # monitoring
       # -- Prometheus ServiceMonitor labels
@@ -2178,6 +2212,8 @@ notifications:
       annotations: {}
       # -- Metrics service labels
       labels: {}
+      # -- Metrics service port name
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -2189,6 +2225,10 @@ notifications:
       # namespace: monitoring
       # interval: 30s
       # scrapeTimeout: 10s
+      # -- Prometheus ServiceMonitor scheme
+      scheme: https 
+      # -- Prometheus ServiceMonitor tlsConfig
+      tlsConfig: {}
 
   # -- Configures notification services such as slack, email or custom webhook
   # @default -- See [values.yaml]

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -259,7 +259,7 @@ controller:
       # -- Metrics service port
       servicePort: 8082
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -380,7 +380,7 @@ dex:
       # -- Metrics service labels
       labels: {}
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -730,7 +730,7 @@ redis:
       # -- Metrics service port
       servicePort: 9121
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1008,7 +1008,7 @@ server:
       # -- Metrics service port
       servicePort: 8083
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1591,7 +1591,7 @@ repoServer:
       # -- Metrics service port
       servicePort: 8084
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1954,7 +1954,7 @@ applicationSet:
       # -- Metrics service port
       servicePort: 8085
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -2213,7 +2213,7 @@ notifications:
       # -- Metrics service labels
       labels: {}
       # -- Metrics service port name
-      portName: metrics
+      portName: http-metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -259,7 +259,7 @@ controller:
       # -- Metrics service port
       servicePort: 8082
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -380,7 +380,7 @@ dex:
       # -- Metrics service labels
       labels: {}
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -730,7 +730,7 @@ redis:
       # -- Metrics service port
       servicePort: 9121
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1008,7 +1008,7 @@ server:
       # -- Metrics service port
       servicePort: 8083
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1591,7 +1591,7 @@ repoServer:
       # -- Metrics service port
       servicePort: 8084
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -1954,7 +1954,7 @@ applicationSet:
       # -- Metrics service port
       servicePort: 8085
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
@@ -2213,7 +2213,7 @@ notifications:
       # -- Metrics service labels
       labels: {}
       # -- Metrics service port name
-      portName: http-metrics
+      portName: metrics
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false


### PR DESCRIPTION
This PR adds the necessary configuration values to be able to use metrics and servicemonitors on an istio service mesh. 


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
