### PR TITLE
chore(argo-events): use policy/v1 for poddisruptionbudgets, when available

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.3
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.7
+version: 2.0.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,6 +15,7 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
+    - "[Fixed]: use policy/v1 for poddisruptionbudgets, when available
     - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
     - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"
     - "[Fixed]: webhook.image.tag value now overrides the tag in the webhook deployment"

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -16,6 +16,3 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - "[Fixed]: use policy/v1 for poddisruptionbudgets, when available
-    - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
-    - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"
-    - "[Fixed]: webhook.image.tag value now overrides the tag in the webhook deployment"

--- a/charts/argo-events/templates/_helpers.tpl
+++ b/charts/argo-events/templates/_helpers.tpl
@@ -125,3 +125,14 @@ Return the default Argo Events app version
 {{- define "argo-events.defaultTag" -}}
   {{- default .Chart.AppVersion .Values.global.image.tag }}
 {{- end -}}
+
+{{/*
+Define Pdb apiVersion
+*/}}
+{{- define "argo-events.pdb.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- printf "policy/v1" -}}
+{{- else }}
+{{- printf "policy/v1beta1" -}}
+{{- end }}
+{{- end }}

--- a/charts/argo-events/templates/argo-events-controller/pdb.yaml
+++ b/charts/argo-events/templates/argo-events-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "argo-events.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-events.controller.fullname" . }}

--- a/charts/argo-events/templates/argo-events-webhook/pdb.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.webhook.enabled .Values.webhook.pdb.enabled (not .Values.controller.rbac.namespaced) }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "argo-events.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-events.webhook.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Vadim Grek <vadimprog@gmail.com>

Fixes #1709

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
