### PR TITLE
fix(argo-cd): remove incorrect flag for repoServer TLS secret

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.7
+version: 5.16.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[chore]: Update ArgoCD to v2.5.5"
+    - "[fixed]: remove incorrect enabled flag for repoServer TLS secret "

--- a/charts/argo-cd/templates/argocd-configs/argocd-repo-server-tls-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-repo-server-tls-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.repoServer.enabled .Values.repoServer.certificateSecret.enabled }}
+{{- if .Values.repoServer.certificateSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
When I added RepoServer TLS Secret, I added the enabled value check to match code on Dex. 
I missed that RepoServer cannot be disabled so there is no enabled flag. Currently to deploy the TLS secret you need to add `.Values.repoServer.enabled: true` just to deploy the secret. This PR is to remove this unnecessary value and only use `.Values.repoServer.certificateSecret.enabled: true` instead.

_Also TLS config using signed certs for Dex, RepoServer and Server have been rolled to production this was the only pain I spotted._

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
