### PR TITLE
feat(argo-cd): Support manually managed TLS certificate for Server

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.0
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.11.0
+version: 5.12.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Added option to use custom TLS certs for Dex"
-    - "[Security]: TLS strict mode is enforced for custom Dex certificates"
+    - "[Added]: New TLS server configuration via server.certificateSecret"
+    - "[Deprecated]: TLS configuration via configs.secret.argocdServerTlsConfig"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -414,7 +414,6 @@ NAME: my-release
 | configs.secret.annotations | object | `{}` | Annotations to be added to argocd-secret |
 | configs.secret.argocdServerAdminPassword | string | `""` | Bcrypt hashed admin password |
 | configs.secret.argocdServerAdminPasswordMtime | string | `""` (defaults to current time) | Admin password modification time. Eg. `"2006-01-02T15:04:05Z"` |
-| configs.secret.argocdServerTlsConfig | object | `{}` | Argo TLS Data |
 | configs.secret.bitbucketServerSecret | string | `""` | Shared secret for authenticating BitbucketServer webhook events |
 | configs.secret.bitbucketUUID | string | `""` | UUID for authenticating Bitbucket webhook events |
 | configs.secret.createSecret | bool | `true` | Create the argocd-secret |
@@ -586,9 +585,9 @@ NAME: my-release
 | server.autoscaling.minReplicas | int | `1` | Minimum number of replicas for the Argo CD server [HPA] |
 | server.autoscaling.targetCPUUtilizationPercentage | int | `50` | Average CPU utilization percentage for the Argo CD server [HPA] |
 | server.autoscaling.targetMemoryUtilizationPercentage | int | `50` | Average memory utilization percentage for the Argo CD server [HPA] |
-| server.certificate.additionalHosts | list | `[]` | Certificate manager additional hosts |
+| server.certificate.additionalHosts | list | `[]` | Certificate Subject Alternate Names (SANs) |
 | server.certificate.domain | string | `"argocd.example.com"` | Certificate primary domain (commonName) |
-| server.certificate.duration | string | `""` | The requested 'duration' (i.e. lifetime) of the Certificate. Value must be in units accepted by Go time.ParseDuration |
+| server.certificate.duration | string | `""` (defaults to 2160h = 90d if not specified) | The requested 'duration' (i.e. lifetime) of the certificate. |
 | server.certificate.enabled | bool | `false` | Deploy a Certificate resource (requires cert-manager) |
 | server.certificate.issuer.group | string | `""` | Certificate issuer group. Set if using an external issuer. Eg. `cert-manager.io` |
 | server.certificate.issuer.kind | string | `""` | Certificate issuer kind. Either `Issuer` or `ClusterIssuer` |
@@ -597,8 +596,13 @@ NAME: my-release
 | server.certificate.privateKey.encoding | string | `"PKCS1"` | The private key cryptography standards (PKCS) encoding for private key. Either: `PCKS1` or `PKCS8` |
 | server.certificate.privateKey.rotationPolicy | string | `"Never"` | Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always` |
 | server.certificate.privateKey.size | int | `2048` | Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored. |
-| server.certificate.renewBefore | string | `""` | How long before the currently issued certificate's expiry cert-manager should renew the certificate. Value must be in units accepted by Go time.ParseDuration |
+| server.certificate.renewBefore | string | `""` (defaults to 360h = 15d if not specified) | How long before the expiry a certificate should be renewed. |
 | server.certificate.secretName | string | `"argocd-server-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
+| server.certificateSecret.annotations | object | `{}` | Annotations to be added to argocd-server-tls secret |
+| server.certificateSecret.crt | string | `""` | Certificate data |
+| server.certificateSecret.enabled | bool | `false` | Create argocd-server-tls secret |
+| server.certificateSecret.key | string | `""` | Private Key of the certificate |
+| server.certificateSecret.labels | object | `{}` | Labels to be added to argocd-server-tls secret |
 | server.clusterAdminAccess.enabled | bool | `true` | Enable RBAC for local cluster deployments |
 | server.containerPort | int | `8080` | Configures the server port |
 | server.containerSecurityContext | object | See [values.yaml] | Server container-level security context |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -40,6 +40,9 @@ DEPRECATED option server.config - Use configs.cm
 {{- if or .Values.server.rbacConfig (hasKey .Values.server "rbacConfigCreate") .Values.server.rbacConfigAnnotations }}
 DEPRECATED option server.rbacConfig - Use configs.rbac
 {{- end }}
