### PR TITLE
feat(argo-cd): Add parameters to enable/disable creation of Roles and RoleBindings

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.9
+version: 5.16.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support relabelings and metricRelabelings to Notification's ServiceMonitor"
+    - "[Added]: A new option for each component to enable or disable the creation of a Role and RoleBinding for that component."

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -585,6 +585,7 @@ NAME: my-release
 | repoServer.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | repoServer.replicas | int | `1` | The number of repo server pods to run |
 | repoServer.resources | object | `{}` | Resource limits and requests for the repo server pods |
+| repoServer.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for the repo server |
 | repoServer.service.annotations | object | `{}` | Repo server service annotations |
 | repoServer.service.labels | object | `{}` | Repo server service labels |
 | repoServer.service.port | int | `8081` | Repo server service port |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1056,6 +1056,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.bots.slack.pdb.maxUnavailable | string | `""` | Number of pods that are unavailble after eviction as number or percentage (eg.: 50%). |
 | notifications.bots.slack.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
 | notifications.bots.slack.resources | object | `{}` | Resource limits and requests for the Slack bot |
+| notifications.bots.slack.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for the Slack bot |
 | notifications.bots.slack.service.annotations | object | `{}` | Service annotations for Slack bot |
 | notifications.bots.slack.service.port | int | `80` | Service port for Slack bot |
 | notifications.bots.slack.service.type | string | `"LoadBalancer"` | Service type for Slack bot |
@@ -1104,6 +1105,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.podLabels | object | `{}` | Labels to be applied to the notifications controller Pods |
 | notifications.priorityClassName | string | `""` | Priority class for the notifications controller pods |
 | notifications.resources | object | `{}` | Resource limits and requests for the notifications controller |
+| notifications.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for the notifications controller |
 | notifications.secret.annotations | object | `{}` | key:value pairs of annotations to be added to the secret |
 | notifications.secret.create | bool | `true` | Whether helm chart creates notifications controller secret |
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the secret |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -715,6 +715,7 @@ NAME: my-release
 | server.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | server.replicas | int | `1` | The number of server pods to run |
 | server.resources | object | `{}` | Resource limits and requests for the Argo CD server |
+| server.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for the server |
 | server.route.annotations | object | `{}` | Openshift Route annotations |
 | server.route.enabled | bool | `false` | Enable an OpenShift Route for the Argo CD server |
 | server.route.hostname | string | `""` | Hostname of OpenShift Route |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -503,6 +503,7 @@ NAME: my-release
 | controller.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | controller.replicas | int | `1` | The number of application controller pods to run. Additional replicas will cause sharding of managed clusters across number of replicas. |
 | controller.resources | object | `{}` | Resource limits and requests for the application controller pods |
+| controller.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for the application controller |
 | controller.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | controller.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | controller.serviceAccount.create | bool | `true` | Create a service account for the application controller |
@@ -1015,6 +1016,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | applicationSet.replicaCount | int | `1` | The number of ApplicationSet controller pods to run |
 | applicationSet.resources | object | `{}` | Resource limits and requests for the ApplicationSet controller pods. |
+| applicationSet.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for the ApplicationSet controller |
 | applicationSet.service.annotations | object | `{}` | ApplicationSet service annotations |
 | applicationSet.service.labels | object | `{}` | ApplicationSet service labels |
 | applicationSet.service.port | int | `7000` | ApplicationSet service port |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -834,6 +834,7 @@ server:
 | dex.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
 | dex.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | dex.resources | object | `{}` | Resource limits and requests for dex |
+| dex.roleAndRoleBinding.create | bool | `true` | Create a role and role binding for Dex |
 | dex.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | dex.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | dex.serviceAccount.create | bool | `true` | Create dex service account |

--- a/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.roleAndRoleBinding.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -34,3 +35,4 @@ rules:
   verbs:
   - create
   - list
