### PR TITLE
fix(argo-cd): Extend K8s RBAC when using UI exec feature

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.0
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.9.0
+version: 4.9.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,8 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update Argo CD to v2.4.0"
-    - "[Added]: Specify logs RBAC enforcement config in server"
-    - "[Changed]: Remove ksonnet and helm 2 support from Application and applicationSet CRDs"
-    - "[Changed]: Use applicationset binary on the upstream image"
-    - "[Changed]: Upgrade redis to 7.0.0"
+    - "[Fixed]: Extend K8s RBAC when using UI exec feature"

--- a/charts/argo-cd/templates/argocd-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrole.yaml
@@ -27,4 +27,12 @@ rules:
       - pods/log
     verbs:
       - get
+  {{- if eq (index .Values.server.config "exec.enabled") "true" }}
+  - apiGroups:
+    - ""
+    resources:
+    - pods/exec
+    verbs:
+    - create
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1231,6 +1231,10 @@ server:
     # Ref: https://argo-cd.readthedocs.io/en/latest/operator-manual/upgrading/2.3-2.4/#enable-logs-rbac-enforcement
     server.rbac.log.enforce.enable: "false"
 
+    # exec.enabled indicates whether the UI exec feature is enabled. It is disabled by default.
+    # Ref: https://argo-cd.readthedocs.io/en/latest/operator-manual/rbac/#exec-resource
+    exec.enabled: "false"
+
     # DEPRECATED: Please instead use configs.credentialTemplates and configs.repositories
     # repositories: |
     #   - url: git@github.com:group/repo.git


### PR DESCRIPTION
To use the new exec feature, RBAC of argocd-server needs to be extended with:
```yaml
  - apiGroups:
    - ""
    resources:
    - pods/exec
    verbs:
    - create
```
Ref: https://argo-cd.readthedocs.io/en/latest/operator-manual/rbac/#exec-resource

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
