### PR TITLE
feat(argo-cd): Add username support for external redis

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.12
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.5.0
+version: 5.5.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -19,6 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: New configuration section `configs.params` for command line parameters"
-    - "[Deprecated]: Command line arguments in `args` sections"
-    - "[Deprecated]: Options `logFormat` and `logLevel` for core components"
+    - "[Added]: REDIS_USERNAME environment variable added automatically based on externalRedis.username"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -852,6 +852,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |
 | externalRedis.secretAnnotations | object | `{}` | External Redis Secret annotations |
+| externalRedis.username | string | `""` | External Redis username |
 
 ## ApplicationSet
 

--- a/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/externalredis-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.externalRedis.password (not .Values.externalRedis.existingSecret) }}
+{{- if and (or .Values.externalRedis.username .Values.externalRedis.password) (not .Values.externalRedis.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,5 +13,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  redis-password: {{ .Values.externalRedis.password | b64enc }}
+  {{- with .Values.externalRedis.username }}
+  redis-username: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.externalRedis.password }}
+  redis-password: {{ . | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1089,6 +1089,8 @@ redis-ha:
 externalRedis:
   # -- External Redis server host
   host: ""
+  # -- External Redis username
+  username: ""
   # -- External Redis password
   password: ""
   # -- External Redis server port


### PR DESCRIPTION
Rebased https://github.com/argoproj/argo-helm/pull/1445 to latest config section. Environmental variable is already referenced in deployment via

```yaml
env:
  - name: REDIS_USERNAME
    valueFrom:
      secretKeyRef:
        name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
        key: redis-username
        optional: true
```

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
