### PR TITLE
chore(github): add argocd-apps on pr-title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,6 +24,7 @@ jobs:
             argo-rollouts
             argo-workflows
             argocd-image-updater
+            argocd-apps
             github
           # Configure that a scope must always be provided.
           requireScope: true


### PR DESCRIPTION
In order to pass CI on https://github.com/argoproj/argo-helm/pull/1356, https://github.com/argoproj/argo-helm/pull/1356#issuecomment-1172845108 , I added `argocd-apps` on pr-title. 🙋 
*It looks that pr-title should be configures before using the new title 👀 

---

Signed-off-by: yu-croco <yu.croco@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
