### PR TITLE
chore(github): Bump GitHub actions versions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Setup Chart Linting
         id: lint
-        uses: helm/chart-testing-action@v2.3.0
+        uses: helm/chart-testing-action@v2.3.1
         with:
           # Note: Also update in scripts/lint.sh
-          version: v3.7.0
+          version: v3.7.1
 
       - name: List changed charts
         id: list-changed
@@ -41,6 +41,7 @@ jobs:
             echo "::set-output name=changed::true"
             echo "::set-output name=changed_charts::$charts"
           fi
+
       - name: Run chart-testing (lint)
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,7 +19,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           git checkout origin/gh-pages index.yaml
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.4.1
         with:
           config: "./.github/configs/cr.yaml"
         env:

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,7 +9,7 @@ echo -e "\n-- Linting all Helm Charts --\n"
 docker run \
      -v "$SRCROOT:/workdir" \
      --entrypoint /bin/sh \
-     quay.io/helmpack/chart-testing:v3.7.0 \
+     quay.io/helmpack/chart-testing:v3.7.1 \
      -c cd /workdir \
      ct lint \
      --config .github/configs/ct-lint.yaml \


### PR DESCRIPTION
Keeping GitHub actions updated

Testing: https://github.com/argoproj/argo-helm/actions/runs/3323692976/jobs/5494364515

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
