### PR TITLE
fix(argo-events): avoid label exceeding maximum length

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.3
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.6
+version: 2.0.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,4 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Argo events controller to v1.7.3"
+    - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
+    - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -17,3 +17,4 @@ annotations:
   artifacthub.io/changes: |
     - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
     - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"
+    - "[Fixed]: webhook.image.tag value now overrides the tag in the webhook deployment"

--- a/charts/argo-events/templates/_helpers.tpl
+++ b/charts/argo-events/templates/_helpers.tpl
@@ -69,6 +69,34 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create kubernetes friendly chart version label for the controller.
+
+Examples:
+image.tag = v1.7.3
+output    = v1.7.3
+
+image.tag = v1.7.3@sha256:a40f4f3ea20d354f00ab469a9f73102668fa545c4d632e1a8e11a206ad3093f3
+output    = v1.7.3
+*/}}
+{{- define "argo-events.controller_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-events.defaultTag" .) .Values.controller.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
+Create kubernetes friendly chart version label for the events webhook.
+
+Examples:
+image.tag = v1.7.3
+output    = v1.7.3
+
+image.tag = v1.7.3@sha256:a40f4f3ea20d354f00ab469a9f73102668fa545c4d632e1a8e11a206ad3093f3
+output    = v1.7.3
+*/}}
+{{- define "argo-events.webhook_chart_version_label" -}}
+{{- regexReplaceAll "[^a-zA-Z0-9-_.]+" (regexReplaceAll "@sha256:[a-f0-9]+" (default (include "argo-events.defaultTag" .) .Values.webhook.image.tag) "") "" | trunc 63 | quote -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "argo-events.labels" -}}

--- a/charts/argo-events/templates/argo-events-controller/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-controller/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "argo-events.controller.fullname" . }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | quote }}
+    app.kubernetes.io/version: {{ include "argo-events.controller_chart_version_label" . }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
         {{- end }}
       labels:
         {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag | quote }}
+        app.kubernetes.io/version: {{ include "argo-events.controller_chart_version_label" . }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.controller.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: events-webhook
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 4 }}
-    app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | quote }}
+    app.kubernetes.io/version: {{ include "argo-events.webhook_chart_version_label" . }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 8 }}
-        app.kubernetes.io/version: {{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag | quote }}
+        app.kubernetes.io/version: {{ include "argo-events.webhook_chart_version_label" . }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.webhook.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Values.webhook.name }}
-        image: {{ default .Values.global.image.repository .Values.webhook.image.repository }}:{{ default (include "argo-events.defaultTag" .) .Values.controller.image.tag }}
+        image: {{ default .Values.global.image.repository .Values.webhook.image.repository }}:{{ default (include "argo-events.defaultTag" .) .Values.webhook.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.webhook.image.imagePullPolicy }}
         args:
         - webhook-service


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
