### PR TITLE
chore(github): Enable GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,9 @@
 blank_issues_enabled: false
 
 contact_links:
+  - name: Ask a question
+    url: https://github.com/argoproj/argo-helm/discussions/new
+    about: Ask a question or start a discussion about our community Helm Charts
   - name: Chat on Slack
     url: https://argoproj.github.io/community/join-slack
     about: Maybe chatting with the community can help


### PR DESCRIPTION
Let's enable GitHub Discussions and place a link on the "create issue" page.