### PR TITLE
fix(argo-cd): Prevent could not parse 0 warning

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.4
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.3
+version: 5.16.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Add annotations to PrometheusRule"
+    - "[Fixed]: Prevent could not parse 0 warning"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -401,7 +401,7 @@ NAME: my-release
 | configs.cm."application.instanceLabelKey" | string | Defaults to app.kubernetes.io/instance | The name of tracking label used by Argo CD for resource pruning |
 | configs.cm."exec.enabled" | bool | `false` | Enable exec feature in Argo UI |
 | configs.cm."server.rbac.log.enforce.enable" | bool | `false` | Enable logs RBAC enforcement |
-| configs.cm."timeout.hard.reconciliation" | int | `0` | Timeout to refresh application data as well as target manifests cache |
+| configs.cm."timeout.hard.reconciliation" | string | `"0s"` | Timeout to refresh application data as well as target manifests cache |
 | configs.cm."timeout.reconciliation" | string | `"180s"` | Timeout to discover if a new manifests version got published to the repository |
 | configs.cm.annotations | object | `{}` | Annotations to be added to argocd-cm configmap |
 | configs.cm.create | bool | `true` | Create the argocd-cm configmap for [declarative setup] |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -133,7 +133,7 @@ configs:
     timeout.reconciliation: 180s
 
     # -- Timeout to refresh application data as well as target manifests cache
-    timeout.hard.reconciliation: 0
+    timeout.hard.reconciliation: 0s
 
     # Dex configuration
     # dex.config: |


### PR DESCRIPTION
a warning similar to below will be generated if `timeout.hard.reconciliation` is set to 0 explicitly without unit

```
time="2022-12-13T18:02:36Z" level=warning msg="Could not parse '0' as a duration string from environment ARGOCD_HARD_RECONCILIATION_TIMEOUT"
```

minimal code to reproduce the issue

```go
package main

import (
	"fmt"
	"math"
	"os"
	"time"

	timeutil "github.com/argoproj/pkg/time"

	log "github.com/sirupsen/logrus"
)

const (
	defaultAppResyncPeriod     = 180
	defaultAppHardResyncPeriod = 0
)

// ref. https://github.com/argoproj/argo-cd/blob/v2.5.4/util/env/env.go#L99
func ParseDurationFromEnv(env string, defaultValue, min, max time.Duration) time.Duration {
	str := os.Getenv(env)
	if str == "" {
		return defaultValue
	}
	durPtr, err := timeutil.ParseDuration(str)
	if err != nil {
		log.Warnf("Could not parse '%s' as a duration string from environment %s", str, env)
		return defaultValue
	}

	dur := *durPtr
	if dur < min {
		log.Warnf("Value in %s is %s, which is less than minimum %s allowed", env, dur, min)
		return defaultValue
	}
	if dur > max {
		log.Warnf("Value in %s is %s, which is greater than maximum %s allowed", env, dur, max)
		return defaultValue
	}
	return dur
}

// ref. https://github.com/argoproj/argo-cd/blob/v2.5.4/cmd/argocd-application-controller/commands/argocd_application_controller.go#L179
func main() {
	fmt.Println(int64(ParseDurationFromEnv("ARGOCD_RECONCILIATION_TIMEOUT", defaultAppResyncPeriod*time.Second, 0, math.MaxInt64).Seconds()))
	fmt.Println(int64(ParseDurationFromEnv("ARGOCD_HARD_RECONCILIATION_TIMEOUT", defaultAppHardResyncPeriod*time.Second, 0, math.MaxInt64).Seconds()))
}
```

```terminal
$ go run main.go
180
0
$ ARGOCD_RECONCILIATION_TIMEOUT=0 ARGOCD_HARD_RECONCILIATION_TIMEOUT=0 go run main.go
time="2022-12-13T20:31:23+02:00" level=warning msg="Could not parse '0' as a duration string from environment ARGOCD_RECONCILIATION_TIMEOUT"
180
time="2022-12-13T20:31:23+02:00" level=warning msg="Could not parse '0' as a duration string from environment ARGOCD_HARD_RECONCILIATION_TIMEOUT"
0
$ ARGOCD_RECONCILIATION_TIMEOUT="1s" ARGOCD_HARD_RECONCILIATION_TIMEOUT="1s" go run main.go
1
1
```

Signed-off-by: Viacheslav Vasilyev <avoidik@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
