### PR TITLE
feat(argo-cd): REDIS_USERNAME environment variable added automatically based on externalRedis.username

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.4.3
+version: 5.4.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Additional initContainers are handled correctly in the dex deployment"
+    - "[Added]: REDIS_USERNAME environment variable added automatically based on externalRedis.username"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -836,8 +836,9 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis credentials (must contain key `redis-password`). When it's set, the `externalRedis.password` parameter is ignored |
+| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis credentials (must contain keys `redis-username` and `redis-password`). When it's set, the `externalRedis.password` and `externalRedis.username` parameters are ignored |
 | externalRedis.host | string | `""` | External Redis server host |
+| externalRedis.username | string | `""` | External Redis username |
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |
 | externalRedis.secretAnnotations | object | `{}` | External Redis Secret annotations |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -838,10 +838,10 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 |-----|------|---------|-------------|
 | externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis credentials (must contain keys `redis-username` and `redis-password`). When it's set, the `externalRedis.password` and `externalRedis.username` parameters are ignored |
 | externalRedis.host | string | `""` | External Redis server host |
-| externalRedis.username | string | `""` | External Redis username |
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |
 | externalRedis.secretAnnotations | object | `{}` | External Redis Secret annotations |
+| externalRedis.username | string | `""` | External Redis username |
 
 ## ApplicationSet
 

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -264,7 +264,14 @@ Return the default Argo CD app version
   {{- default .Chart.AppVersion .Values.global.image.tag }}
 {{- end -}}
 
-{{- define "argo-cd.redisPasswordEnv" -}}
+{{- define "argo-cd.externalRedisEnv" -}}
+{{- if or .Values.externalRedis.username .Values.externalRedis.existingSecret -}}
+- name: REDIS_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+      key: redis-username
+{{- end -}}
 {{- if or .Values.externalRedis.password .Values.externalRedis.existingSecret -}}
 - name: REDIS_PASSWORD
   valueFrom:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -83,7 +83,7 @@ spec:
           {{- end }}
           - name: ARGOCD_CONTROLLER_REPLICAS
             value: {{ .Values.controller.replicas | quote }}
-          {{- include "argo-cd.redisPasswordEnv" . | nindent 10 }}
+          {{- include "argo-cd.externalRedisEnv" . | nindent 10 }}
         {{- with .Values.controller.envFrom }}
         envFrom:
           {{- toYaml . | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.externalRedis.password (not .Values.externalRedis.existingSecret) }}
+{{- if and (or .Values.externalRedis.username .Values.externalRedis.password) (not .Values.externalRedis.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,5 +11,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+{{-if .Values.externalRedis.username }}
+  redis-username: {{ .Values.externalRedis.username | b64enc }}
+{{- end }}
+{{-if .Values.externalRedis.password }}
   redis-password: {{ .Values.externalRedis.password | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
@@ -11,10 +11,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-{{-if .Values.externalRedis.username }}
+{{- if .Values.externalRedis.username }}
   redis-username: {{ .Values.externalRedis.username | b64enc }}
 {{- end }}
-{{-if .Values.externalRedis.password }}
+{{- if .Values.externalRedis.password }}
   redis-password: {{ .Values.externalRedis.password | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           value: /helm-working-dir
         - name: HELM_DATA_HOME
           value: /helm-working-dir
-          {{- include "argo-cd.redisPasswordEnv" . | nindent 8 }}
+          {{- include "argo-cd.externalRedisEnv" . | nindent 8 }}
           {{- with .Values.repoServer.env }}
           {{- toYaml . | nindent 8 }}
           {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -67,9 +67,9 @@ spec:
         {{- if .Values.server.containerSecurityContext }}
         securityContext: {{- toYaml .Values.server.containerSecurityContext | nindent 10 }}
         {{- end }}
-        {{- if or .Values.server.env .Values.externalRedis.password .Values.externalRedis.existingSecret }}
+        {{- if or .Values.server.env .Values.externalRedis.username .Values.externalRedis.password .Values.externalRedis.existingSecret }}
         env:
-          {{- include "argo-cd.redisPasswordEnv" . | nindent 8 }}
+          {{- include "argo-cd.externalRedisEnv" . | nindent 8 }}
           {{- with .Values.server.env }}
           {{- toYaml . | nindent 8 }}
           {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -842,8 +842,8 @@ externalRedis:
   password: ""
   # -- External Redis server port
   port: 6379
-  # -- The name of an existing secret with Redis credentials (must contain key `redis-password`).
-  # When it's set, the `externalRedis.password` parameter is ignored
+  # -- The name of an existing secret with Redis credentials (must contain keys `redis-username` and `redis-password`).
+  # When it's set, the `externalRedis.password` and `externalRedis.username` parameters are ignored
   existingSecret: ""
   # -- External Redis Secret annotations
   secretAnnotations: {}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -836,6 +836,8 @@ redis-ha:
 externalRedis:
   # -- External Redis server host
   host: ""
+  # -- External Redis username
+  username: ""
   # -- External Redis password
   password: ""
   # -- External Redis server port


### PR DESCRIPTION
Signed-off-by: Eugene Lugovtsov <lug.zhenia@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
