### PR TITLE
fix(argo-workflows): missing artifact GC rbac

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.21.0
+version: 0.22.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Removed]: Deprecated Role permission"
+    - "[Fixed]: Missing Artifact GC permissions"

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -42,6 +42,7 @@ rules:
       - argoproj.io
     resources:
       - workflowtasksets
+      - workflowartifactgctasks
     verbs:
       - list
       - watch
@@ -49,6 +50,7 @@ rules:
       - argoproj.io
     resources:
       - workflowtasksets/status
+      - workflowartifactgctasks/status
     verbs:
       - patch
   {{- end }}


### PR DESCRIPTION
According to the documentation:
https://argoproj.github.io/argo-workflows/walk-through/artifacts/#artifact-garbage-collection

Signed-off-by: danmx <daniel@iziourov.info>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
