### PR TITLE
feat(argo-cd): Add appHardResyncPeriod option for controller

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.3.5
+version: 5.3.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Redis HA to 4.22.1
+    - "[Added]: Add appHardResyncPeriod option for application controller"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -380,6 +380,7 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
+| controller.args.appHardResyncPeriod | string | `"0"` | define the application controller `--app-hard-resync` |
 | controller.args.appResyncPeriod | string | `"180"` | define the application controller `--app-resync` |
 | controller.args.operationProcessors | string | `"10"` | define the application controller `--operation-processors` |
 | controller.args.repoServerTimeoutSeconds | string | `"60"` | define the application controller `--repo-server-timeout-seconds` |

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -44,6 +44,8 @@ spec:
         - {{ .Values.controller.args.operationProcessors | quote }}
         - --app-resync
         - {{ .Values.controller.args.appResyncPeriod | quote }}
+        - --app-hard-resync
+        - {{ .Values.controller.args.appHardResyncPeriod | quote }}
         - --self-heal-timeout-seconds
         - {{ .Values.controller.args.selfHealTimeout | quote }}
         - --repo-server

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -128,6 +128,8 @@ controller:
     statusProcessors: "20"
     # -- define the application controller `--operation-processors`
     operationProcessors: "10"
+    # -- define the application controller `--app-hard-resync`
+    appHardResyncPeriod: "0"
     # -- define the application controller `--app-resync`
     appResyncPeriod: "180"
     # -- define the application controller `--self-heal-timeout-seconds`


### PR DESCRIPTION
Base on this PR upstream https://github.com/argoproj/argo-cd/pull/8928 we can
now provide a hard resync value to the ArgoCD Application Controller

Signed-off-by: jmeridth <jmeridth@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/main/community#contributing-to-argo).
* [x] My build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
