### PR TITLE
feat: add chart version input on bug report to help investigation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -30,7 +30,7 @@ body:
   attributes:
     label: Helm chart version
     description: Helm chart version that you encounterd problem.
-    placeholder: ex. 0.16.2
+    placeholder: e.g. 0.16.2
   validations:
     required: true
 
@@ -38,7 +38,7 @@ body:
   attributes:
     label: App version
     description: App version that you encounterd problem.
-    placeholder: ex. v3.3.6
+    placeholder: e.g. v3.3.6
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -29,7 +29,7 @@ body:
 - type: input
   attributes:
     label: Helm chart version
-    description: Helm chart version that you encounterd problem.
+    description: Version of the Helm chart this issue relates to
     placeholder: e.g. 0.16.2
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -26,6 +26,22 @@ body:
   validations:
     required: true
 
+- type: input
+  attributes:
+    label: Helm chart version
+    description: Helm chart version that you encounterd problem.
+    placeholder: ex. 0.16.2
+  validations:
+    required: true
+
+- type: input
+  attributes:
+    label: App version
+    description: App version that you encounterd problem.
+    placeholder: ex. v3.3.6
+  validations:
+    required: true
+
 - type: textarea
   attributes:
     label: To Reproduce

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -34,14 +34,6 @@ body:
   validations:
     required: true
 
-- type: input
-  attributes:
-    label: App version
-    description: App version that you encounterd problem.
-    placeholder: e.g. v3.3.6
-  validations:
-    required: true
-
 - type: textarea
   attributes:
     label: To Reproduce


### PR DESCRIPTION
On issues, the report of `helm chart version`  will help us to investigate more efficiently.
So I added the input form for them. 🙋 

---

Signed-off-by: yu-croco <yuki.kita22@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/main/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
