### PR TITLE
Creiche/configure argo events webhook port

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.3
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.7
+version: 2.0.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,6 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)
-    - "[Fixed]: generated value for app.kubernetes.io/version label is now valid even when defining a controller/webhook .image.tag with a SHA digest"
-    - "[Fixed]: webhook.image.tag value now overrides the tag in the webhook deployment"
+    - "[Added]: Ability to specify port for webhook deployment"

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -155,6 +155,7 @@ done
 | webhook.pdb.labels | object | `{}` | Labels to be added to admission webhook pdb |
 | webhook.podAnnotations | object | `{}` | Annotations to be added to event controller pods |
 | webhook.podLabels | object | `{}` | Labels to be added to event controller pods |
+| webhook.port | int | `443` | Port to listen on |
 | webhook.priorityClassName | string | `""` | Priority class for the event controller pods |
 | webhook.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | webhook.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -50,6 +50,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: PORT
+          value: "{{ .Values.webhook.port }}"
         {{- with .Values.webhook.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -63,7 +65,7 @@ spec:
         {{- end }}
         ports:
         - name: webhook
-          containerPort: 443
+          containerPort: {{ .Values.webhook.port }}
           protocol: TCP
         livenessProbe:
           tcpSocket:

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -315,6 +315,9 @@ webhook:
   # -- Labels to be added to event controller pods
   podLabels: {}
 
+  # -- Port to listen on
+  port: 443
+
   # -- Event controller container-level security context
   containerSecurityContext: {}
     # capabilities:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
