### PR TITLE
fix(argo-cd): argo-cd notifications config map & secret names

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.4
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.8.2
+version: 4.8.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support separate imagePullSecrets"
+    - "[Fixed]: change default notifications config map name to argocd-notifications-cm"
+    - "[Fixed]: change default notifications secret name to argocd-notifications-secret"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -254,7 +254,7 @@ Create the name of the notifications controller secret to use
 */}}
 {{- define "argo-cd.notifications.secretName" -}}
 {{- if .Values.notifications.secret.create -}}
-    {{ default (printf "%s-secret" (include "argo-cd.notifications.fullname" .)) .Values.notifications.secret.name }}
+    {{ default "argocd-notifications-secret" .Values.notifications.secret.name }}
 {{- else -}}
     {{ default "argocd-notifications-secret" .Values.notifications.secret.name }}
 {{- end -}}
@@ -265,7 +265,7 @@ Create the name of the configmap to use
 */}}
 {{- define "argo-cd.notifications.configMapName" -}}
 {{- if .Values.notifications.cm.create -}}
-    {{ default (printf "%s-cm" (include "argo-cd.notifications.fullname" .)) .Values.notifications.cm.name }}
+    {{ default "argocd-notifications-cm" .Values.notifications.cm.name }}
 {{- else -}}
     {{ default "argocd-notifications-cm" .Values.notifications.cm.name }}
 {{- end -}}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2212,7 +2212,7 @@ notifications:
     annotations: {}
 
     # -- The name of the secret to use.
-    ## If not set and create is true, the default name 'argocd-notifications-secret' is used
+    ## If not set the default name 'argocd-notifications-secret' is used
     name: ""
 
     # -- Generic key:value pairs to be inserted into the secret
@@ -2325,7 +2325,7 @@ notifications:
     create: true
 
     # -- The name of the config map to use.
-    ## If not set and create is true, the default name 'argocd-notifications-cm' is used
+    ## If not set the default name 'argocd-notifications-cm' is used
     name: ""
 
   # -- Contains centrally managed global application subscriptions


### PR DESCRIPTION
The notifications controller is hard coded to look for argocd-notifications-secret and argocd-notifications-cm. Unless this changes I think the sane default should be `argocd-notifications-cm` & `argocd-notifications-secret`

fixes: #1187


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/main/community#contributing-to-argo).
* [ ] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
