### PR TITLE
fix(argo-cd): Add missing applicaton & events create ClusterRole perms

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.13.6
+version: 5.13.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.1
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.13.4
+version: 5.13.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Add missing ClusterRole permissions to argo-cd-server to manage Application in all namespaces"
+    - "[Fixed]: Add missing events create & application create ClusterRole permissions to argo-cd-server to manage Application in all namespaces"

--- a/charts/argo-cd/templates/argocd-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrole.yaml
@@ -20,6 +20,7 @@ rules:
       - events
     verbs:
       - list
+      - create
   - apiGroups:
       - ""
     resources:
@@ -43,5 +44,6 @@ rules:
       - get
       - list
       - update
+      - create
       - watch
 {{- end }}


### PR DESCRIPTION
This expands upon #1621 and provides the full fix for allowing to create applications in all namespaces.

argocd-server log before the change:
```
time="2022-11-07T19:47:01Z" level=warning msg="finished unary call with code PermissionDenied" error="rpc error: code = PermissionDenied desc = error creating application: applications.argoproj.io is forbidden: User \"system:serviceaccount:argocd:argocd-server\" cannot create resource \"applications\" in API group \"argoproj.io\" in the namespace \"mynamespace\"" grpc.code=PermissionDenied grpc.method=Create grpc.service=application.ApplicationService grpc.start_time="2022-11-07T19:47:00Z" grpc.time_ms=1151.638 span.kind=server system=grpc

time="2022-11-07T19:58:49Z" level=error msg="Unable to create audit event: events is forbidden: User \"system:serviceaccount:argocd:argocd-server\" cannot create resource \"events\" in API group \"\" in the namespace \"mynamespace\"" application=guestbook dest-namespace=default dest-server="https://kubernetes.default.svc" reason=ResourceCreated type=Normal
```
Both of the errors are cleared up with this PR.

Signed-off-by: Nick Fisher <nxf5025@gmail.com>

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
