### PR TITLE
fix(argo-workflows): serviceaccount rbac when sso is enabled

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.20.4
+version: 0.20.5
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Enable to set different imagePullPolicy for mainContainer and executor"
+    - "[Fixed]: Removed invalid rbac block from configmap"

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -131,10 +131,6 @@ data:
         name: {{ .clientSecret.name }}
         key: {{ .clientSecret.key }}
       redirectUrl: {{ .redirectUrl }}
-      {{- with .rbac }}
-      rbac:
-        enabled: {{ .enabled }}
-      {{- end }}
       {{- if .scopes }}
       scopes: {{ toYaml .scopes | nindent 8 }}
       {{- end }}

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -30,7 +30,7 @@ rules:
   - list
   - watch
   - delete
-  {{- if .Values.server.sso }}
+{{- if .Values.server.sso }}
 - apiGroups:
   - ""
   resources:
@@ -46,7 +46,7 @@ rules:
   - secrets
   verbs:
   - create
-    {{- if .Values.server.sso.rbac }}
+  {{- if .Values.server.sso.rbac }}
 - apiGroups:
   - ""
   resources:
@@ -55,8 +55,8 @@ rules:
   - get
   - list
   - watch
-    {{- end }}
   {{- end }}
+{{- end }}
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Fixes: #1572 

Removed the sso.rbac map as it breaks the sso integration. Also if the sso block is used we should include serviceaccount in our clusterrole instead of being managed by another setting.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
