### PR TITLE
ci(github): Cleanup unused chart-repos

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -6,11 +6,7 @@ target-branch: main
 chart-dirs:
   - charts
 chart-repos:
-  - argo=https://argoproj.github.io/argo-helm
-  - minio=https://helm.min.io/
   - dandydeveloper=https://dandydeveloper.github.io/charts/
-  - stable=https://charts.helm.sh/stable
-  - incubator=https://charts.helm.sh/incubator
 helm-extra-args: "--timeout 600s"  
 validate-chart-schema: false
 validate-maintainers: true

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -6,11 +6,7 @@ target-branch: main
 chart-dirs:
   - charts
 chart-repos:
-  - argo=https://argoproj.github.io/argo-helm
-  - minio=https://helm.min.io/
   - dandydeveloper=https://dandydeveloper.github.io/charts/
-  - stable=https://charts.helm.sh/stable
-  - incubator=https://charts.helm.sh/incubator
 helm-extra-args: "--timeout 600s"  
 validate-chart-schema: false
 validate-maintainers: true

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,5 +1,4 @@
 ## Reference: https://github.com/helm/chart-testing-action
----
 name: Linting and Testing
 on: pull_request
 jobs: 

--- a/.github/workflows/pr-sizing.yml
+++ b/.github/workflows/pr-sizing.yml
@@ -1,5 +1,4 @@
 ## Reference: https://github.com/pascalgn/size-label-action
----
 name: 'PR Labeling'
 on: 
   pull_request_target:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
----
+## Reference: https://github.com/helm/chart-releaser-action
 name: Chart Publish
 on:
   push:
     branches:
       - main
-      - rewrite-build
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,11 +19,8 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add argo https://argoproj.github.io/argo-helm
-          helm repo add minio https://helm.min.io/
           helm repo add dandydeveloper https://dandydeveloper.github.io/charts/
-          helm repo add stable https://charts.helm.sh/stable
-          helm repo add incubator https://charts.helm.sh/incubator
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
I always wondered why we have configured the two EOL repos:
- https://charts.helm.sh/stable
- https://charts.helm.sh/incubator

So let's remove all currently unused repos.

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
