### PR TITLE
feat(argo-cd): bump redis-ha dependency to 4.17.1

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.16.1
-digest: sha256:83d33cc45a9abc134f4de4bbe6b0036196bd8e153ee7392efdf3a1407698078e
-generated: "2022-06-28T09:30:44.5453445-04:00"
+  version: 4.17.1
+digest: sha256:eecc8c4bee9af2f12aa6c7e6d0d76c87a8c0b06aa3f2af8405578c4725a5f501
+generated: "2022-06-29T14:57:19.381444853+02:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.3
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 4.9.10
+version: 4.9.11
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -16,9 +16,9 @@ maintainers:
   - name: seanson
 dependencies:
   - name: redis-ha
-    version: 4.16.1
+    version: 4.17.1
     repository: https://dandydeveloper.github.io/charts/
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - [Changed]: Update redis-ha dependency for cve mitigation"
+    - [Changed]: Update redis-ha dependency for better configuration options


### PR DESCRIPTION
Upgrade redis-ha to bring additional configuration parameters

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
