### PR TITLE
fix(argo-cd): Update redis-ha dependency for haproxy CVEs

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.12.17
-digest: sha256:ad1833436031e3578165d48646c90323040fa1bc00d9235fe7ba7c67b20094ec
-generated: "2021-07-27T16:35:27.2509236-04:00"
+  version: 4.15.0
+digest: sha256:dbe1d621ce62ce8cf42eb1b60b8d35667beb8920bc3dbf7417f77081c8ed5f2d
+generated: "2022-05-21T12:28:08.0813269-04:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.4
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.6.3
+version: 4.6.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -16,9 +16,9 @@ maintainers:
   - name: seanson
 dependencies:
   - name: redis-ha
-    version: 4.12.17
+    version: 4.15.0
     repository: https://dandydeveloper.github.io/charts/
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add support for external issuers in server Certificate resource"
+    - "[Changed]: Updated redis-ha dependency chart"


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

See - https://github.com/DandyDeveloper/charts/commit/295dc64ff4d7d59ed1dca3c3b447bf909480ee19

argocd chart is using an older `redis-ha` dependency which uses `haproxy:2.0.4` image/
`haproxy:2.0.4` has several critical CVEs.  This PR updates to the latest `redis-ha` which uses a more recent haproxy image.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#versioning)
* [X ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#documentation)
* [X ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md#changelog).
* [X ] Any new values are backwards compatible and/or have sensible default.
* [X ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo).
* [X ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `master`. They are not published on branches.
