### PR TITLE
chore(argo-cd): Consolidate cluster-wide RBAC

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.14
+version: 5.16.15
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,6 +23,7 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Docs]: Added sample how to provide K8s credentials plugin"
-    - "[Docs]: Added sample how to provide Argo config management plugin"
-    - "[Docs]: Removed samples that injects tools into incorrect controllers"
+    - "[Added]: Option createClusterRoles to enable cluster roles from one place"
+    - "[Deprecated]: Option controller.clusterAdminAccess.enabled"
+    - "[Deprecated]: Option server.clusterAdminAccess.enabled"
+    - "[Deprecated]: Option repoServer.clusterAdminAccess.enabled"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -362,7 +362,8 @@ NAME: my-release
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |
-| createAggregateRoles | bool | `false` | Create clusterroles that extend existing clusterroles to interact with argo-cd crds |
+| createAggregateRoles | bool | `false` | Create aggregated roles that extend existing cluster roles to interact with argo-cd resources |
+| createClusterRoles | bool | `true` | Create cluster roles for cluster-wide installation. |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | fullnameOverride | string | `""` | String to fully override `"argo-cd.fullname"` |
 | kubeVersionOverride | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests |
@@ -451,7 +452,6 @@ NAME: my-release
 |-----|------|---------|-------------|
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | controller.args | object | `{}` | DEPRECATED - Application controller commandline flags |
-| controller.clusterAdminAccess.enabled | bool | `true` | Enable RBAC for local cluster deployments |
 | controller.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the application controller's ClusterRole resource |
 | controller.clusterRoleRules.rules | list | `[]` | List of custom rules for the application controller's ClusterRole resource |
 | controller.containerPort | int | `8082` | Application controller listening port |
@@ -529,7 +529,6 @@ NAME: my-release
 | repoServer.certificateSecret.enabled | bool | `false` | Create argocd-repo-server-tls secret |
 | repoServer.certificateSecret.key | string | `""` | Certificate private key |
 | repoServer.certificateSecret.labels | object | `{}` | Labels to be added to argocd-repo-server-tls secret |
-| repoServer.clusterAdminAccess.enabled | bool | `false` | Enable RBAC for local cluster deployments |
 | repoServer.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the Repo server's Cluster Role resource |
 | repoServer.clusterRoleRules.rules | list | `[]` | List of custom rules for the Repo server's Cluster Role resource |
 | repoServer.containerPort | int | `8081` | Configures the repo server port |
@@ -631,7 +630,6 @@ NAME: my-release
 | server.certificateSecret.enabled | bool | `false` | Create argocd-server-tls secret |
 | server.certificateSecret.key | string | `""` | Private Key of the certificate |
 | server.certificateSecret.labels | object | `{}` | Labels to be added to argocd-server-tls secret |
-| server.clusterAdminAccess.enabled | bool | `true` | Enable RBAC for local cluster deployments |
 | server.containerPort | int | `8080` | Configures the server port |
 | server.containerSecurityContext | object | See [values.yaml] | Server container-level security context |
 | server.deploymentAnnotations | object | `{}` | Annotations to be added to server Deployment |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -52,6 +52,18 @@ DEPRECATED option configs.gpgKeys - Use config.gpg.keys
 {{- if .Values.configs.gpgKeysAnnotations }}
 DEPRECATED option configs.gpgKeysAnnotations - Use config.gpg.annotations
 {{- end }}
