### PR TITLE
feat(argo-cd): Set container security contexts

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v2
 appVersion: v2.5.0
+kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.9.1
+version: 5.10.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -22,4 +23,8 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Removed]: Liveness probe for application controller"
+    - "[Security]: Use recommended container security contexts by default"
+    - "[Added]: Container security context for server UI extensions sidecar"
+    - "[Fixed]: Redis metrics sidecar now uses correct configuration option"
+    - "[Removed]: ApplicationSet securityContext in favor of global.securityContext"
+    - "[Removed]: Notification securityContext in favor of global.securityContext"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -101,6 +101,11 @@ kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=<appVer
 kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=v2.4.9"
 ```
 
+### 5.10.0
+
+This version hardens security by configuring default container security contexts.
+The change aligns chart with [supported versions](https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#supported-versions) by upstream and adds requirement for minimum Kubernetes version >= 1.22.
+
 ### 5.5.20
 
 This version moved API version templates into dedicated helper. If you are using these in your umbrella
@@ -312,7 +317,7 @@ server:
 
 ## Prerequisites
 
-- Kubernetes 1.7+
+- Kubernetes: `>=1.22.0-0`
 - Helm v3.0.0+
 
 ## Installing the Chart
@@ -431,7 +436,7 @@ NAME: my-release
 | controller.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the application controller's ClusterRole resource |
 | controller.clusterRoleRules.rules | list | `[]` | List of custom rules for the application controller's ClusterRole resource |
 | controller.containerPort | int | `8082` | Application controller listening port |
-| controller.containerSecurityContext | object | `{}` | Application controller container-level security context |
+| controller.containerSecurityContext | object | See [values.yaml] | Application controller container-level security context |
 | controller.env | list | `[]` | Environment variables to pass to application controller |
 | controller.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to application controller |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to application controller |
@@ -502,7 +507,7 @@ NAME: my-release
 | repoServer.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the Repo server's Cluster Role resource |
 | repoServer.clusterRoleRules.rules | list | `[]` | List of custom rules for the Repo server's Cluster Role resource |
 | repoServer.containerPort | int | `8081` | Configures the repo server port |
-| repoServer.containerSecurityContext | object | `{}` | Repo server container-level security context |
+| repoServer.containerSecurityContext | object | See [values.yaml] | Repo server container-level security context |
 | repoServer.env | list | `[]` | Environment variables to pass to repo server |
 | repoServer.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to repo server |
 | repoServer.extraArgs | list | `[]` | Additional command line arguments to pass to repo server |
@@ -596,9 +601,10 @@ NAME: my-release
 | server.certificate.secretName | string | `"argocd-server-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
 | server.clusterAdminAccess.enabled | bool | `true` | Enable RBAC for local cluster deployments |
 | server.containerPort | int | `8080` | Configures the server port |
-| server.containerSecurityContext | object | `{}` | Servers container-level security context |
+| server.containerSecurityContext | object | See [values.yaml] | Server container-level security context |
 | server.env | list | `[]` | Environment variables to pass to Argo CD server |
 | server.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to Argo CD server |
+| server.extensions.containerSecurityContext | object | See [values.yaml] | Server UI extensions container-level security context |
 | server.extensions.enabled | bool | `false` | Enable support for Argo UI extensions |
 | server.extensions.image.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for extensions |
 | server.extensions.image.repository | string | `"ghcr.io/argoproj-labs/argocd-extensions"` | Repository to use for extensions image |
@@ -732,7 +738,7 @@ server:
 | dex.containerPortGrpc | int | `5557` | Container port for gRPC access |
 | dex.containerPortHttp | int | `5556` | Container port for HTTP access |
 | dex.containerPortMetrics | int | `5558` | Container port for metrics access |
-| dex.containerSecurityContext | object | `{}` | Dex container-level security context |
+| dex.containerSecurityContext | object | See [values.yaml] | Dex container-level security context |
 | dex.enabled | bool | `true` | Enable dex |
 | dex.env | list | `[]` | Environment variables to pass to the Dex server |
 | dex.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the Dex server |
@@ -805,7 +811,7 @@ server:
 |-----|------|---------|-------------|
 | redis.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | redis.containerPort | int | `6379` | Redis container port |
-| redis.containerSecurityContext | object | `{}` | Redis container-level security context |
+| redis.containerSecurityContext | object | See [values.yaml] | Redis container-level security context |
 | redis.enabled | bool | `true` | Enable redis |
 | redis.env | list | `[]` | Environment variables to pass to the Redis server |
 | redis.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the Redis server |