+{{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.roleAndRoleBinding.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "argo-cd.controllerServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/role.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.applicationSet.enabled }}
+{{- if and .Values.applicationSet.enabled .Values.applicationSet.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/argocd-applicationset/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.applicationSet.enabled }}
+{{- if and .Values.applicationSet.enabled .Values.applicationSet.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/argocd-notifications/bots/slack/role.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/bots/slack/role.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.notifications.enabled .Values.notifications.bots.slack.enabled }}
+{{ if and .Values.notifications.enabled .Values.notifications.bots.slack.enabled .Values.notifications.bots.slack.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/argocd-notifications/bots/slack/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/bots/slack/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.notifications.enabled .Values.notifications.bots.slack.enabled }}
+{{ if and .Values.notifications.enabled .Values.notifications.bots.slack.enabled .Values.notifications.bots.slack.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/argocd-notifications/role.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.notifications.enabled }}
+{{- if and .Values.notifications.enabled .Values.notifications.roleAndRoleBinding.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/argocd-notifications/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.notifications.enabled }}
+{{- if and .Values.notifications.enabled .Values.notifications.roleAndRoleBinding.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/argocd-repo-server/role.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.repoServer.serviceAccount.create }}
+{{- if .Values.repoServer.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/argocd-repo-server/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.repoServer.serviceAccount.create }}
+{{- if .Values.repoServer.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/argocd-server/role.yaml
+++ b/charts/argo-cd/templates/argocd-server/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -42,3 +43,4 @@ rules:
   verbs:
   - create
   - list
+{{- end}}

--- a/charts/argo-cd/templates/argocd-server/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.roleAndRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "argo-cd.serverServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/argo-cd/templates/dex/role.yaml
+++ b/charts/argo-cd/templates/dex/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dex.enabled }}
+{{- if and .Values.dex.enabled .Values.dex.roleAndRoleBinding.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/dex/rolebinding.yaml
+++ b/charts/argo-cd/templates/dex/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dex.enabled }}
+{{- if and .Values.dex.enabled .Values.dex.roleAndRoleBinding.create}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2600,6 +2600,11 @@ notifications:
 
     # -- Labels applied to created service account
     labels: {}
+
+  roleAndRoleBinding:
+    # -- Create a role and role binding for the notifications controller
+    create: true
+
   cm:
     # -- Whether helm chart creates notifications controller config map
     create: true
@@ -2937,6 +2942,10 @@ notifications:
 
         # -- Annotations applied to created service account
         annotations: {}
+
+      roleAndRoleBinding:
+        # -- Create a role and role binding for the Slack bot
+        create: true
 
       # -- Slack bot container-level security Context
       # @default -- See [values.yaml]

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -631,6 +631,10 @@ controller:
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
+  roleAndRoleBinding:
+    # -- Create a role and role binding for the application controller
+    create: true
+
   ## Application controller metrics configuration
   metrics:
     # -- Deploy metrics service
@@ -2248,6 +2252,10 @@ applicationSet:
     # -- The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+
+  roleAndRoleBinding:
+    # -- Create a role and role binding for the ApplicationSet controller
+    create: true
 
   # -- Annotations to be added to ApplicationSet controller Deployment
   deploymentAnnotations: {}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2101,6 +2101,10 @@ repoServer:
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
+  roleAndRoleBinding:
+    # -- Create a role and role binding for the repo server
+    create: true
+
   # -- Additional containers to be added to the repo server pod
   extraContainers: []
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -920,6 +920,10 @@ dex:
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
+  roleAndRoleBinding:
+    # -- Create a role and role binding for Dex
+    create: true
+
   # -- Additional volumeMounts to the dex main container
   volumeMounts: []
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1582,6 +1582,10 @@ server:
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
+  roleAndRoleBinding:
+    # -- Create a role and role binding for the server
+    create: true
+
   ingress:
     # -- Enable an ingress resource for the Argo CD server
     enabled: false


### PR DESCRIPTION
This PR adds a new parameter for each component: `roleAndRoleBinding.create` with default values `true`. This change will not introduce any breaking changes to the existing Helm chart. However, it will allow a more granular approach to the installation process of ArgoCD, especially when Argo operators don't have full cluster-admin permissions. 





Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
