### PR TITLE
fix(argo-workflows): adjust api version of pod disruption budget by referring to k8s version

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: v3.3.5
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version v3.3.5"
+    - "[Fixed]: Adjust api version of pod disruption budget by referring to k8s version"

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -104,6 +104,17 @@ Return the appropriate apiVersion for ingress
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for pod disruption budget
+*/}}
+{{- define "argo-workflows.podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "argo-workflows.kubeVersion" $) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the target Kubernetes version
 */}}
 {{- define "argo-workflows.kubeVersion" -}}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-workflows.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}

--- a/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.server.enabled .Values.server.pdb.enabled -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-workflows.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}


### PR DESCRIPTION
This resolves https://github.com/argoproj/argo-helm/issues/1281 🙋 
for argo-cd's PR: https://github.com/argoproj/argo-helm/pull/1289

---

Signed-off-by: yu-croco <yuki.kita22@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
