### PR TITLE
feat(argo-cd): Upgrade argocd redis-ha dependency

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.16.0
-digest: sha256:fa6a784ee32cc11fbc1bbbbaafcb179e447bc984e898ae35a1cd4408dbed7ccb
-generated: "2022-05-25T11:44:28.53802+02:00"
+  version: 4.16.1
+digest: sha256:83d33cc45a9abc134f4de4bbe6b0036196bd8e153ee7392efdf3a1407698078e
+generated: "2022-06-28T09:30:44.5453445-04:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.9.9
+version: 4.9.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -16,9 +16,9 @@ maintainers:
   - name: seanson
 dependencies:
   - name: redis-ha
-    version: 4.16.0
+    version: 4.16.1
     repository: https://dandydeveloper.github.io/charts/
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - [Changed]: Update to app version 2.4.3"
+    - [Changed]: Update redis-ha dependency for cve mitigation"


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

Update redis-ha dependency to use a newer version of haproxy docker container
See - https://github.com/DandyDeveloper/charts/pull/196
_haproxy 2.4.9 has 53 CVEs, 8 of them critical which this will help mitigate_

**Why this is needed for argocd:**
Even though the argocd chart now supports overriding the haproxy image tag it will not work without this change.
In the redis-ha template the haproxy configuration has `option http-use-htx` enabled which is deprecated.  Overriding the image tag will cause haproxy to not start due to a configuration error.  
This PR is required to use newer versions of the haproxy image.  It removes the deprecated (and default) `option http-use-htx` which will allow argocd users to patch their own newer versions of argocd if desired.
(details in the linked PR)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
