### PR TITLE
fix(argo-cd): Invalid argocd-gpg-keys-cm template

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.14.0
+version: 5.14.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/templates/argocd-configs/argocd-gpg-keys-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-gpg-keys-cm.yaml
@@ -4,13 +4,13 @@ metadata:
   name: argocd-gpg-keys-cm
   labels:
     {{- include "argo-cd.labels" (dict "context" . "name" "gpg-keys-cm") | nindent 4 }}
-  {{- with (mergeOverwrite (deepCopy .Values.configs.gpg.annotations) (.Values.configs.gpgKeysAnnotations | default dict)) -}}
+  {{ with (mergeOverwrite (deepCopy .Values.configs.gpg.annotations) (.Values.configs.gpgKeysAnnotations | default dict)) -}}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
-{{- with (mergeOverwrite (deepCopy .Values.configs.gpg.keys) (.Values.configs.gpgKeys | default dict)) -}}
+{{ with (mergeOverwrite (deepCopy .Values.configs.gpg.keys) (.Values.configs.gpgKeys | default dict)) -}}
 data:
   {{- toYaml . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
The template removed a little too much whitespace resulting in an invalid ConfigMap.

Error:
```
Error: YAML parse error on argocd/charts/argo-cd/templates/argocd-configs/argocd-gpg-keys-cm.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```

Signed-off-by: Allex <allexveldman+github@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
