### PR TITLE
fix: Workaround helm-docs v1.10.0 breaking change

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -37,10 +37,16 @@ jobs:
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
       
       - name: Run docs-testing (helm-docs)
-        uses: buttahtoast/helm-release-action@v2.0.1
-        with:
-          charts: "${{ steps.list-changed.outputs.changed_charts }}"
-        if: steps.list-changed.outputs.changed == 'true'
+        id: helm-docs
+        run: |
+          ./scripts/helm-docs.sh
+          if [[ $(git diff --stat) != '' ]]; then
+            echo -e '\033[0;31mDocumentation outdated!\033[0m ❌'
+            git diff --color
+            exit 1
+          else
+            echo -e '\033[0;32mDocumentation up to date\033[0m ✔'
+          fi
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/scripts/helm-docs.sh
+++ b/scripts/helm-docs.sh
@@ -8,4 +8,4 @@ echo "Running Helm-Docs"
 docker run \
     -v "$CHART_DIR:/helm-docs" \
     -u $(id -u) \
-    jnorwood/helm-docs:latest
+    jnorwood/helm-docs:v1.9.1


### PR DESCRIPTION
Let's try something hacky:
<img width="1212" alt="screenshot of running action" src="https://user-images.githubusercontent.com/7290987/169164198-63e925f2-512b-439a-8642-b460573b0bae.png">

Related to https://github.com/norwoodj/helm-docs/issues/148

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
