### PR TITLE
feat(argo-workflows): Allow controller to whitelist secrets

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.3
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.20.8
+version: 0.20.9
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: add missing attribute for sso"
+    - "[Fixed]: allow users to optionally whitelist secrets"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -107,7 +107,7 @@ Fields to note:
 | controller.podSecurityContext | object | `{}` | SecurityContext to set on the controller pods |
 | controller.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages. |
 | controller.rbac.create | bool | `true` | Adds Role and RoleBinding for the controller. |
-| controller.rbac.secretWhitelist | object | `{}` | Allows controller to get, list, abd watch certain k8s secrets |
+| controller.rbac.secretWhitelist | list | `[]` | Allows controller to get, list, and watch certain k8s secrets |
 | controller.replicas | int | `1` | The number of controller pods to run |
 | controller.resourceRateLimit | object | `{}` | Globally limits the rate at which pods are created. This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of parallel nodes. |
 | controller.resources | object | `{}` | Resource limits and requests for the controller |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -107,6 +107,7 @@ Fields to note:
 | controller.podSecurityContext | object | `{}` | SecurityContext to set on the controller pods |
 | controller.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages. |
 | controller.rbac.create | bool | `true` | Adds Role and RoleBinding for the controller. |
+| controller.rbac.secretWhitelist | object | `{}` | Allows controller to get, list, abd watch certain k8s secrets |
 | controller.replicas | int | `1` | The number of controller pods to run |
 | controller.resourceRateLimit | object | `{}` | Globally limits the rate at which pods are created. This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of parallel nodes. |
 | controller.resources | object | `{}` | Resource limits and requests for the controller |

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -164,6 +164,19 @@ rules:
   resourceNames:
   {{/* for HTTP templates */}}
   - argo-workflows-agent-ca-certificates
+{{- if .Values.controller.rbac.secretWhitelist }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  {{- with .Values.controller.rbac.secretWhitelist }}
+  resourceNames: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
 
 {{- if .Values.controller.clusterWorkflowTemplates.enabled }}
 ---

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -164,7 +164,7 @@ rules:
   resourceNames:
   {{/* for HTTP templates */}}
   - argo-workflows-agent-ca-certificates
-{{- if .Values.controller.rbac.secretWhitelist }}
+{{- with .Values.controller.rbac.secretWhitelist }}
 - apiGroups:
   - ""
   resources:
@@ -173,9 +173,7 @@ rules:
   - get
   - list
   - watch
-  {{- with .Values.controller.rbac.secretWhitelist }}
   resourceNames: {{- toYaml . | nindent 4 }}
-  {{- end }}
 {{- end }}
 
 {{- if .Values.controller.clusterWorkflowTemplates.enabled }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -70,7 +70,7 @@ controller:
   rbac:
     # -- Adds Role and RoleBinding for the controller.
     create: true
-    # -- Allows controller to get, list, abd watch certain k8s secrets
+    # -- Allows controller to get, list, and watch certain k8s secrets
     secretWhitelist: []
 
   # -- Limits the maximum number of incomplete workflows in a namespace

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -70,6 +70,8 @@ controller:
   rbac:
     # -- Adds Role and RoleBinding for the controller.
     create: true
+    # -- Allows controller to get, list, abd watch certain k8s secrets
+    secretWhitelist: {}
 
   # -- Limits the maximum number of incomplete workflows in a namespace
   namespaceParallelism:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -71,7 +71,7 @@ controller:
     # -- Adds Role and RoleBinding for the controller.
     create: true
     # -- Allows controller to get, list, abd watch certain k8s secrets
-    secretWhitelist: {}
+    secretWhitelist: []
 
   # -- Limits the maximum number of incomplete workflows in a namespace
   namespaceParallelism:


### PR DESCRIPTION
Allow the controller to get any secrets.

When I was working with argo events, I created the following objects:
- an argo workflow that uses service account A
- service account A using mimagePullSecret `docker-registry`

The argo events sensor get an error when triggering the workflow. The error is `
secrets "docker-registry" is forbidden: User "system:serviceaccount:argo:my-argo-workflows-workflow-controller"
cannot get resource "secrets" in API group "" in the namespace "yolu-ci"'`

The error happens because the service account that the controller is using does not have permission to get secrets. This PR allows users to whitelist secrets. After making this change, the error is gone

Signed-off-by: emmayylu <84873428+yolu-kxs@users.noreply.github.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
