### PR TITLE
fix(argo-cd): Fix config migration path

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.5.0
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.8.5
+version: 5.8.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -22,5 +22,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Cleanup indentation in Redis deployment manifest"
-    - "[Fixed]: Global image pull policy works with Redis"
+    - "[Fixed]: Migration of configs for users who create them manually"

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -34,10 +34,10 @@ DEPRECATED option repoServer.logFormat - Use configs.params.repoServer.log.forma
 {{- if .Values.repoServer.logLevel }}
 DEPRECATED option repoServer.logLevel - Use configs.params.repoServer.log.level
 {{- end }}
-{{- if or .Values.server.config .Values.server.configEnabled .Values.server.configAnnotations }}
+{{- if or .Values.server.config (hasKey .Values.server "configEnabled") .Values.server.configAnnotations }}
 DEPRECATED option server.config - Use configs.cm
 {{- end }}
-{{- if or .Values.server.rbacConfig .Values.server.rbacConfigCreate .Values.server.rbacConfigAnnotations }}
+{{- if or .Values.server.rbacConfig (hasKey .Values.server "rbacConfigCreate") .Values.server.rbacConfigAnnotations }}
 DEPRECATED option server.rbacConfig - Use configs.rbac
 {{- end }}
 {{- if .Values.controller.service }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
@@ -1,4 +1,4 @@
-{{- if (coalesce .Values.server.configEnabled .Values.configs.cm.create) }}
+{{- if (hasKey .Values.server "configEnabled") | ternary .Values.server.configEnabled .Values.configs.cm.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -1,4 +1,4 @@
-{{- if (coalesce .Values.server.rbacConfigCreate .Values.configs.rbac.create) }}
+{{- if (hasKey .Values.server "rbacConfigCreate") | ternary .Values.server.rbacConfigCreate .Values.configs.rbac.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Fixes situation when user disabled creation of configs. Coalesce takes `server.configEnabled: false` as empty value and condition will fall through to `cm.create: true`.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
