### PR TITLE
chore(github): Add new maintainer for argo-events

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1 @mkilchhofer @yu-croco
 
 # Argo Events
-/charts/argo-events/ @jbehling @VaibhavPage 
+/charts/argo-events/ @jbehling @VaibhavPage @pdrastil
 
 # Argo Rollouts
-/charts/argo-rollouts/ 
+/charts/argo-rollouts/


### PR DESCRIPTION
Add new maintainer for Argo Events chart

Signed-off-by: Petr Drastil <petr.drastil@gmail.com>
