### PR TITLE
feat(argo-cd): dex-server — Add TLS support

### DIFF
--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -39,6 +39,16 @@ Create dex name and version as used by the chart label.
 {{- define "argo-cd.dex.fullname" -}}
 {{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.dex.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{/*
+Create dex server host and schema.
+*/}}
+{{- define "argo-cd.dex.serverUrl" -}}
+{{- if .Values.dex.tls.enabled -}}
+{{- printf "https://%s:%s" (include "argo-cd.dex.fullname" .) .Values.dex.servicePortHttp -}}
+{{- else -}}
+{{- printf "http://%s:%s" (include "argo-cd.dex.fullname" .) .Values.dex.servicePortHttp -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create redis name and version as used by the chart label.

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - {{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
         {{- if .Values.dex.enabled }}
         - --dex-server
-        - http://{{ template "argo-cd.dex.fullname" . }}:{{ .Values.dex.servicePortHttp }}
+        - {{ template "argo-cd.dex.serverUrl" . }}
         {{- end }}
         - --logformat
         - {{default .Values.global.logging.format .Values.server.logFormat }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -47,6 +47,10 @@ spec:
         volumeMounts:
         - mountPath: /shared
           name: static-files
+        {{- if .Values.dex.tls.secretName }}
+        - mountPath: /tls
+          name: argocd-dex-server-tls
+        {{- end }}
       {{- if .Values.dex.initContainers }}
       {{- toYaml .Values.dex.initContainers | nindent 6 }}
       {{- end }}
@@ -57,6 +61,9 @@ spec:
         command:
         - /shared/argocd-dex
         - rundex
+        {{- if eq .Values.dex.tls.enabled false }}
+        - --disable-tls
+        {{- end }}
         {{- with .Values.dex.extraArgs }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
@@ -143,6 +150,19 @@ spec:
       volumes:
       - emptyDir: {}
         name: tmp-dir
+      {{- if .Values.dex.tls.secretName }}
+      - name: dex-server-tls
+        secret:
+          secretName: {{ .Values.dex.tls.secretName }}
+          optional: true
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: ca.crt
+            path: ca.crt
+      {{- end }}
       {{- if .Values.dex.volumes }}
       {{- toYaml .Values.dex.volumes | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -388,6 +388,12 @@ dex:
   # -- Additional command line arguments to pass to the Dex server
   extraArgs: []
 
+  tls:
+    # -- Use TLS to expose dex server to ArgoCD
+    enabled: false
+    # -- Use this secret as a certificate source
+    secretName: ""
+
   metrics:
     # -- Deploy metrics service
     enabled: false


### PR DESCRIPTION
# Context

The TLS support with Dex server was introduced with https://github.com/argoproj/argo-cd/pull/9883 with version 2.5.0 (yet to be released).

This PR will try to integrate this feature with the Helm chart.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
