### PR TITLE
fix(argo-cd): add automountServiceAccountToken to repoServer

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -19,4 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Remove version labels to avoid invalid characters"
+    - "[Fixed]: Template existing value automountServiceAccountToken into repo-server"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.4.0
+version: 5.4.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.repoServer.serviceAccount.automountServiceAccountToken }}
       {{- if .Values.global.securityContext }}
       securityContext: {{- toYaml .Values.global.securityContext | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Adding existing value [`repoServer.serviceAccount.automountServiceAccountToken`](https://github.com/argoproj/argo-helm/blob/71da4e98f26a222e664269fac55dde5c374915d5/charts/argo-cd/values.yaml#L1654) to its [deployment template](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-repo-server/deployment.yaml).

E.g. redis already has this key implemented in the deployment:
https://github.com/argoproj/argo-helm/blob/71da4e98f26a222e664269fac55dde5c374915d5/charts/argo-cd/templates/redis/deployment.yaml#L31

This PR will enable the usage of [Kubernetes Authentication](https://github.com/argoproj-labs/argocd-vault-plugin/blob/v1.12.0/docs/backends.md#kubernetes-authentication) within argocd-vault-plugin.


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
