### PR TITLE
feat(argo-cd): Make labels for repoServer and notification service accounts configurable

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.14
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.5.14
+version: 5.5.15
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -22,4 +22,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Incorrectly placed timeout.reconciliation and timeout.hard.reconciliation"
+    - "[Added]: Make labels for repoServer and notification service accounts configurable"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -535,6 +535,7 @@ NAME: my-release
 | repoServer.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | repoServer.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | repoServer.serviceAccount.create | bool | `true` | Create repo server service account |
+| repoServer.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | repoServer.serviceAccount.name | string | `""` | Repo server service account name |
 | repoServer.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | repoServer.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the repo server |
@@ -983,6 +984,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.securityContext | object | `{"runAsNonRoot":true}` | Pod Security Context |
 | notifications.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | notifications.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| notifications.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | notifications.serviceAccount.name | string | `"argocd-notifications-controller"` | The name of the service account to use. |
 | notifications.subscriptions | list | `[]` | Contains centrally managed global application subscriptions |
 | notifications.templates | object | `{}` | The notification template is used to generate the notification content |

--- a/charts/argo-cd/templates/argocd-notifications/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/serviceaccount.yaml
@@ -12,4 +12,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
+  {{- range $key, $value := .Values.notifications.serviceAccount.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/serviceaccount.yaml
@@ -12,4 +12,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
+  {{- range $key, $value := .Values.repoServer.serviceAccount.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1921,6 +1921,8 @@ repoServer:
     name: "" # "argocd-repo-server"
     # -- Annotations applied to created service account
     annotations: {}
+    # -- Labels applied to created service account
+    labels: {}
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
@@ -2364,6 +2366,8 @@ notifications:
     # -- Annotations applied to created service account
     annotations: {}
 
+    # -- Labels applied to created service account
+    labels: {}
   cm:
     # -- Whether helm chart creates controller config map
     create: true


### PR DESCRIPTION
#1513 miss 2 components

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
