### PR TITLE
fix(argo-events): Added missing NATS version in values.yaml

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.4
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.0.10
+version: 2.0.11
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Upgrade Argo events controller to v1.7.4"
+    - "[Fixed]: Added missing NATS version in values.yaml"

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -57,7 +57,7 @@ done
 | configs.jetstream.versions[0].natsImage | string | `"nats:latest"` |  |
 | configs.jetstream.versions[0].startCommand | string | `"/nats-server"` |  |
 | configs.jetstream.versions[0].version | string | `"latest"` |  |
-| configs.nats.versions | list | `[{"metricsExporterImage":"natsio/prometheus-nats-exporter:latest","natsStreamingImage":"nats-streaming:latest","version":"latest"},{"metricsExporterImage":"natsio/prometheus-nats-exporter:0.8.0","natsStreamingImage":"nats-streaming:0.22.1","version":"0.22.1"}]` | Supported versions of NATS event bus |
+| configs.nats.versions | list | See [values.yaml] | Supported versions of NATS event bus |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -57,7 +57,7 @@ done
 | configs.jetstream.versions[0].natsImage | string | `"nats:latest"` |  |
 | configs.jetstream.versions[0].startCommand | string | `"/nats-server"` |  |
 | configs.jetstream.versions[0].version | string | `"latest"` |  |
-| configs.nats.versions | list | `[{"metricsExporterImage":"natsio/prometheus-nats-exporter:latest","natsStreamingImage":"nats-streaming:latest","version":"latest"}]` | Supported versions of NATS event bus |
+| configs.nats.versions | list | `[{"metricsExporterImage":"natsio/prometheus-nats-exporter:latest","natsStreamingImage":"nats-streaming:latest","version":"latest"},{"metricsExporterImage":"natsio/prometheus-nats-exporter:0.8.0","natsStreamingImage":"nats-streaming:0.22.1","version":"0.22.1"}]` | Supported versions of NATS event bus |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -62,6 +62,7 @@ configs:
   ## NATS event bus
   nats:
     # -- Supported versions of NATS event bus
+    # @default -- See [values.yaml]
     versions:
       - version: latest
         natsStreamingImage: nats-streaming:latest

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -66,6 +66,9 @@ configs:
       - version: latest
         natsStreamingImage: nats-streaming:latest
         metricsExporterImage: natsio/prometheus-nats-exporter:latest
+      - version: 0.22.1
+        natsStreamingImage: nats-streaming:0.22.1
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
 
   ## JetStream event bus
   jetstream:


### PR DESCRIPTION
Discussion about changes to this new PR are contained in the previous closed PR #1725 .

Fixes issue #1724 

Signed-off-by: Ramin Akhbari <ramin@akhbari.us>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
