### PR TITLE
fix(argo-cd): adjust api version of pod disruption budget by referring to k8s version

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.4
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.6.3
+version: 4.6.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add support for external issuers in server Certificate resource"
+    - "[Fixed]: Adjust api version of pod disruption budget by referring to k8s version"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -284,3 +284,14 @@ Create the name of the configmap to use
       key: redis-password
   {{- end }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for pod disruption budget
+*/}}
+{{- define "argo-cd.podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "argo-cd.kubeVersion" $) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller/poddisruptionbudget.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-cd.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-cd.controller.fullname" . }}

--- a/charts/argo-cd/templates/argocd-repo-server/poddisruptionbudget.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.repoServer.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-cd.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-cd.repoServer.fullname" . }}

--- a/charts/argo-cd/templates/argocd-server/poddisruptionbudget.yaml
+++ b/charts/argo-cd/templates/argocd-server/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-cd.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-cd.server.fullname" . }}

--- a/charts/argo-cd/templates/dex/poddisruptionbudget.yaml
+++ b/charts/argo-cd/templates/dex/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.dex.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-cd.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-cd.dex.fullname" . }}

--- a/charts/argo-cd/templates/redis/poddisruptionbudget.yaml
+++ b/charts/argo-cd/templates/redis/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.redis.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "argo-cd.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-cd.redis.fullname" . }}


### PR DESCRIPTION
This resolves https://github.com/argoproj/argo-helm/issues/1281 🙋
for argo-workflows' PR: https://github.com/argoproj/argo-helm/pull/1288

---

Signed-off-by: yu-croco <yuki.kita22@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
