### PR TITLE
fix(argo-cd): Replace coalesce with merge for old config values

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.0
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.12.2
+version: 5.12.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Update network policy to fix prometheus scraping for argocd-application-controller"
+    - "[Fixed]: Merging of old configs with newly defined sections to get default values"

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -182,7 +182,7 @@ ui.cssurl: "./custom/custom.styles.css"
 Merge Argo Configuration with Preset Configuration
 */}}
 {{- define "argo-cd.config.cm" -}}
-{{- $config := coalesce .Values.server.config (omit .Values.configs.cm "create" "annotations") -}}
+{{- $config := (mergeOverwrite (deepCopy (omit .Values.configs.cm "create" "annotations")) (.Values.server.config | default dict))  -}}
 {{- $preset := include "argo-cd.config.cm.presets" . | fromYaml | default dict -}}
 {{- range $key, $value := mergeOverwrite $preset $config }}
 {{ $key }}: {{ toString $value | toYaml }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
@@ -5,7 +5,7 @@ metadata:
   name: argocd-cm
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" "cm") | nindent 4 }}
-  {{- with (coalesce .Values.server.configAnnotations .Values.configs.cm.annotations) }}
+  {{- with (mergeOverwrite (deepCopy .Values.configs.cm.annotations) (.Values.server.configAnnotations | default dict)) }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-rbac-cm.yaml
@@ -5,13 +5,13 @@ metadata:
   name: argocd-rbac-cm
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" "rbac-cm") | nindent 4 }}
-  {{- with (coalesce .Values.server.rbacConfigAnnotations .Values.configs.rbac.annotations) }}
+  {{- with (mergeOverwrite (deepCopy .Values.configs.rbac.annotations) (.Values.server.rbacConfigAnnotations | default dict)) }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
-{{- with (coalesce .Values.server.rbacConfig (omit .Values.configs.rbac "create" "annotations")) }}
+{{- with (mergeOverwrite (deepCopy (omit .Values.configs.rbac "create" "annotations")) (.Values.server.rbacConfig | default dict)) }}
 data:
   {{- toYaml . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Closes: https://github.com/argoproj/argo-helm/issues/1611

As pointed out in the issue `colaesce` do not respect old default values and proper way would be to merge new section with the old one.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
