### PR TITLE
feat(argo-cd): Set aggregate roles only for using resources, with argocdextensions also

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.3
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.0
+version: 5.16.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,6 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Ability to annotate Deployment and Statefulset objects for all components"
+    - "[Fixed]: Set aggregate roles only for using resources"
+    - "[Added]: Add argocdextensions to aggregate roles"
+    - "[Fixed]: Fix typo of notification.bots.slack.image in values"

--- a/charts/argo-cd/templates/aggregate-roles.yaml
+++ b/charts/argo-cd/templates/aggregate-roles.yaml
@@ -11,7 +11,12 @@ rules:
   - argoproj.io
   resources:
   - applications
+  {{- if .Values.applicationSet.enabled }}
   - applicationsets
+  {{- end }}
+  {{- if .Values.server.extensions.enabled }}
+  - argocdextensions
+  {{- end }}
   - appprojects
   verbs:
   - get
@@ -31,7 +36,12 @@ rules:
   - argoproj.io
   resources:
   - applications
+  {{- if .Values.applicationSet.enabled }}
   - applicationsets
+  {{- end }}
+  {{- if .Values.server.extensions.enabled }}
+  - argocdextensions
+  {{- end }}
   - appprojects
   verbs:
   - create
@@ -56,7 +66,12 @@ rules:
   - argoproj.io
   resources:
   - applications
+  {{- if .Values.applicationSet.enabled }}
   - applicationsets
+  {{- end }}
+  {{- if .Values.server.extensions.enabled }}
+  - argocdextensions
+  {{- end }}
   - appprojects
   verbs:
   - create

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2890,7 +2890,7 @@ notifications:
         ## Has higher precedence over `notifications.bots.slack.pdb.minAvailable`
         maxUnavailable: ""
 
-      ## Slack bot imabe
+      ## Slack bot image
       image:
         # -- Repository to use for the Slack bot
         # @default -- `""` (defaults to global.image.repository)


### PR DESCRIPTION
Signed-off-by: Hyeonmin Park <hyeonmin.park@kennysoft.kr>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
