### PR TITLE
feat(argo-workflows): Add extra manifests to deploy within the chart

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.0
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.19.6
+version: 0.20.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Helm syntax on SSO configuration"
+    - "[Added]: Additional manifests to deploy within the chart"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -45,6 +45,7 @@ Fields to note:
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |
 | createAggregateRoles | bool | `true` | Create clusterroles that extend existing clusterroles to interact with argo-cd crds |
+| extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | fullnameOverride | string | `nil` | String to fully override "argo-workflows.fullname" template |
 | images.pullPolicy | string | `"Always"` | imagePullPolicy to apply to all containers |
 | images.pullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |

--- a/charts/argo-workflows/templates/extra-manifests.yaml
+++ b/charts/argo-workflows/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -496,6 +496,32 @@ server:
   # -- Extra containers to be added to the server deployment
   extraContainers: []
 
+# -- Array of extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: argo-server-sso
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "argo/server/sso"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client_id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client_secret"
+  #     secretObjects:
+  #     - data:
+  #       - key: client_id
+  #         objectName: client_id
+  #       - key: client_secret
+  #         objectName: client_secret
+  #       secretName: argo-server-sso-secrets-store
+  #       type: Opaque
+
 # -- Influences the creation of the ConfigMap for the workflow-controller itself.
 useDefaultArtifactRepo: false
 # -- Use static credentials for S3 (eg. when not using AWS IRSA)


### PR DESCRIPTION
Objective of this PR is the same that others have made to other charts.

Ref
- https://github.com/argoproj/argo-helm/pull/1094
- https://github.com/argoproj/argo-helm/pull/1366

This change enables us to use SecretProviderClass, and will be useful when we use SSO and OIDC.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