@@ -817,6 +823,7 @@ server:
 | redis.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | redis.initContainers | list | `[]` | Init containers to add to the redis pod |
 | redis.metrics.containerPort | int | `9121` | Port to use for redis-exporter sidecar |
+| redis.metrics.containerSecurityContext | object | See [values.yaml] | Redis exporter security context |
 | redis.metrics.enabled | bool | `false` | Deploy metrics service and redis-exporter sidecar |
 | redis.metrics.image.imagePullPolicy | string | `"IfNotPresent"` | redis-exporter image PullPolicy |
 | redis.metrics.image.repository | string | `"public.ecr.aws/bitnami/redis-exporter"` | redis-exporter image repository |
@@ -849,7 +856,7 @@ server:
 | redis.podLabels | object | `{}` | Labels to be added to the Redis server pods |
 | redis.priorityClassName | string | `""` | Priority class for redis |
 | redis.resources | object | `{}` | Resource limits and requests for redis |
-| redis.securityContext | object | `{"runAsNonRoot":true,"runAsUser":999}` | Redis pod-level security context |
+| redis.securityContext | object | See [values.yaml] | Redis pod-level security context |
 | redis.service.annotations | object | `{}` | Redis service annotations |
 | redis.service.labels | object | `{}` | Additional redis service labels |
 | redis.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
@@ -913,6 +920,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.args.metricsAddr | string | `":8080"` | The default metric address |
 | applicationSet.args.policy | string | `"sync"` | How application is synced between the generator and the cluster |
 | applicationSet.args.probeBindAddr | string | `":8081"` | The default health check port |
+| applicationSet.containerSecurityContext | object | See [values.yaml] | ApplicationSet controller container-level security context |
 | applicationSet.enabled | bool | `true` | Enable ApplicationSet controller |
 | applicationSet.extraArgs | list | `[]` | List of extra cli args to add |
 | applicationSet.extraContainers | list | `[]` | Additional containers to be added to the applicationset controller pod |
@@ -956,7 +964,6 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
 | applicationSet.podAnnotations | object | `{}` | Annotations for the controller pods |
 | applicationSet.podLabels | object | `{}` | Labels for the controller pods |
-| applicationSet.podSecurityContext | object | `{}` | Pod Security Context |
 | applicationSet.priorityClassName | string | `""` | If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default. |
 | applicationSet.readinessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for ApplicationSet controller |
 | applicationSet.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
@@ -966,7 +973,6 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | applicationSet.replicaCount | int | `1` | The number of ApplicationSet controller pods to run |
 | applicationSet.resources | object | `{}` | Resource limits and requests for the controller pods. |
-| applicationSet.securityContext | object | `{}` | Security Context |
 | applicationSet.service.annotations | object | `{}` | Application set service annotations |
 | applicationSet.service.labels | object | `{}` | Application set service labels |
 | applicationSet.service.port | int | `7000` | Application set service port |
@@ -993,7 +999,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.affinity | object | `{}` | Assign custom [affinity] rules |
 | notifications.argocdUrl | string | `nil` | Argo CD dashboard url; used in place of {{.context.argocdUrl}} in templates |
 | notifications.bots.slack.affinity | object | `{}` | Assign custom [affinity] rules |
-| notifications.bots.slack.containerSecurityContext | object | `{}` | Container Security Context |
+| notifications.bots.slack.containerSecurityContext | object | See [values.yaml] | Slack bot container-level security Context |
 | notifications.bots.slack.enabled | bool | `false` | Enable slack bot |
 | notifications.bots.slack.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Slack bot |
 | notifications.bots.slack.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the Slack bot |
@@ -1006,7 +1012,6 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.bots.slack.pdb.maxUnavailable | string | `""` | Number of pods that are unavailble after eviction as number or percentage (eg.: 50%). |
 | notifications.bots.slack.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
 | notifications.bots.slack.resources | object | `{}` | Resource limits and requests for the Slack bot |
-| notifications.bots.slack.securityContext | object | `{"runAsNonRoot":true}` | Pod Security Context |
 | notifications.bots.slack.service.annotations | object | `{}` | Service annotations for Slack bot |
 | notifications.bots.slack.service.port | int | `80` | Service port for Slack bot |
 | notifications.bots.slack.service.type | string | `"LoadBalancer"` | Service type for Slack bot |
@@ -1016,7 +1021,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.bots.slack.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | notifications.bots.slack.updateStrategy | object | `{"type":"Recreate"}` | The deployment strategy to use to replace existing pods with new ones |
 | notifications.cm.create | bool | `true` | Whether helm chart creates controller config map |
