### PR TITLE
fix(argo-cd): fix argo-cd notifications resource names in role

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.2
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.9.6
+version: 4.9.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support clusterResourceBlacklist"
+    - "[Fixed]: fix ArgoCD notifications config map name in role"
+    - "[Fixed]: fix ArgoCD notifications secret name in role"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.2
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.9.8
+version: 4.9.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-notifications/role.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/role.yaml
@@ -28,7 +28,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - {{ template "argo-cd.notifications.fullname" . }}-cm
+  - {{ include "argo-cd.notifications.configMapName" . }}
   resources:
   - configmaps
   verbs:
@@ -36,7 +36,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - {{ template "argo-cd.notifications.fullname" . }}-secret
+  - {{ include "argo-cd.notifications.secretName" . }}
   resources:
   - secrets
   verbs:


### PR DESCRIPTION
Currently, the ArgoCD notification controller doesn't have access to the config map and the secret when these are provided externally and not created from within the chart. This is due to the incorrect resources named in the role.

Let me know if there is any feedback or what is missing to move this PR forward.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
