### PR TITLE
chore(argo-cd): Update Redis HA to 4.22.2

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis-ha
   repository: https://dandydeveloper.github.io/charts/
-  version: 4.22.1
-digest: sha256:d9dbffa70c257bb916439103f1df6bb83a034372d3cb0ca57a853c57a4618232
-generated: "2022-08-26T15:08:50.062721+02:00"
+  version: 4.22.2
+digest: sha256:b6dc7774d0cc20a7a889d10e61f3dd653bdacd7836558f4875688b5cb5051d80
+generated: "2022-09-19T12:39:19.736045+02:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.12
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.4.4
+version: 5.4.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -14,9 +14,9 @@ maintainers:
     url: https://argoproj.github.io/
 dependencies:
   - name: redis-ha
-    version: 4.22.1
+    version: 4.22.2
     repository: https://dandydeveloper.github.io/charts/
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update to app version 2.4.12"
+    - "[Changed]: Update redis-ha to 4.22.2"


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/1461

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
