### PR TITLE
feat(argo-workflows): add values, secret and configmap for static token auth

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.13
+version: 0.16.14
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.9
+version: 0.16.8
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.8
+version: 0.16.9
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.11
+version: 0.16.12
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.10
+version: 0.16.11
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.12
+version: 0.16.13
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.8
+version: 0.16.10
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.7
+version: 0.16.8
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.14
+version: 0.16.15
 appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.6
-appVersion: v3.3.8
+version: 0.16.7
+appVersion: v3.3.8 # TODO: switch to 3.3.9 when available
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version v3.3.8"
+    - "[Feat]: Static token authentication secret and config"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -152,6 +152,7 @@ Fields to note:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | server.affinity | object | `{}` | Assign custom [affinity] rules |
+| server.authTokenSecret | object | `{}` | secret for token authentication this is required if using --auth-mode sso to the server command line. |
 | server.baseHref | string | `"/"` | Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. |
 | server.clusterWorkflowTemplates.enableEditing | bool | `true` | Give the server permissions to edit ClusterWorkflowTemplates. |
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -152,7 +152,9 @@ Fields to note:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | server.affinity | object | `{}` | Assign custom [affinity] rules |
-| server.authTokenSecret | object | `{"create":true,"enabled":false,"name":"{{ include \"argo-workflows.fullname\" . }}-static-token"}` | secret for token authentication this is required if using --auth-mode sso to the server command line. |
+| server.authTokenSecret.create | bool | `true` | Auto create secret |
+| server.authTokenSecret.enabled | bool | `false` | Enable secret for token authentication this is required if using `--auth-mode sso` to the server command line. |
+| server.authTokenSecret.name | string | `"{{ include \"argo-workflows.fullname\" . }}-static-token"` | Default secret name |
 | server.baseHref | string | `"/"` | Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. |
 | server.clusterWorkflowTemplates.enableEditing | bool | `true` | Give the server permissions to edit ClusterWorkflowTemplates. |
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -152,7 +152,7 @@ Fields to note:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | server.affinity | object | `{}` | Assign custom [affinity] rules |
-| server.authTokenSecret | object | `{}` | secret for token authentication this is required if using --auth-mode sso to the server command line. |
+| server.authTokenSecret | object | `{"create":true,"enabled":false,"name":"{{ include \"argo-workflows.fullname\" . }}-static-token"}` | secret for token authentication this is required if using --auth-mode sso to the server command line. |
 | server.baseHref | string | `"/"` | Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. |
 | server.clusterWorkflowTemplates.enableEditing | bool | `true` | Give the server permissions to edit ClusterWorkflowTemplates. |
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -48,6 +48,7 @@ rules:
   - workflows/finalizers
   - workflowtasksets
   - workflowtasksets/finalizers
+  - workflowartifactgctasks
   verbs:
   - get
   - list

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -13,11 +13,6 @@ data:
     instanceID: {{ .Values.controller.instanceID.explicitID }}
       {{- end }}
     {{- end }}
