### PR TITLE
chore(argo-workflows): Upgrade helm chart to 3.4

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v3.3.9
+appVersion: v3.4.0
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.17.1
+version: 0.18.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Helm chart maintainers standardized to argoproj"
+    - "[Changed]: Update to app version v3.4.0"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -66,8 +66,6 @@ Fields to note:
 |-----|------|---------|-------------|
 | controller.affinity | object | `{}` | Assign custom [affinity] rules |
 | controller.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the controller to access ClusterWorkflowTemplates. |
-| controller.containerRuntimeExecutor | string | `"emissary"` | Specifies the container runtime interface to use (one of: `docker`, `kubelet`, `k8sapi`, `pns`, `emissary`) |
-| controller.containerRuntimeExecutors | list | `[]` | Specifies the executor to use. This has precedence over `controller.containerRuntimeExecutor`. |
 | controller.deploymentAnnotations | object | `{}` | deploymentAnnotations is an optional map of annotations to be applied to the controller Deployment |
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |

--- a/charts/argo-workflows/crds/argoproj.io_workflowartifactgctasks.yaml
+++ b/charts/argo-workflows/crds/argoproj.io_workflowartifactgctasks.yaml
@@ -1,0 +1,41 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workflowartifactgctasks.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowArtifactGCTask
+    listKind: WorkflowArtifactGCTaskList
+    plural: workflowartifactgctasks
+    shortNames:
+    - wfat
+    singular: workflowartifactgctask
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -48,6 +48,7 @@ rules:
   - workflows/finalizers
   - workflowtasksets
   - workflowtasksets/finalizers
+  - workflowartifactgctasks
   verbs:
   - get
   - list

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -13,11 +13,6 @@ data:
     instanceID: {{ .Values.controller.instanceID.explicitID }}
       {{- end }}
     {{- end }}
-    containerRuntimeExecutor: {{ .Values.controller.containerRuntimeExecutor }}
-    {{- with .Values.controller.containerRuntimeExecutors }}
-    containerRuntimeExecutors:
-    {{- toYaml . | nindent 6 }}
-    {{- end }}
     {{- if .Values.controller.parallelism }}
     parallelism: {{ .Values.controller.parallelism }}
     {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -170,15 +170,6 @@ controller:
   workflowNamespaces:
     - default
 
-  # -- Specifies the container runtime interface to use (one of: `docker`, `kubelet`, `k8sapi`, `pns`, `emissary`)
-  ## Ref: https://argoproj.github.io/argo-workflows/workflow-executors/
-  containerRuntimeExecutor: emissary
-  # -- Specifies the executor to use. This has precedence over `controller.containerRuntimeExecutor`.
-  containerRuntimeExecutors: []
-    # - name: emissary
-    #   selector:
-    #     matchLabels:
-    #       workflows.argoproj.io/container-runtime-executor: emissary
   instanceID:
     # -- Configures the controller to filter workflow submissions
     # to only those which have a matching instanceID attribute.


### PR DESCRIPTION
Resolves #1460

[Release](https://github.com/argoproj/argo-workflows/releases/tag/v3.4.0)

[Upgrade notes](https://argoproj.github.io/argo-workflows/upgrading/#upgrading-to-v34)

Got other info (i.e., new CRD and perms) from [here](https://github.com/argoproj/argo-helm/discussions/1406#discussioncomment-3449067) via @terrytangyuan (thank you)

- [x] new CRD for workflowartifactgctasks
- [x] remove all executor options, emissary executor is only one now
- [x] update chart version

Signed-off-by: jmeridth <jmeridth@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
