### PR TITLE
fix(argo-cd): Removal of duplicate mapping key annotations in crds

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.3.1
+version: 5.3.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Env variable ARGOCD_CONTROLLER_REPLICAS is now automatically set by replica count"
+    - "[Fixed]: Removal of duplicate mapping key annotations in crds"

--- a/charts/argo-cd/templates/crds/crd-applicationset.yaml
+++ b/charts/argo-cd/templates/crds/crd-applicationset.yaml
@@ -9,11 +9,10 @@ metadata:
     {{- with .Values.crds.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    controller-gen.kubebuilder.io/version: v0.3.0
   labels:
     app.kubernetes.io/name: applicationsets.argoproj.io
     app.kubernetes.io/part-of: argocd
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
   name: applicationsets.argoproj.io
 spec:
   group: argoproj.io

--- a/charts/argo-cd/templates/crds/crd-extension.yaml
+++ b/charts/argo-cd/templates/crds/crd-extension.yaml
@@ -9,11 +9,10 @@ metadata:
     {{- with .Values.crds.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+    controller-gen.kubebuilder.io/version: v0.4.1
   labels:
     app.kubernetes.io/name: argocdextensions.argoproj.io
     app.kubernetes.io/part-of: argocd
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
   name: argocdextensions.argoproj.io
 spec:
   group: argoproj.io


### PR DESCRIPTION
Signed-off-by: Jan Fuhrer <janfuhrer@mailbox.org>

**Problem**
If you install argocd with fluxcd, following error occurs:

```bash
Last Helm logs:
  Warning  error  8m41s (x8 over 10m)  helm-controller  reconciliation failed: Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 12: mapping key "annotations" already defined at line 5
```

Tell me If I can correct anything.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