-    containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
-    {{- with .Values.controller.containerRuntimeExecutors }}
-    containerRuntimeExecutors:
-    {{- toYaml . | nindent 6 }}
-    {{- end }}
     {{- if .Values.controller.parallelism }}
     parallelism: {{ .Values.controller.parallelism }}
     {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -95,13 +95,13 @@ data:
       enabled: {{ .Values.controller.metricsConfig.enabled }}
       path: {{ .Values.controller.metricsConfig.path }}
       port: {{ .Values.controller.metricsConfig.port }}
-      {{ with .Values.controller.metricsConfig.metricsTTL }}
+      {{- with .Values.controller.metricsConfig.metricsTTL }}
       metricsTTL: {{ . }}
       {{- end }}
-      {{ with .Values.controller.metricsConfig.ignoreErrors }}
+      {{- with .Values.controller.metricsConfig.ignoreErrors }}
       ignoreErrors: {{ . }}
       {{- end }}
-      {{ with .Values.controller.metricsConfig.secure }}
+      {{- with .Values.controller.metricsConfig.secure }}
       secure: {{ . }}
       {{- end }}
     {{- end }}
@@ -110,13 +110,13 @@ data:
       enabled: {{ .Values.controller.telemetryConfig.enabled }}
       path: {{ .Values.controller.telemetryConfig.path }}
       port: {{ .Values.controller.telemetryConfig.port }}
-      {{ with .Values.controller.telemetryConfig.metricsTTL }}
+      {{- with .Values.controller.telemetryConfig.metricsTTL }}
       metricsTTL: {{ . }}
       {{- end }}
-      {{ with .Values.controller.telemetryConfig.ignoreErrors }}
+      {{- with .Values.controller.telemetryConfig.ignoreErrors }}
       ignoreErrors: {{ . }}
       {{- end }}
-      {{ with .Values.controller.telemetryConfig.secure }}
+      {{- with .Values.controller.telemetryConfig.secure }}
       secure: {{ . }}
       {{- end }}
     {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -130,7 +130,8 @@ data:
     sso: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if .Values.server.authTokenSecret.enabled }}
