### PR TITLE
fix(argocd-image-updater,argo-events,argo-rollouts,argo-workflows): SHA digest in image.tag no longer generates invalid label and fix webhook.image.tag reference

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -17,3 +17,4 @@ annotations:
   artifacthub.io/changes: |
     - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
     - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"
+    - "[Fixed]: webhook.image.tag value now overrides the tag in the webhook deployment"

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -15,4 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
+    - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
+    - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.3
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.6
+version: 2.0.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Argo events controller to v1.7.3"
+    - "[Changed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)

--- a/charts/argo-events/templates/_helpers.tpl
+++ b/charts/argo-events/templates/_helpers.tpl
@@ -69,6 +69,34 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create kubernetes friendly chart version label for the controller.
+
+Examples:
+image.tag = v1.7.3
+output    = v1.7.3
+
+image.tag = v1.7.3@sha256:a40f4f3ea20d354f00ab469a9f73102668fa545c4d632e1a8e11a206ad3093f3
+output    = v1.7.3
+*/}}
+{{- define "argo-events.controller_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-events.defaultTag" .) .Values.controller.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
+Create kubernetes friendly chart version label for the events webhook.
+
+Examples:
+image.tag = v1.7.3
+output    = v1.7.3
+
+image.tag = v1.7.3@sha256:a40f4f3ea20d354f00ab469a9f73102668fa545c4d632e1a8e11a206ad3093f3
+output    = v1.7.3
+*/}}
+{{- define "argo-events.webhook_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-events.defaultTag" .) .Values.webhook.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "argo-events.labels" -}}

--- a/charts/argo-events/templates/argo-events-controller/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-controller/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "argo-events.controller.fullname" . }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | quote }}
+    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
         {{- end }}
       labels:
         {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | quote }}
+        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.controller.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-events/templates/argo-events-controller/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-controller/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "argo-events.controller.fullname" . }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
+    app.kubernetes.io/version: {{ include "argo-events.controller_chart_version_label" . }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
         {{- end }}
       labels:
         {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
+        app.kubernetes.io/version: {{ include "argo-events.controller_chart_version_label" . }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.controller.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: events-webhook
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | quote }}
+    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | trunc 63 | quote }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | quote }}
+        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | trunc 63 | quote }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.webhook.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Values.webhook.name }}
-        image: {{ default .Values.global.image.repository .Values.webhook.image.repository }}:{{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag }}
+        image: {{ default .Values.global.image.repository .Values.webhook.image.repository }}:{{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.webhook.image.imagePullPolicy }}
         args:
         - webhook-service

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: events-webhook
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | trunc 63 | quote }}
+    app.kubernetes.io/version: {{ include "argo-events.webhook_chart_version_label" . }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | trunc 63 | quote }}
+        app.kubernetes.io/version: {{ include "argo-events.webhook_chart_version_label" . }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.webhook.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.3.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.21.1
+version: 2.21.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade ArgoRollouts to v1.3.1"
+    - "[Changed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -15,4 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
+    - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
+    - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller.image.tag with a SHA digest"

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Common labels
 helm.sh/chart: {{ include "argo-rollouts.chart" . }}
 {{ include "argo-rollouts.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ default .Chart.AppVersion $.Values.controller.image.tag | quote }}
+app.kubernetes.io/version: {{ default .Chart.AppVersion $.Values.controller.image.tag | trunc 63 | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: argo-rollouts

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -32,13 +32,27 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create kubernetes friendly chart version label.
+
+Examples:
+image.tag = v1.3.1
+output    = v1.3.1
+
+image.tag = v1.3.1@sha256:38828e693b02e6f858d89fa22a9d9811d3d7a2430a1d4c7d687b6f509775c6ce
+output    = v1.3.1
+*/}}
+{{- define "argo-rollouts.chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default .Chart.AppVersion $.Values.controller.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "argo-rollouts.labels" -}}
 helm.sh/chart: {{ include "argo-rollouts.chart" . }}
 {{ include "argo-rollouts.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ default .Chart.AppVersion $.Values.controller.image.tag | trunc 63 | quote }}
+app.kubernetes.io/version: {{ include "argo-rollouts.chart_version_label" . }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: argo-rollouts

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.22.0
+version: 0.22.1
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Missing Artifact GC permissions"
+    - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
+    - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/server/executor.image.tag with a SHA digest"

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -46,6 +46,45 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create kubernetes friendly chart version label for the controller.
+Examples:
+image.tag = v3.4.4
+output    = v3.4.4
+
+image.tag = v3.4.4@sha256:d06860f1394a94ac3ff8401126ef32ba28915aa6c3c982c7e607ea0b4dadb696
+output    = v3.4.4
+*/}}
+{{- define "argo-workflows.controller_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
+Create kubernetes friendly chart version label for the executor.
+Examples:
+image.tag = v3.4.4
+output    = v3.4.4
+
+image.tag = v3.4.4@sha256:d06860f1394a94ac3ff8401126ef32ba28915aa6c3c982c7e607ea0b4dadb696
+output    = v3.4.4
+*/}}
+{{- define "argo-workflows.executor_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
+Create kubernetes friendly chart version label for the server.
+Examples:
+image.tag = v3.4.4
+output    = v3.4.4
+
+image.tag = v3.4.4@sha256:d06860f1394a94ac3ff8401126ef32ba28915aa6c3c982c7e607ea0b4dadb696
+output    = v3.4.4
+*/}}
+{{- define "argo-workflows.server_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-workflows.defaultTag" .) .Values.server.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "argo-workflows.labels" -}}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
+    app.kubernetes.io/version: {{ include "argo-workflows.controller_chart_version_label" . }}
   {{- with .Values.controller.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}
+        app.kubernetes.io/version: {{ include "argo-workflows.controller_chart_version_label" . }}
         {{- with.Values.controller.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag | trunc 63 | quote }}
+    app.kubernetes.io/version: {{ include "argo-workflows.server_chart_version_label" . }}
   {{- with .Values.server.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag | trunc 63 | quote }}
+        app.kubernetes.io/version: {{ include "argo-workflows.server_chart_version_label" . }}
         {{- with .Values.server.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-workflows/templates/server/server-service.yaml
+++ b/charts/argo-workflows/templates/server/server-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag | trunc 63 | quote }}
+    app.kubernetes.io/version: {{ include "argo-workflows.server_chart_version_label" . }}
   {{- with .Values.server.serviceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: v0.12.0
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -15,4 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add support for additional initContainers and additional volume/volumeMounts"
+    - "[Changed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)

--- a/charts/argocd-image-updater/templates/_helpers.tpl
+++ b/charts/argocd-image-updater/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Common labels
 helm.sh/chart: {{ include "argocd-image-updater.chart" . }}
 {{ include "argocd-image-updater.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | trunc 63 | quote}}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
