### PR TITLE
fix(argo-events): Fix selectorLabels of ServiceMonitor

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.1
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.2
+version: 2.0.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -16,5 +16,4 @@ maintainers:
   - name: whynowy
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Argo events controller to v1.7.1"
-    - "[Changed]: Upgrade sample configuration for NATs images"
+    - "[Fixed]: Fixed selectorLabel of ServiceMonitor that doesn't match metrics Service"

--- a/charts/argo-events/templates/argo-events-controller/servicemonitor.yaml
+++ b/charts/argo-events/templates/argo-events-controller/servicemonitor.yaml
@@ -34,5 +34,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "argo-events.selectorLabels" (dict "context" . "component" .Values.controller.name "name" "metrics") | nindent 6 }}
+      {{- include "argo-events.selectorLabels" (dict "context" . "component" .Values.controller.name "name" (printf "%s-metrics" .Values.controller.name)) | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
[selectorLabels of controller's ServiceMonitor ](https://github.com/argoproj/argo-helm/blob/main/charts/argo-events/templates/argo-events-controller/servicemonitor.yaml#L37) should same as [the labels of metrics Service](https://github.com/argoproj/argo-helm/blob/main/charts/argo-events/templates/argo-events-controller/service.yaml#L13), but it isn't.


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
