### PR TITLE
feat(argo-cd): override apiVersion of cloud.google.com resources

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -20,3 +20,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: Clarified documentation around CRD upgrades"
+    - "[Added]: Override apiVersion of cloud.google.com resources such as BackendConfig"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -328,6 +328,7 @@ NAME: my-release
 |-----|------|---------|-------------|
 | apiVersionOverrides.autoscaling | string | `""` | String to override apiVersion of autoscaling rendered by this helm chart |
 | apiVersionOverrides.certmanager | string | `""` | String to override apiVersion of certmanager resources rendered by this helm chart |
+| apiVersionOverrides.cloudgooglecom | string | `""` | String to override apiVersion of cloud.google.com resources rendered by this helm chart |
 | apiVersionOverrides.ingress | string | `""` | String to override apiVersion of ingresses rendered by this helm chart |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-cd/templates/argocd-server/backendconfig.yaml
+++ b/charts/argo-cd/templates/argocd-server/backendconfig.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.server.GKEbackendConfig.enabled }}
-apiVersion: cloud.google.com/v1beta1
+{{- if .Values.apiVersionOverrides.cloudgooglecom -}}
+apiVersion: {{ .Values.apiVersionOverrides.cloudgooglecom }}
+{{- else if .Capabilities.APIVersions.Has "cloud.google.com/v1beta1" }}
+apiVersion: "cloud.google.com/v1beta1"
+{{- else }}
+apiVersion: "cloud.google.com/v1"
+{{- end }}
 kind: BackendConfig
 metadata:
   name: {{ template "argo-cd.server.fullname" . }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -18,6 +18,8 @@ apiVersionOverrides:
   ingress: "" # networking.k8s.io/v1beta1
   # -- String to override apiVersion of autoscaling rendered by this helm chart
   autoscaling: "" # autoscaling/v2
+  # -- String to override apiVersion of cloud.google.com resources rendered by this helm chart
+  cloudgooglecom: "" # cloud.google.com/v1beta1
 
 # -- Create clusterroles that extend existing clusterroles to interact with argo-cd crds
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
