### PR TITLE
fix(argo-cd): Avoid invalid labels when image tags have digest

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.3.4
+version: 5.4.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Helm chart maintainers standardized to argoproj"
+    - "[Changed]: Avoid invalid characters in version labels"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -284,3 +284,10 @@ Return the appropriate apiVersion for pod disruption budget
 {{- print "policy/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return valid version label
+*/}}
+{{- define "argo-cd.versionLabel" -}}
+app.kubernetes.io/version: {{ regexReplaceAll "[^-A-Za-z0-9.]" . "-" | trunc 63 | quote }}
+{{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-cd.controller.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.controller.image.tag) }}
 spec:
   selector:
     matchLabels:
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.controller.image.tag) }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.controller.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-cd.applicationSet.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.applicationSet.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.applicationSet.image.tag) }}
 spec:
   replicas: {{ .Values.applicationSet.replicaCount }}
   selector:
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.applicationSet.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.applicationSet.image.tag) }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.applicationSet.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-cd.notifications.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.notifications.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.notifications.image.tag) }}
 spec:
   strategy:
     {{- .Values.notifications.updateStrategy | toYaml | nindent 4 }}
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.notifications.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.notifications.image.tag) }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.notifications.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-cd.repoServer.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag) }}
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag) }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.repoServer.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-cd.server.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.server.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.server.image.tag) }}
 spec:
   selector:
     matchLabels:
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-cd.defaultTag" .) .Values.server.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" (default (include "argo-cd.defaultTag" .) .Values.server.image.tag) }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.server.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-cd.dex.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ .Values.dex.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" .Values.dex.image.tag }}
 spec:
   selector:
     matchLabels:
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ .Values.dex.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" .Values.dex.image.tag }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.dex.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "argo-cd.redis.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ .Values.redis.image.tag | trunc 63 | quote }}
+    {{ include "argo-cd.versionLabel" .Values.redis.image.tag }}
 spec:
   selector:
     matchLabels:
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ .Values.redis.image.tag | trunc 63 | quote }}
+        {{ include "argo-cd.versionLabel" .Values.redis.image.tag }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.redis.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This was missing from https://github.com/argoproj/argo-helm/pull/1368
to fix https://github.com/argoproj/argo-helm/issues/417.

Fix the following validation error:

> Error: failed to create resource: Deployment.apps "argocd-applicationset-controller" is invalid: [metadata.labels: Invalid value: "v2.4.4@sha256:9d78128c71e88daf7c6bb45c7c2d58ac293786fea6ae1c572": a valid label must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character (e.g. ''MyValue'',  or ''my_value'',  or ''12345'', regex used for validation is ''(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?''), spec.template.labels: Invalid value: "v2.4.4@sha256:9d78128c71e88daf7c6bb45c7c2d58ac293786fea6ae1c572": a valid label must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character (e.g. ''MyValue'',  or ''my_value'',  or ''12345'', regex used for validation is ''(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'')]

Ref: https://gitlab.com/kubitus-project/kubitus-installer/-/jobs/2922927151#L1878

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
