### PR TITLE
chore(argo-cd): Remove liveness probe from application controller

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.5.0
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.9.0
+version: 5.9.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -22,4 +22,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Optional probes for ApplicationSet controller"
+    - "[Removed]: Liveness probe for application controller"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -441,11 +441,6 @@ NAME: my-release
 | controller.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the application controller |
 | controller.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | controller.initContainers | list | `[]` | Init containers to add to the application controller pod |
-| controller.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
-| controller.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
-| controller.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
-| controller.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
-| controller.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | controller.metrics.applicationLabels.enabled | bool | `false` | Enables additional labels in argocd_app_labels metric |
 | controller.metrics.applicationLabels.labels | list | `[]` | Additional labels |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -231,15 +231,6 @@ spec:
         - name: metrics
           containerPort: {{ .Values.controller.containerPort }}
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: metrics
-          initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /healthz

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -98,18 +98,22 @@ spec:
           httpGet:
             path: /healthz/live
             port: metrics
-          {{- with .Values.dex.livenessProbe }}
-            {{- omit . "enabled" | toYaml | nindent 10 }}
-          {{- end }}
+          initialDelaySeconds: {{ .Values.dex.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.dex.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.dex.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.dex.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.dex.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if .Values.dex.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /healthz/ready
             port: metrics
-          {{- with .Values.dex.readinessProbe }}
-            {{- omit . "enabled" | toYaml | nindent 10 }}
-          {{- end }}
+          initialDelaySeconds: {{ .Values.dex.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.dex.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.dex.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.dex.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.dex.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
         - name: static-files

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -569,20 +569,9 @@ controller:
   # -- Application controller listening port
   containerPort: 8082
 
-  ## Readiness and liveness probes for default backend
+  # Rediness probe for application controller
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
   readinessProbe:
-    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
-    failureThreshold: 3
-    # -- Number of seconds after the container has started before [probe] is initiated
-    initialDelaySeconds: 10
-    # -- How often (in seconds) to perform the [probe]
-    periodSeconds: 10
-    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
-    successThreshold: 1
-    # -- Number of seconds after which the [probe] times out
-    timeoutSeconds: 1
-  livenessProbe:
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
     # -- Number of seconds after the container has started before [probe] is initiated


### PR DESCRIPTION
- Align application controller based on @mkilchhofer comment
- Use same template pattern for Dex probes

Ref:
- argoproj/argo-cd#9557

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