-    tokenSecretName: {{ tpl .Values.server.authTokenSecret.name . }}
+    token:
+      secretName: {{ tpl .Values.server.authTokenSecret.name . }}
     {{- end }}
     {{- with .Values.controller.workflowRestrictions }}
     workflowRestrictions: {{- toYaml . | nindent 6 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -92,10 +92,22 @@ data:
     {{- end}}
     {{- if .Values.controller.metricsConfig.enabled }}
     metricsConfig:
-{{ toYaml .Values.controller.metricsConfig | indent 6}}{{- end }}
+      - enabled: {{ .Values.controller.metricsConfig.enabled }}
+      - path: {{ .Values.controller.metricsConfig.path }}
+      - port: {{ .Values.controller.metricsConfig.port }}
+      - metricsTTL: {{ .Values.controller.metricsConfig.metricsTTL }}
+      - ignoreErrors: {{ .Values.controller.metricsConfig.ignoreErrors | default true }}
+      - secure: {{ .Values.controller.metricsConfig.secure | default false }}
+    {{- end }}
     {{- if .Values.controller.telemetryConfig.enabled }}
     telemetryConfig:
-{{ toYaml .Values.controller.telemetryConfig | indent 6}}{{- end }}
+      - enabled: {{ .Values.controller.telemetryConfig.enabled }}
+      - path: {{ .Values.controller.telemetryConfig.path }}
+      - port: {{ .Values.controller.telemetryConfig.port }}
+      - metricsTTL: {{ .Values.controller.telemetryConfig.metricsTTL }}
+      - ignoreErrors: {{ .Values.controller.telemetryConfig.ignoreErrors | default true }}
+      - secure: {{ .Values.controller.telemetryConfig.secure | default false }}
+    {{- end }}
     {{- if .Values.controller.persistence }}
     persistence:
 {{ toYaml .Values.controller.persistence | indent 6 }}{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -95,18 +95,30 @@ data:
       enabled: {{ .Values.controller.metricsConfig.enabled }}
       path: {{ .Values.controller.metricsConfig.path }}
       port: {{ .Values.controller.metricsConfig.port }}
-      metricsTTL: {{ .Values.controller.metricsConfig.metricsTTL }}
-      ignoreErrors: {{ .Values.controller.metricsConfig.ignoreErrors | default true }}
-      secure: {{ .Values.controller.metricsConfig.secure | default false }}
+      {{ with .Values.controller.metricsConfig.metricsTTL }}
+      metricsTTL: {{ . }}
+      {{- end }}
+      {{ with .Values.controller.metricsConfig.ignoreErrors }}
+      ignoreErrors: {{ . }}
+      {{- end }}
+      {{ with .Values.controller.metricsConfig.secure }}
+      secure: {{ . }}
+      {{- end }}
     {{- end }}
     {{- if .Values.controller.telemetryConfig.enabled }}
     telemetryConfig:
       enabled: {{ .Values.controller.telemetryConfig.enabled }}
       path: {{ .Values.controller.telemetryConfig.path }}
       port: {{ .Values.controller.telemetryConfig.port }}
-      metricsTTL: {{ .Values.controller.telemetryConfig.metricsTTL }}
-      ignoreErrors: {{ .Values.controller.telemetryConfig.ignoreErrors | default true }}
-      secure: {{ .Values.controller.telemetryConfig.secure | default false }}
+      {{ with .Values.controller.telemetryConfig.metricsTTL }}
+      metricsTTL: {{ . }}
+      {{- end }}
+      {{ with .Values.controller.telemetryConfig.ignoreErrors }}
+      ignoreErrors: {{ . }}
+      {{- end }}
+      {{ with .Values.controller.telemetryConfig.secure }}
+      secure: {{ . }}
+      {{- end }}
     {{- end }}
     {{- if .Values.controller.persistence }}
     persistence:

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -92,21 +92,21 @@ data:
     {{- end}}
     {{- if .Values.controller.metricsConfig.enabled }}
     metricsConfig:
-      - enabled: {{ .Values.controller.metricsConfig.enabled }}
-      - path: {{ .Values.controller.metricsConfig.path }}
-      - port: {{ .Values.controller.metricsConfig.port }}
-      - metricsTTL: {{ .Values.controller.metricsConfig.metricsTTL }}
-      - ignoreErrors: {{ .Values.controller.metricsConfig.ignoreErrors | default true }}
-      - secure: {{ .Values.controller.metricsConfig.secure | default false }}
+      enabled: {{ .Values.controller.metricsConfig.enabled }}
+      path: {{ .Values.controller.metricsConfig.path }}
+      port: {{ .Values.controller.metricsConfig.port }}
+      metricsTTL: {{ .Values.controller.metricsConfig.metricsTTL }}
+      ignoreErrors: {{ .Values.controller.metricsConfig.ignoreErrors | default true }}
+      secure: {{ .Values.controller.metricsConfig.secure | default false }}
     {{- end }}
     {{- if .Values.controller.telemetryConfig.enabled }}
     telemetryConfig:
-      - enabled: {{ .Values.controller.telemetryConfig.enabled }}
-      - path: {{ .Values.controller.telemetryConfig.path }}
-      - port: {{ .Values.controller.telemetryConfig.port }}
-      - metricsTTL: {{ .Values.controller.telemetryConfig.metricsTTL }}
-      - ignoreErrors: {{ .Values.controller.telemetryConfig.ignoreErrors | default true }}
-      - secure: {{ .Values.controller.telemetryConfig.secure | default false }}
+      enabled: {{ .Values.controller.telemetryConfig.enabled }}
+      path: {{ .Values.controller.telemetryConfig.path }}
+      port: {{ .Values.controller.telemetryConfig.port }}
+      metricsTTL: {{ .Values.controller.telemetryConfig.metricsTTL }}
+      ignoreErrors: {{ .Values.controller.telemetryConfig.ignoreErrors | default true }}
+      secure: {{ .Values.controller.telemetryConfig.secure | default false }}
     {{- end }}
     {{- if .Values.controller.persistence }}
     persistence:

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -110,6 +110,9 @@ data:
     {{- with .Values.server.sso }}
     sso: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.server.staticTokenSecret }}
+    tokenSecretName: {{ .Values.server.authTokenSecret.name }}
+    {{- end }}
     {{- with .Values.controller.workflowRestrictions }}
     workflowRestrictions: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -110,8 +110,8 @@ data:
     {{- with .Values.server.sso }}
     sso: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.server.staticTokenSecret }}
