### PR TITLE
chore(argo-cd): Add jmeridth to argo-cd in CODEOWNERS to help with PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 /charts/argo-workflows/ @stefansedich @paguos @vladlosev @yann-soubeyrand @jmeridth @yu-croco
 
 # Argo CD
-/charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1 @mkilchhofer @yu-croco
+/charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1 @mkilchhofer @yu-croco @jmeridth
 
 # Argo Events
 /charts/argo-events/ @jbehling @VaibhavPage @pdrastil


### PR DESCRIPTION
I'm already helping with argo-workflows helm chart PRs and would like to help with argo-cd also.  We're actively using it so it'll help us also.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
