### PR TITLE
fix(argo-workflows): remove unsupported value from SSO configuration

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.0
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.19.0
+version: 0.19.1
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Move crds folder into templates folder and add conditional flags for install and keep"
+    - "[Fixed]: Remove unsupported values from SSO configuration"

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -482,11 +482,6 @@ server:
     # redirectUrl: https://argo/oauth2/callback
     # rbac:
     #   enabled: true
-    ## When present, restricts secrets the server can read to a given list.
-    ## You can use it to restrict the server to only be able to access the
-    ## service account token secrets that are associated with service accounts
-    ## used for authorization.
-    #   secretWhitelist: []
     ## Scopes requested from the SSO ID provider.  The 'groups' scope requests
     ## group membership information, which is usually used for authorization
     ## decisions.


### PR DESCRIPTION
There is unsupported value on `.Values.server.sso` , so I removed it. 🙋 
ref: https://github.com/argoproj/argo-helm/pull/1463#issuecomment-1251732944

---

Signed-off-by: yu-croco <yu.croco@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
