### PR TITLE
feat(argo-events): Allow users not to install controller

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.3
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.6
+version: 2.0.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Argo events controller to v1.7.3"
+    - "[Added]: Allow users not to install controller"

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -23,7 +23,7 @@ To regenerate this document, please run:
 
 Some users would prefer to install the CRDs _outside_ of the chart. You can disable the CRD installation of this chart by using `--set crds.install=false` when installing the chart.
 
-You can install the CRDs manually from `templates/crds` folder.
+You can install the only CRDs manually setting using `--set crds.install=true --set controller.install=false`
 
 ### 2.0.*
 
@@ -88,6 +88,7 @@ done
 | controller.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the events controller |
 | controller.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the events controller |
 | controller.initContainers | list | `[]` | Init containers to add to the events controller pods |
+| controller.install | bool | `true` | Install Argo Events controller |
 | controller.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | controller.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | controller.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |

--- a/charts/argo-events/templates/argo-events-controller/config.yaml
+++ b/charts/argo-events/templates/argo-events-controller/config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,3 +41,4 @@ data:
           startCommand: {{ .startCommand }}
         {{- end }}
       {{- end }}
+{{- end }}

--- a/charts/argo-events/templates/argo-events-controller/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-controller/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -135,3 +136,4 @@ spec:
       {{- with .Values.controller.volumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/charts/argo-events/templates/argo-events-controller/pdb.yaml
+++ b/charts/argo-events/templates/argo-events-controller/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 {{- if .Values.controller.pdb.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -25,4 +26,5 @@ spec:
   selector:
     matchLabels:
       {{- include "argo-events.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/argo-events/templates/argo-events-controller/rbac.yaml
+++ b/charts/argo-events/templates/argo-events-controller/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 {{- if .Values.controller.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.controller.rbac.namespaced | ternary "Role" "ClusterRole" }}
@@ -110,4 +111,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "argo-events.controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/argo-events/templates/argo-events-controller/service.yaml
+++ b/charts/argo-events/templates/argo-events-controller/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 {{- if .Values.controller.metrics.enabled }}
 apiVersion: v1
 kind: Service
@@ -22,4 +23,5 @@ spec:
     targetPort: metrics
   selector:
     {{- include "argo-events.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/argo-events/templates/argo-events-controller/serviceaccount.yaml
+++ b/charts/argo-events/templates/argo-events-controller/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 {{- if .Values.controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -12,4 +13,5 @@ metadata:
   {{- end }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/argo-events/templates/argo-events-controller/servicemonitor.yaml
+++ b/charts/argo-events/templates/argo-events-controller/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.install }}
 {{- if and .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -35,4 +36,5 @@ spec:
   selector:
     matchLabels:
       {{- include "argo-events.selectorLabels" (dict "context" . "component" .Values.controller.name "name" (printf "%s-metrics" .Values.controller.name)) | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -97,6 +97,9 @@ configs:
 
 ## Argo Events controller
 controller:
+  # -- Install Argo Events controller
+  install: true
+
   # -- Argo Events controller name string
   name: controller-manager
 


### PR DESCRIPTION
Currently, there is no way to install only the CRDs. I would like to provide an option to install only the CRDs by setting `controller.install` to `false` and `crds.install` to true

Signed-off-by: emmayylu <emma.yongyi.lu@gmail.com>

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
