### PR TITLE
fix: chart-testing defaults to `master`, set it to `main` now

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -2,6 +2,7 @@
 # Don't add the 'debug' attribute, otherwise the workflow won't work anymore
 # Only Used for the CT Install Stage
 remote: origin
+target-branch: main
 chart-dirs:
   - charts
 chart-repos:

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -2,6 +2,7 @@
 # Don't add the 'debug' attribute, otherwise the workflow won't work anymore
 # Only Used for the CT Lint Stage
 remote: origin
+target-branch: main
 chart-dirs:
   - charts
 chart-repos:


### PR DESCRIPTION
Related to the recent default branch renaming #1194 / #1292

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/main/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
