### PR TITLE
feat(argo-cd): Add support for labels on Service Accounts

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.13
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.5.8
+version: 5.5.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -22,4 +22,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Upgrade Dex to v2.35.0 to avoid CVE-2022-39222 and update app version to v2.4.13"
+    - "[Added]: Allow labels to be set on service accounts"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -462,6 +462,7 @@ NAME: my-release
 | controller.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | controller.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | controller.serviceAccount.create | bool | `true` | Create a service account for the application controller |
+| controller.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | controller.serviceAccount.name | string | `"argocd-application-controller"` | Service account name |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the application controller |
@@ -677,6 +678,7 @@ NAME: my-release
 | server.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | server.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | server.serviceAccount.create | bool | `true` | Create server service account |
+| server.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | server.serviceAccount.name | string | `"argocd-server"` | Server service account name |
 | server.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | server.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the Argo CD server |
@@ -908,6 +910,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.service.portName | string | `"webhook"` | Application set service port name |
 | applicationSet.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | applicationSet.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| applicationSet.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | applicationSet.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | applicationSet.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | applicationSet.webhook.ingress.annotations | object | `{}` | Additional ingress annotations |

--- a/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
@@ -12,4 +12,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
+  {{- range $key, $value := .Values.controller.serviceAccount.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/serviceaccount.yaml
@@ -12,4 +12,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
+  {{- range $key, $value := .Values.applicationSet.serviceAccount.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
@@ -12,4 +12,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+  {{- range $key, $value := .Values.server.serviceAccount.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -516,6 +516,8 @@ controller:
     name: argocd-application-controller
     # -- Annotations applied to created service account
     annotations: {}
+    # -- Labels applied to created service account
+    labels: {}
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
@@ -1356,6 +1358,8 @@ server:
     name: argocd-server
     # -- Annotations applied to created service account
     annotations: {}
+    # -- Labels applied to created service account
+    labels: {}
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
@@ -2068,6 +2072,8 @@ applicationSet:
     create: true
     # -- Annotations to add to the service account
     annotations: {}
+    # -- Labels applied to created service account
+    labels: {}
     # -- The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""


### PR DESCRIPTION
Adds support for labels on Service Accounts which is needed for using Federated Workload Identity in Azure as an example.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
