### PR TITLE
fix(argo-cd): deprecate server.extraArgs."--insecure"

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.14.1
+version: 5.14.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,7 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Configuration option configs.gpg"
-    - "[Deprecated]: Configuration option configs.gpgKeys"
-    - "[Deprecated]: Configuration option configs.gpgKeysAnnotations"
-    - "[Fixed]: Documentation for declarative setup"
+    - "[Deprecated]: Configuration option server.extraArgs."--insecure""

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -28,6 +28,9 @@ DEPRECATED option server.logFormat - Use configs.params.server.log.format
 {{- if .Values.server.logLevel }}
 DEPRECATED option server.logLevel - Use configs.params.server.log.level
 {{- end }}
+{{- if has "--insecure" .Values.server.extraArgs }}
+DEPRECATED option server.extraArgs."--insecure" - Use configs.params.server.insecure
+{{- end }}
 {{- if .Values.repoServer.logFormat }}
 DEPRECATED option repoServer.logFormat - Use configs.params.repoServer.log.format
 {{- end }}


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