+{{- if hasKey .Values "createAggregateRoles" }}
+DEPRECATED option createAggregateRoles - Use global.rbac.aggregatedRoles
+{{- end }}
+{{- if hasKey (.Values.controller.clusterAdminAccess | default dict) "enabled" }}
+DEPRECATED option .controller.clusterAdminAccess.enabled - Use createClusterRoles
+{{- end }}
+{{- if hasKey (.Values.server.clusterAdminAccess | default dict) "enabled" }}
+DEPRECATED option .server.clusterAdminAccess.enabled - Use createClusterRoles
+{{- end }}
+{{- if hasKey (.Values.repoServer.clusterAdminAccess | default dict) "enabled" }}
+DEPRECATED option .server.clusterAdminAccess.enabled - Use createClusterRoles
+{{- end }}
 {{- if .Values.controller.service }}
 REMOVED option controller.service - Use controller.metrics
 {{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/clusterrole.yaml
@@ -1,23 +1,24 @@
-{{- if .Values.controller.clusterAdminAccess.enabled }}
+{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "argo-cd.controller.fullname" . }}
+  name: {{ include "argo-cd.controller.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:
   {{- if .Values.controller.clusterRoleRules.enabled }}
-  {{- toYaml .Values.controller.clusterRoleRules.rules | nindent 0 }}
+    {{- toYaml .Values.controller.clusterRoleRules.rules | nindent 2 }}
   {{- else }}
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - nonResourceURLs:
+    - '*'
+    verbs:
+    - '*'
   {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
@@ -1,16 +1,17 @@
-{{- if .Values.controller.clusterAdminAccess.enabled }}
+{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "argo-cd.controller.fullname" . }}
+  name: {{ include "argo-cd.controller.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "argo-cd.controller.fullname" . }}
+  name: {{ include "argo-cd.controller.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.controllerServiceAccountName" . }}
+  name: {{ include "argo-cd.controllerServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/clusterrole.yaml
@@ -1,23 +1,24 @@
-{{- if and .Values.repoServer.serviceAccount.create .Values.repoServer.clusterAdminAccess.enabled }}
+{{- $config := .Values.repoServer.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "argo-cd.repoServer.fullname" . }}
+  name: {{ include "argo-cd.repoServer.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
 rules:
   {{- if .Values.repoServer.clusterRoleRules.enabled }}
-  {{- toYaml .Values.repoServer.clusterRoleRules.rules | nindent 0 }}
+    {{- toYaml .Values.repoServer.clusterRoleRules.rules | nindent 2 }}
   {{- else }}
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+    - '*'
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - nonResourceURLs:
+    - '*'
+    verbs:
+    - '*'
   {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/clusterrolebinding.yaml
@@ -1,16 +1,17 @@
-{{- if and .Values.repoServer.serviceAccount.create .Values.repoServer.clusterAdminAccess.enabled }}
+{{- $config := .Values.repoServer.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "argo-cd.repoServer.fullname" . }}
+  name: {{ include "argo-cd.repoServer.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "argo-cd.repoServer.fullname" . }}
+  name: {{ include "argo-cd.repoServer.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.repoServerServiceAccountName" . }}
+  name: {{ include "argo-cd.repoServerServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.server.clusterAdminAccess.enabled }}
+{{- $config := .Values.server.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/argo-cd/templates/argocd-server/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrolebinding.yaml
@@ -1,16 +1,17 @@
-{{- if .Values.server.clusterAdminAccess.enabled }}
+{{- $config := .Values.server.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "argo-cd.server.fullname" . }}
+  name: {{ include "argo-cd.server.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "argo-cd.server.fullname" . }}
+  name: {{ include "argo-cd.server.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.serverServiceAccountName" . }}
+  name: {{ include "argo-cd.serverServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -19,9 +19,12 @@ apiVersionOverrides:
   # -- String to override apiVersion of autoscaling rendered by this helm chart
   autoscaling: "" # autoscaling/v2
 
-# -- Create clusterroles that extend existing clusterroles to interact with argo-cd crds
+# -- Create aggregated roles that extend existing cluster roles to interact with argo-cd resources
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
 createAggregateRoles: false
+# -- Create cluster roles for cluster-wide installation.
+## Used when you manage applications in the same cluster where Argo CD runs
+createClusterRoles: true
 
 openshift:
   # -- enables using arbitrary uid for argo repo server
@@ -717,11 +720,6 @@ controller:
     #   namespace: monitoring
     #   additionalLabels: {}
     #   annotations: {}
-
-  ## Enable if you would like to grant rights to Argo CD to deploy to the local Kubernetes cluster.
-  clusterAdminAccess:
-    # -- Enable RBAC for local cluster deployments
-    enabled: true
 
   ## Enable this and set the rules: to whatever custom rules you want for the Cluster Role resource.
   ## Defaults to off
@@ -1732,12 +1730,6 @@ server:
     # -- Termination policy of Openshift Route
     termination_policy: None
 
-  ## Enable Admin ClusterRole resources.
-  ## Enable if you would like to grant rights to Argo CD to deploy to the local Kubernetes cluster.
-  clusterAdminAccess:
-    # -- Enable RBAC for local cluster deployments
-    enabled: true
-
   GKEbackendConfig:
     # -- Enable BackendConfig custom resource for Google Kubernetes Engine
     enabled: false
@@ -2031,11 +2023,6 @@ repoServer:
       # -- Prometheus ServiceMonitor annotations
       annotations: {}
 
-  ## Enable Admin ClusterRole resources.
-  ## Enable if you would like to grant cluster rights to Argo CD repo server.
-  clusterAdminAccess:
-    # -- Enable RBAC for local cluster deployments
-    enabled: false
   ## Enable Custom Rules for the Repo server's Cluster Role resource
   ## Enable this and set the rules: to whatever custom rules you want for the Cluster Role resource.
   ## Defaults to off


### PR DESCRIPTION
Argo CD 2.5.0 introduced feature for managing applications in other namespaces and users are starting to look for a ways to disable cluster roles to have namespaced installation. This PR consolidates cluster-wide RBAC under single configuration key.

Closes: https://github.com/argoproj/argo-helm/issues/1592

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
