### PR TITLE
fix(argo-cd): Use raw json for cluster credentials for Vault compatibility

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.13.6
+version: 5.13.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Argo CD to 2.5.2"
+    - "[Fixed]: Use raw json format for cluster credentials for Vault plugin compatibility"

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -26,6 +26,5 @@ stringData:
   clusterResources: {{ .clusterResources | quote }}
     {{- end }}
   {{- end }}
-  config: |
-    {{- required "A valid .Values.configs.clusterCredentials[].config entry is required!" .config | toPrettyJson | nindent 4 }}
+  config: {{ required "A valid .Values.configs.clusterCredentials[].config entry is required!" .config | toRawJson }}
 {{- end }}


### PR DESCRIPTION
Closes:
- #1633
- #1117

Use provided cluster config json config as is to enable post-processing by Vault plugin.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
