### PR TITLE
fix(argo-cd): Add missing templating for some service labels

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.12
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.5.4
+version: 5.5.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Clarified documentation around CRD upgrades"
+    - "[Fixed]: Add missing templating for some service labels"

--- a/charts/argo-cd/templates/argocd-application-controller/service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/service.yaml
@@ -10,8 +10,8 @@ metadata:
   name: {{ template "argo-cd.controller.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-{{- if .Values.controller.service.labels }}
-{{- toYaml .Values.controller.service.labels | nindent 4 }}
+{{- with .Values.controller.service.labels }}
+{{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/argo-cd/templates/argocd-application-controller/service.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/service.yaml
@@ -10,6 +10,9 @@ metadata:
   name: {{ template "argo-cd.controller.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
+{{- if .Values.controller.service.labels }}
+{{- toYaml .Values.controller.service.labels | nindent 4 }}
+{{- end }}
 spec:
   ports:
   - name: {{ .Values.controller.service.portName }}

--- a/charts/argo-cd/templates/argocd-applicationset/service.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/service.yaml
@@ -11,8 +11,8 @@ metadata:
   name: {{ template "argo-cd.applicationSet.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
-{{- if .Values.applicationSet.service.labels }}
-{{- toYaml .Values.applicationSet.service.labels | nindent 4 }}
+{{- with .Values.applicationSet.service.labels }}
+{{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/argo-cd/templates/argocd-applicationset/service.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/service.yaml
@@ -11,6 +11,9 @@ metadata:
   name: {{ template "argo-cd.applicationSet.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
+{{- if .Values.applicationSet.service.labels }}
+{{- toYaml .Values.applicationSet.service.labels | nindent 4 }}
+{{- end }}
 spec:
   ports:
   - name: {{ .Values.applicationSet.service.portName }}

--- a/charts/argo-cd/templates/argocd-repo-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/service.yaml
@@ -9,6 +9,9 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
+{{- if .Values.repoServer.service.labels }}
+{{- toYaml .Values.repoServer.service.labels | nindent 4 }}
+{{- end }}
   name: {{ template "argo-cd.repoServer.fullname" . }}
 spec:
   ports:

--- a/charts/argo-cd/templates/argocd-repo-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/service.yaml
@@ -9,8 +9,8 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
-{{- if .Values.repoServer.service.labels }}
-{{- toYaml .Values.repoServer.service.labels | nindent 4 }}
+{{- with .Values.repoServer.service.labels }}
+{{- toYaml . | nindent 4 }}
 {{- end }}
   name: {{ template "argo-cd.repoServer.fullname" . }}
 spec:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