-    tokenSecretName: {{ .Values.server.authTokenSecret.name }}
+    {{- if .Values.server.authTokenSecret.enabled }}
+    tokenSecretName: {{ tpl .Values.server.authTokenSecret.name . }}
     {{- end }}
     {{- with .Values.controller.workflowRestrictions }}
     workflowRestrictions: {{- toYaml . | nindent 6 }}

--- a/charts/argo-workflows/templates/server/server-token-secret.yaml
+++ b/charts/argo-workflows/templates/server/server-token-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.server.authTokenSecret.enabled .Values.server.authTokenSecret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ tpl .Values.server.authTokenSecret.name . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+type: Opaque
+{{- with .Values.server.authTokenSecret.token }}
+data: 
+  token: {{ . | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -80,6 +80,12 @@ controller:
     path: /metrics
     # -- Port is the port where metrics are emitted
     port: 9090
+    # -- Container metrics port name
+    portName: metrics
+    # -- Service metrics port
+    servicePort: 8080
+    # -- Service metrics port name
+    servicePortName: metrics
   # -- the controller container's securityContext
   securityContext:
     readOnlyRootFilesystem: true
@@ -134,6 +140,10 @@ controller:
     path: /telemetry
     # -- telemetry container port
     port: 8081
+    # -- telemetry service port
+    servicePort: 8081
+    # -- telemetry service port name
+    servicePortName: telemetry
   serviceMonitor:
     # -- Enable a prometheus ServiceMonitor
     enabled: false

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -80,12 +80,6 @@ controller:
     path: /metrics
     # -- Port is the port where metrics are emitted
     port: 9090
-    # -- Container metrics port name
-    portName: metrics
-    # -- Service metrics port
-    servicePort: 8080
-    # -- Service metrics port name
-    servicePortName: metrics
   # -- the controller container's securityContext
   securityContext:
     readOnlyRootFilesystem: true
@@ -140,10 +134,6 @@ controller:
     path: /telemetry
     # -- telemetry container port
     port: 8081
-    # -- telemetry service port
-    servicePort: 8081
-    # -- telemetry service port name
-    servicePortName: telemetry
   serviceMonitor:
     # -- Enable a prometheus ServiceMonitor
     enabled: false

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -480,11 +480,12 @@ server:
     # - groups
   # -- secret for token authentication
   # this is required if using --auth-mode sso to the server command line.
-  authTokenSecret: {}
+  authTokenSecret:
+    enabled: false
     ## Auto create secret
-    # create: true
+    create: true
     ## Default secret name
-    # name: argo-workflows-token
+    name: '{{ include "argo-workflows.fullname" . }}-static-token'
     ## Set token from value (unsafe)
     # token: test-token
 

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -478,13 +478,14 @@ server:
     ## decisions.
     # scopes:
     # - groups
-  # -- secret for token authentication
-  # this is required if using --auth-mode sso to the server command line.
+  ## secret for token authentication
   authTokenSecret:
+    # -- Enable secret for token authentication
+    # this is required if using `--auth-mode sso` to the server command line.
     enabled: false
-    ## Auto create secret
+    # -- Auto create secret
     create: true
-    ## Default secret name
+    # -- Default secret name
     name: '{{ include "argo-workflows.fullname" . }}-static-token'
     ## Set token from value (unsafe)
     # token: test-token

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -478,6 +478,15 @@ server:
     ## decisions.
     # scopes:
     # - groups
+  # -- secret for token authentication
+  # this is required if using --auth-mode sso to the server command line.
+  authTokenSecret: {}
+    ## Auto create secret
+    # create: true
+    ## Default secret name
+    # name: argo-workflows-token
+    ## Set token from value (unsafe)
+    # token: test-token
 
   # -- Extra containers to be added to the server deployment
   extraContainers: []


### PR DESCRIPTION
Signed-off-by: Loric ANDRE <loric.a@padoa-group.com>

Linked to https://github.com/argoproj/argo-workflows/pull/9086


This requires that PR to be merged to be fully fonctional as this implements the k8s part of a new authentication mode for argo-workflow (--auth-mode token using a static token from a kube secret).

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
