### PR TITLE
fix(argo-cd): Duplicated dex init containers

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.4.2
+version: 5.4.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add priorityClassName to notifications controller"
+    - "[Fixed]: Additional initContainers are handled correctly in the dex deployment"

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: static-files
+      {{- if .Values.dex.initContainers }}
+      {{- toYaml .Values.dex.initContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Values.dex.name }}
         image: {{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}
@@ -145,10 +148,6 @@ spec:
       {{- end }}
       {{- if .Values.dex.extraVolumes }}
       {{- toYaml .Values.dex.extraVolumes | nindent 6 }}
-      {{- end }}
-      {{- if .Values.dex.initContainers }}
-      initContainers:
-      {{- toYaml .Values.dex.initContainers | nindent 6 }}
       {{- end }}
 {{- if .Values.dex.priorityClassName }}
       priorityClassName: {{ .Values.dex.priorityClassName }}


### PR DESCRIPTION
Signed-off-by: bakito <github@bakito.ch>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

This pull request fixes an issue in the dex deployment if additional init containers are defined in the values.
The current implementation adds a second initContainers section. The fix is to merge them both together.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