+{{- if .Values.configs.secret.argocdServerTlsConfig }}
+DEPRECATED option config.secret.argocdServerTlsConfig - Use server.certificate or server.certificateSecret
+{{- end }}
 {{- if .Values.controller.service }}
 REMOVED option controller.service - Use controller.metrics
 {{- end }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-server-tls.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-server-tls.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.server.certificateSecret.enabled (not .Values.server.certificate.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-server-tls
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" "server-tls") | nindent 4 }}
+    {{- with .Values.server.certificateSecret.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.certificateSecret.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.server.certificateSecret.crt | b64enc | quote }}
+  tls.key: {{ .Values.server.certificateSecret.key | b64enc | quote }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-server/certificate.yaml
@@ -2,10 +2,11 @@
 apiVersion: {{ include "argo-cd.apiVersion.cert-manager" . }}
 kind: Certificate
 metadata:
-  name: {{ template "argo-cd.server.fullname" . }}
+  name: {{ include "argo-cd.server.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
+  secretName: {{ .Values.server.certificate.secretName }}
   commonName: {{ .Values.server.certificate.domain | quote }}
   dnsNames:
     - {{ .Values.server.certificate.domain | quote }}
@@ -14,6 +15,9 @@ spec:
     {{- end }}
   {{- with .Values.server.certificate.duration }}
   duration: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.server.certificate.renewBefore }}
+  renewBefore: {{ . | quote }}
   {{- end }}
   issuerRef:
     {{- with .Values.server.certificate.issuer.group }}
@@ -25,8 +29,4 @@ spec:
   privateKey:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.server.certificate.renewBefore }}
-  renewBefore: {{ . | quote }}
-  {{- end }}
-  secretName: {{ .Values.server.certificate.secretName | quote }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -415,16 +415,10 @@ configs:
       # LDAP_PASSWORD: "mypassword"
 
     # -- Argo TLS Data
-    argocdServerTlsConfig:
-      {}
-      # key:
-      # crt: |
-      #   -----BEGIN CERTIFICATE-----
-      #   <cert data>
-      #   -----END CERTIFICATE-----
-      #   -----BEGIN CERTIFICATE-----
-      #   <ca cert data>
-      #   -----END CERTIFICATE-----
+    # DEPRECATED - Use server.certificate or server.certificateSecret
+    # argocdServerTlsConfig:
+    #  key: ''
+    #  crt: ''
 
     # -- Bcrypt hashed admin password
     ## Argo expects the password in the secret to be bcrypt hashed. You can create this hash with
@@ -1433,16 +1427,34 @@ server:
   #    cpu: 50m
   #    memory: 64Mi
 
-  ## Certificate configuration
+  # TLS certificate configuration via cert-manager
+  ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#tls-certificates-used-by-argocd-server
   certificate:
     # -- Deploy a Certificate resource (requires cert-manager)
     enabled: false
+    # -- The name of the Secret that will be automatically created and managed by this Certificate resource
+    secretName: argocd-server-tls
     # -- Certificate primary domain (commonName)
     domain: argocd.example.com
-    # -- The requested 'duration' (i.e. lifetime) of the Certificate. Value must be in units accepted by Go time.ParseDuration
+    # -- Certificate Subject Alternate Names (SANs)
+    additionalHosts: []
+    # -- The requested 'duration' (i.e. lifetime) of the certificate.
+    # @default -- `""` (defaults to 2160h = 90d if not specified)
+    ## Ref: https://cert-manager.io/docs/usage/certificate/#renewal
     duration: ""
-    # -- How long before the currently issued certificate's expiry cert-manager should renew the certificate. Value must be in units accepted by Go time.ParseDuration
+    # -- How long before the expiry a certificate should be renewed.
+    # @default -- `""` (defaults to 360h = 15d if not specified)
+    ## Ref: https://cert-manager.io/docs/usage/certificate/#renewal
     renewBefore: ""
+    # Certificate issuer
+    ## Ref: https://cert-manager.io/docs/concepts/issuer
+    issuer:
+      # -- Certificate issuer group. Set if using an external issuer. Eg. `cert-manager.io`
+      group: ""
+      # -- Certificate issuer kind. Either `Issuer` or `ClusterIssuer`
+      kind: ""
+      # -- Certificate isser name. Eg. `letsencrypt`
+      name: ""
     # Private key of the certificate
     privateKey:
       # -- Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always`
@@ -1453,17 +1465,20 @@ server:
       algorithm: RSA
       # -- Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored.
       size: 2048
-    issuer:
-      # -- Certificate issuer group. Set if using an external issuer. Eg. `cert-manager.io`
-      group: ""
-      # -- Certificate issuer kind. Either `Issuer` or `ClusterIssuer`
-      kind: ""
-      # -- Certificate isser name. Eg. `letsencrypt`
-      name: ""
-    # -- Certificate manager additional hosts
-    additionalHosts: []
-    # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-    secretName: argocd-server-tls
+
+  # TLS certificate configuration via Secret
+  ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#tls-certificates-used-by-argocd-server
+  certificateSecret:
+    # -- Create argocd-server-tls secret
+    enabled: false
+    # -- Annotations to be added to argocd-server-tls secret
+    annotations: {}
+    # -- Labels to be added to argocd-server-tls secret
+    labels: {}
+    # -- Private Key of the certificate
+    key: ''
+    # -- Certificate data
+    crt: ''
 
   ## Server service configuration
   service:
@@ -1591,7 +1606,7 @@ server:
     # -- Ingress TLS configuration
     tls:
       []
-      # - secretName: argocd-tls-certificate
+      # - secretName: your-certificate-name
       #   hosts:
       #     - argocd.example.com
 
@@ -1657,7 +1672,7 @@ server:
     # -- Ingress TLS configuration for dedicated [gRPC-ingress]
     tls:
       []
-      # - secretName: argocd-tls-certificate
+      # - secretName: your-certificate-name
       #   hosts:
       #     - argocd.example.com
 


### PR DESCRIPTION
- Replaces deprecated configuration via configs.secret.argocdServerTlsConfig
- Fixes cert-manager resource so the secret name is always valid

---

Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#tls-certificates-used-by-argocd-server

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
