### PR TITLE
feat(argo-workflows): Assign common labels to some resources

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.16.6
+version: 0.16.7
 appVersion: v3.3.8
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
@@ -15,4 +15,4 @@ maintainers:
   - name: benjaminws
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version v3.3.8"
+    - "[Changed]: Assign common labels to some resources"

--- a/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "argo-workflows.fullname" . }}-view
   labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
@@ -29,6 +30,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "argo-workflows.fullname" . }}-edit
   labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
@@ -59,6 +61,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "argo-workflows.fullname" . }}-admin
   labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -170,6 +170,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}-cluster-template
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:
 - apiGroups:
   - argoproj.io

--- a/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.controllerServiceAccountName" . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
   {{ with .Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml .| nindent 4 }}

--- a/charts/argo-workflows/templates/controller/workflow-rb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-rb.yaml
@@ -5,6 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "argo-workflows.fullname" $ }}-workflow
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
     {{- with $namespace }}
   namespace: {{ . }}
     {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -5,6 +5,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "argo-workflows.fullname" $ }}-workflow
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
     {{- with $namespace }}
   namespace: {{ . }}
     {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-sa.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $.Values.workflow.serviceAccount.name }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
     {{- with $namespace }}
   namespace: {{ . }}
     {{- end }}

--- a/charts/argo-workflows/templates/server/server-sa.yaml
+++ b/charts/argo-workflows/templates/server/server-sa.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.serverServiceAccountName" . }}
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
   {{- with .Values.server.serviceAccount.annotations  }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Since some resources were not given common labels, I have tried to give them.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
