### PR TITLE
fix(argo-workflows): change default type of `.mainContainer.env` and `.executor.env` from object to array

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.0
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.19.2
+version: 0.19.3
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Set only used values on SSO configuration"
+    - "[Fixed]: Change default type of `.mainContainer.env` and `.executor.env` from object to array"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -139,7 +139,7 @@ Fields to note:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| mainContainer.env | object | `{}` | Adds environment variables for the Workflow main container |
+| mainContainer.env | list | `[]` | Adds environment variables for the Workflow main container |
 | mainContainer.imagePullPolicy | string | `"Always"` | imagePullPolicy to apply to Workflow main container |
 | mainContainer.resources | object | `{}` | Resource limits and requests for the Workflow main container |
 | mainContainer.securityContext | object | `{}` | sets security context for the Workflow main container |
@@ -148,7 +148,7 @@ Fields to note:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| executor.env | object | `{}` | Adds environment variables for the executor. |
+| executor.env | list | `[]` | Adds environment variables for the executor. |
 | executor.image.registry | string | `"quay.io"` | Registry to use for the Workflow Executors |
 | executor.image.repository | string | `"argoproj/argoexec"` | Repository to use for the Workflow Executors |
 | executor.image.tag | string | `""` | Image tag for the workflow executor. Defaults to `.Values.images.tag`. |

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -283,7 +283,7 @@ mainContainer:
   # -- Resource limits and requests for the Workflow main container
   resources: {}
   # -- Adds environment variables for the Workflow main container
-  env: {}
+  env: []
   # -- sets security context for the Workflow main container
   securityContext: {}
 
@@ -299,7 +299,7 @@ executor:
   # -- Resource limits and requests for the Workflow Executors
   resources: {}
   # -- Adds environment variables for the executor.
-  env: {}
+  env: []
   # -- sets security context for the executor container
   securityContext: {}
 


### PR DESCRIPTION
This PR resolves https://github.com/argoproj/argo-helm/issues/1450 . 🙋 

---

Signed-off-by: yu-croco <yu.croco@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
