### PR TITLE
fix(argo-workflows): Moving CRDs to the Templates folder

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.9
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.17.1
+version: 0.17.2
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Helm chart maintainers standardized to argoproj"
+    - "[Changed]: Moved crds folder in the templates folder and added crds variable in the values.yaml file"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -15,6 +15,12 @@ A few options are:
 
 ## Usage Notes
 
+### Custom resource definitions
+
+Some users would prefer to install the CRDs _outside_ of the chart. You can disable the CRD installation of this chart by using `--set crds.install=false` when installing the chart.
+
+You can install the CRDs manually from `templates/crds` folder.
+
 ### Workflow controller
 
 This chart defaults to setting the `controller.instanceID.enabled` to `false` now, which means the deployed controller will act upon any workflow deployed to the cluster. If you would like to limit the behavior and deploy multiple workflow controllers, please use the `controller.instanceID.enabled` attribute along with one of its configuration options to set the `instanceID` of the workflow controller to be properly scoped for your needs.
@@ -42,6 +48,9 @@ Fields to note:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | createAggregateRoles | bool | `true` | Create clusterroles that extend existing clusterroles to interact with argo-cd crds |
+| crds.install  | bool  `true`  | Install and update CRDs |
+| crds.keep  | bool  `true`  | Keep CRDs on chart uninstallation |
+| crds.annotations  | object  `{}`  | Additional annotations to be added to the CRDs |
 | fullnameOverride | string | `nil` | String to fully override "argo-workflows.fullname" template |
 | images.pullPolicy | string | `"Always"` | imagePullPolicy to apply to all containers |
 | images.pullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |

--- a/charts/argo-workflows/templates/crds/argoproj.io_clusterworkflowtemplates.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_clusterworkflowtemplates.yaml
@@ -1,17 +1,26 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: workflowtasksets.argoproj.io
+  name: clusterworkflowtemplates.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
-    kind: WorkflowTaskSet
-    listKind: WorkflowTaskSetList
-    plural: workflowtasksets
+    kind: ClusterWorkflowTemplate
+    listKind: ClusterWorkflowTemplateList
+    plural: clusterworkflowtemplates
     shortNames:
-    - wfts
-    singular: workflowtaskset
-  scope: Namespaced
+    - clusterwftmpl
+    - cwft
+    singular: clusterworkflowtemplate
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:
@@ -27,15 +36,10 @@ spec:
             type: object
             x-kubernetes-map-type: atomic
             x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - spec
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+{{- end }}

--- a/charts/argo-workflows/templates/crds/argoproj.io_cronworkflows.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_cronworkflows.yaml
@@ -1,16 +1,25 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: workflowtemplates.argoproj.io
+  name: cronworkflows.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
-    kind: WorkflowTemplate
-    listKind: WorkflowTemplateList
-    plural: workflowtemplates
+    kind: CronWorkflow
+    listKind: CronWorkflowList
+    plural: cronworkflows
     shortNames:
-    - wftmpl
-    singular: workflowtemplate
+    - cwf
+    - cronwf
+    singular: cronworkflow
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -27,9 +36,14 @@ spec:
             type: object
             x-kubernetes-map-type: atomic
             x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - spec
         type: object
     served: true
     storage: true
+{{- end }}

--- a/charts/argo-workflows/templates/crds/argoproj.io_workfloweventbindings.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_workfloweventbindings.yaml
@@ -1,7 +1,15 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workfloweventbindings.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
@@ -33,3 +41,4 @@ spec:
         type: object
     served: true
     storage: true
+{{- end }}

--- a/charts/argo-workflows/templates/crds/argoproj.io_workflows.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_workflows.yaml
@@ -1,20 +1,37 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cronworkflows.argoproj.io
+  name: workflows.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
-    kind: CronWorkflow
-    listKind: CronWorkflowList
-    plural: cronworkflows
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
     shortNames:
-    - cwf
-    - cronwf
-    singular: cronworkflow
+    - wf
+    singular: workflow
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Status of the workflow
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: When the workflow was started
+      format: date-time
+      jsonPath: .status.startedAt
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -38,3 +55,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
+{{- end }}

--- a/charts/argo-workflows/templates/crds/argoproj.io_workflowtaskresults.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_workflowtaskresults.yaml
@@ -1,7 +1,15 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflowtaskresults.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
@@ -423,3 +431,4 @@ spec:
         type: object
     served: true
     storage: true
+{{- end }}

--- a/charts/argo-workflows/templates/crds/argoproj.io_workflowtasksets.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_workflowtasksets.yaml
@@ -1,29 +1,27 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: workflows.argoproj.io
+  name: workflowtasksets.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
-    kind: Workflow
-    listKind: WorkflowList
-    plural: workflows
+    kind: WorkflowTaskSet
+    listKind: WorkflowTaskSetList
+    plural: workflowtasksets
     shortNames:
-    - wf
-    singular: workflow
+    - wfts
+    singular: workflowtaskset
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Status of the workflow
-      jsonPath: .status.phase
-      name: Status
-      type: string
-    - description: When the workflow was started
-      format: date-time
-      jsonPath: .status.startedAt
-      name: Age
-      type: date
-    name: v1alpha1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -47,4 +45,6 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/argo-workflows/templates/crds/argoproj.io_workflowtemplates.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_workflowtemplates.yaml
@@ -1,18 +1,25 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterworkflowtemplates.argoproj.io
+  name: workflowtemplates.argoproj.io
+  annotations:
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: argoproj.io
   names:
-    kind: ClusterWorkflowTemplate
-    listKind: ClusterWorkflowTemplateList
-    plural: clusterworkflowtemplates
+    kind: WorkflowTemplate
+    listKind: WorkflowTemplateList
+    plural: workflowtemplates
     shortNames:
-    - clusterwftmpl
-    - cwft
-    singular: clusterworkflowtemplate
-  scope: Cluster
+    - wftmpl
+    singular: workflowtemplate
+  scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
@@ -34,3 +41,4 @@ spec:
         type: object
     served: true
     storage: true
+{{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -11,6 +11,15 @@ images:
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
 createAggregateRoles: true
 
+## Custom resource configuration
+crds:
+  # -- Install and upgrade CRDs
+  install: true
+  # -- Keep CRDs on chart uninstall
+  keep: true
+  # -- Annotations to be added to all CRDs
+  annotations: {}
+
 # -- String to partially override "argo-workflows.fullname" template
 nameOverride:
 


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

This PR is related to https://github.com/argoproj/argo-helm/issues/1430. This PR includes:
- Moving CRDs to the templates folder
- Adding `crds` variable in the `values.yaml

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
