### PR TITLE
chore: Add labeler action to automate PR labeling

### DIFF
--- a/.github/configs/labeler.yaml
+++ b/.github/configs/labeler.yaml
@@ -1,0 +1,14 @@
+argo-cd:
+  - charts/argo-cd/**/*
+
+argo-events:
+  - charts/argo-events/**/*
+
+argo-rollouts:
+  - charts/argo-rollouts/**/*
+
+argo-workflows:
+  - charts/argo-workflows/**/*
+
+argocd-image-updater:
+  - charts/argocd-image-updater/**/*

--- a/.github/workflows/pr-sizing.yml
+++ b/.github/workflows/pr-sizing.yml
@@ -1,10 +1,24 @@
 ## Reference: https://github.com/pascalgn/size-label-action
 ---
-name: 'PR Size'
+name: 'PR Labeling'
 on: 
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          configuration-path: ".github/configs/labeler.yaml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true
+
   size-label:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Let's automate some "triage" work here:
![grafik](https://user-images.githubusercontent.com/7290987/170473418-3015b088-7741-4e80-9680-556848f3a2c0.png)
-> Tested it in a fork

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/main/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