-| notifications.containerSecurityContext | object | `{}` | Container Security Context |
+| notifications.containerSecurityContext | object | See [values.yaml] | Notification controller container-level security Context |
 | notifications.context | object | `{}` | Define user-defined context |
 | notifications.enabled | bool | `true` | Enable notifications controller |
 | notifications.extraArgs | list | `[]` | Extra arguments to provide to the controller |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -100,6 +100,11 @@ kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=<appVer
 kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=v2.4.9"
 ```
 
+### 5.10.0
+
+This version hardens security by configuring default container security contexts.
+The change aligns chart with [supported versions](https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#supported-versions) by upstream and adds requirement for minimum Kubernetes version >= 1.22.
+
 ### 5.5.20
 
 This version moved API version templates into dedicated helper. If you are using these in your umbrella
@@ -312,7 +317,7 @@ server:
 
 ## Prerequisites
 
-- Kubernetes 1.7+
+- {{ template "chart.kubeVersionLine" . }}
 - Helm v3.0.0+
 
 ## Installing the Chart

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -81,10 +81,6 @@ spec:
         image: {{ default .Values.global.image.repository .Values.controller.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.controller.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.controller.image.imagePullPolicy }}
         name: {{ .Values.controller.name }}
-        {{- with .Values.controller.containerSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         env:
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 10 }}
@@ -242,6 +238,8 @@ spec:
           failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.controller.containerSecurityContext | nindent 10 }}
         workingDir: /home/argocd
         volumeMounts:
         {{- with .Values.controller.volumeMounts }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -28,8 +28,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.global.securityContext }}
       securityContext:
-        {{- toYaml (mergeOverwrite (deepCopy .Values.global.securityContext) .Values.applicationSet.podSecurityContext) | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "argo-cd.applicationSetServiceAccountName" . }}
       containers:
         - name: {{ .Values.applicationSet.name }}
@@ -99,7 +101,7 @@ spec:
           resources:
             {{- toYaml .Values.applicationSet.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.applicationSet.securityContext | nindent 12 }}
+            {{- toYaml .Values.applicationSet.containerSecurityContext | nindent 12 }}
           volumeMounts:
             {{- with .Values.applicationSet.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}

--- a/charts/argo-cd/templates/argocd-notifications/bots/slack/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/bots/slack/deployment.yaml
@@ -20,14 +20,15 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.global.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "argo-cd.notificationsBotsSlackServiceAccountName" . }}
-      securityContext: {{- toYaml (mergeOverwrite (deepCopy .Values.global.securityContext) .Values.notifications.securityContext) | nindent 8 }}
       containers:
         - name: {{ template "argo-cd.notifications.fullname" . }}-bot
           image: {{ default .Values.global.image.repository .Values.notifications.bots.slack.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.notifications.bots.slack.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.notifications.bots.slack.image.pullPolicy }}
-          resources:
-            {{- toYaml .Values.notifications.bots.slack.resources | nindent 12 }}
           command:
             - argocd-notifications
             - bot
@@ -35,19 +36,20 @@ spec:
           ports:
           - containerPort: 8080
             name: http
-          {{- with .Values.notifications.bots.slack.containerSecurityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
-          {{- end }}
+          resources:
+            {{- toYaml .Values.notifications.bots.slack.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.notifications.bots.slack.containerSecurityContext | nindent 12 }}
       {{- with .Values.notifications.bots.slack.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.notifications.bots.slack.affinity }}
+      {{- with .Values.notifications.bots.slack.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.notifications.bots.slack.tolerations }}
+      {{- end }}
+      {{- with .Values.notifications.bots.slack.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
 {{ end }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -38,30 +38,16 @@ spec:
         - name: {{ .Values.notifications.name }}
           image: {{ default .Values.global.image.repository .Values.notifications.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.notifications.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.notifications.image.imagePullPolicy }}
-          resources:
-            {{- toYaml .Values.notifications.resources | nindent 12 }}
           command:
             - argocd-notifications
             - --loglevel={{ default .Values.global.logging.level .Values.notifications.logLevel }}
             - --logformat={{ default .Values.global.logging.format .Values.notifications.logFormat }}
-            {{- if .Values.notifications.metrics.enabled }}
             - --metrics-port={{ .Values.notifications.metrics.port }}
-            {{- end }}
             - --namespace={{ .Release.Namespace }}
             - --argocd-repo-server={{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
             {{- range .Values.notifications.extraArgs }}
             - {{ . | squote }}
             {{- end }}
-          workingDir: /app
-          ports:
-          {{- if .Values.notifications.metrics.enabled }}
-          - containerPort: {{ .Values.notifications.metrics.port }}
-            name: metrics
-            protocol: TCP
-          {{- end }}
-          {{- if .Values.notifications.containerSecurityContext }}
-          securityContext: {{- toYaml .Values.notifications.containerSecurityContext | nindent 12 }}
-          {{- end }}
           {{- with .Values.notifications.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -70,6 +56,15 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          ports:
+          - name: metrics
+            containerPort: {{ .Values.notifications.metrics.port }}
+            protocol: TCP
+          resources:
+            {{- toYaml .Values.notifications.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.notifications.containerSecurityContext | nindent 12 }}
+          workingDir: /app
           volumeMounts:
             - name: tls-certs
               mountPath: /app/config/tls

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -55,10 +55,6 @@ spec:
         {{- with .Values.repoServer.extraArgs }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.repoServer.containerSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         env:
           {{- with .Values.repoServer.env }}
             {{- toYaml . | nindent 10 }}
@@ -254,10 +250,10 @@ spec:
           timeoutSeconds: {{ .Values.repoServer.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.repoServer.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.repoServer.readinessProbe.failureThreshold }}
-        {{- with .Values.repoServer.resources }}
         resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.repoServer.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
       {{- with .Values.repoServer.extraContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -52,10 +52,6 @@ spec:
         {{- with .Values.server.extraArgs }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.server.containerSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         env:
           {{- with .Values.server.env }}
             {{- toYaml . | nindent 10 }}
@@ -309,10 +305,10 @@ spec:
           timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-        {{- with .Values.server.resources }}
         resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.server.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.server.containerSecurityContext | nindent 10 }}
         {{- with .Values.server.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}
@@ -324,11 +320,13 @@ spec:
       - name: argocd-extensions
         image: {{ .Values.server.extensions.image.repository }}:{{ .Values.server.extensions.image.tag }}
         imagePullPolicy: {{ .Values.server.extensions.image.imagePullPolicy }}
+        resources:
+          {{- toYaml .Values.server.extensions.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.server.extensions.containerSecurityContext | nindent 10 }}
         volumeMounts:
           - name: extensions
             mountPath: /tmp/extensions/
-        resources:
-          {{- toYaml .Values.server.extensions.resources | nindent 10 }}
       {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -36,12 +36,6 @@ spec:
       - name: copyutil
         image: {{ default .Values.global.image.repository .Values.dex.initImage.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.dex.initImage.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.initImage.imagePullPolicy }}
-        resources:
-          {{- toYaml .Values.dex.resources | nindent 10 }}
-        {{- with .Values.dex.containerSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         command:
         - cp
         - -n
@@ -52,6 +46,10 @@ spec:
           name: static-files
         - mountPath: /tmp
           name: dexconfig
+        resources:
+          {{- toYaml .Values.dex.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
       {{- with .Values.dex.initContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -64,10 +62,7 @@ spec:
         args:
         - rundex
         {{- with .Values.dex.extraArgs }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if .Values.dex.containerSecurityContext }}
-        securityContext: {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
           {{- with .Values.dex.env }}
@@ -115,18 +110,20 @@ spec:
           successThreshold: {{ .Values.dex.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.dex.readinessProbe.failureThreshold }}
         {{- end }}
+        resources:
+          {{- toYaml .Values.dex.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
         volumeMounts:
+        {{- with .Values.dex.volumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: static-files
           mountPath: /shared
         - name: dexconfig
           mountPath: /tmp
         - name: argocd-dex-server-tls
           mountPath: /tls
-        {{- with .Values.dex.volumeMounts }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        resources:
-          {{- toYaml .Values.dex.resources | nindent 10 }}
       {{- with .Values.dex.extraContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -63,10 +63,8 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.resources | nindent 10 }}
-        {{- with .Values.redis.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.redis.containerSecurityContext | nindent 10 }}
         {{- with .Values.redis.volumeMounts }}
         volumeMounts:
           {{- toYaml . | nindent 10 }}
@@ -86,10 +84,8 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.metrics.resources | nindent 10 }}
-        {{- with .Values.redis.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.redis.metrics.containerSecurityContext | nindent 10 }}
       {{- end }}
       {{- with .Values.redis.extraContainers }}
         {{- toYaml . | nindent 6 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -558,13 +558,16 @@ controller:
   podLabels: {}
 
   # -- Application controller container-level security context
+  # @default -- See [values.yaml]
   containerSecurityContext:
-    {}
-    # capabilities:
-    #   drop:
-    #     - all
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   # -- Application controller listening port
   containerPort: 8082
@@ -814,6 +817,7 @@ dex:
   # @default -- `[]` (defaults to global.imagePullSecrets)
   imagePullSecrets: []
 
+  # Argo CD init image that creates Dex config
   initImage:
     # -- Argo CD init image repository
     # @default -- `""` (defaults to global.image.repository)
@@ -841,6 +845,18 @@ dex:
 
   # -- Labels to be added to the Dex server pods
   podLabels: {}
+
+  # -- Dex container-level security context
+  # @default -- See [values.yaml]
+  containerSecurityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   ## Probes for Dex server
   ## Supported from Dex >= 2.28.0
@@ -921,14 +937,6 @@ dex:
 
   # -- Priority class for dex
   priorityClassName: ""
-
-  # -- Dex container-level security context
-  containerSecurityContext:
-    {}
-    # capabilities:
-    #   drop:
-    #     - all
-    # readOnlyRootFilesystem: true
 
   # -- Resource limits and requests for dex
   resources: {}
@@ -1021,6 +1029,22 @@ redis:
   # -- Labels to be added to the Redis server pods
   podLabels: {}
 
+  # -- Redis pod-level security context
+  # @default -- See [values.yaml]
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Redis container-level security context
+  # @default -- See [values.yaml]
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
@@ -1038,19 +1062,6 @@ redis:
 
   # -- Priority class for redis
   priorityClassName: ""
-
-  # -- Redis container-level security context
-  containerSecurityContext:
-    {}
-    # capabilities:
-    #   drop:
-    #     - all
-    # readOnlyRootFilesystem: true
-
-  # -- Redis pod-level security context
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 999
 
   serviceAccount:
     # -- Create a service account for the redis pod
@@ -1113,6 +1124,19 @@ redis:
       imagePullPolicy: IfNotPresent
     # -- Port to use for redis-exporter sidecar
     containerPort: 9121
+
+    # -- Redis exporter security context
+    # @default -- See [values.yaml]
+    containerSecurityContext:
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+        - ALL
+
     # -- Resource limits and requests for redis-exporter sidecar
     resources: {}
       # limits:
@@ -1371,13 +1395,17 @@ server:
   # -- Priority class for the Argo CD server
   priorityClassName: ""
 
-  # -- Servers container-level security context
+  # -- Server container-level security context
+  # @default -- See [values.yaml]
   containerSecurityContext:
-    {}
-    # capabilities:
-    #   drop:
-    #     - all
-    # readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   # -- Resource limits and requests for the Argo CD server
   resources: {}
@@ -1732,6 +1760,18 @@ server:
       # -- Image pull policy for extensions
       imagePullPolicy: IfNotPresent
 
+    # -- Server UI extensions container-level security context
+    # @default -- See [values.yaml]
+    containerSecurityContext:
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+        - ALL
+
     # -- Resource limits and requests for the argocd-extensions container
     resources: {}
     #  limits:
@@ -1895,12 +1935,16 @@ repoServer:
   priorityClassName: ""
 
   # -- Repo server container-level security context
+  # @default -- See [values.yaml]
   containerSecurityContext:
-    {}
-    # capabilities:
-    #   drop:
-    #     - all
-    # readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   # -- Resource limits and requests for the repo server pods
   resources: {}
@@ -2149,18 +2193,17 @@ applicationSet:
   # -- Labels for the controller pods
   podLabels: {}
 
-  # -- Pod Security Context
-  podSecurityContext: {}
-    # fsGroup: 2000
-
-  # -- Security Context
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  # -- ApplicationSet controller container-level security context
+  # @default -- See [values.yaml]
+  containerSecurityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   ## Probes for ApplicationSet controller (optional)
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
@@ -2440,8 +2483,17 @@ notifications:
   # -- Labels to be applied to the controller Pods
   podLabels: {}
 
-  # -- Container Security Context
-  containerSecurityContext: {}
+  # -- Notification controller container-level security Context
+  # @default -- See [values.yaml]
+  containerSecurityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   # -- Priority class for the controller pods
   priorityClassName: ""
@@ -2810,12 +2862,17 @@ notifications:
         # -- Annotations applied to created service account
         annotations: {}
 
-      # -- Pod Security Context
-      securityContext:
+      # -- Slack bot container-level security Context
+      # @default -- See [values.yaml]
+      containerSecurityContext:
         runAsNonRoot: true
-
-      # -- Container Security Context
-      containerSecurityContext: {}
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+          - ALL
 
       # -- Resource limits and requests for the Slack bot
       resources: {}


### PR DESCRIPTION
Resolves: 
- https://github.com/argoproj/argo-helm/issues/1494
- https://github.com/argoproj/argo-helm/issues/1560

Container security context have been placed into same place across all components
Minimum supported version is 1.22 based on https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#supported-versions

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
