### PR TITLE
chore(argo-cd): Remove legacy API versions for PDBs

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.11
+version: 5.16.12
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Added HostAliases to ApplicationSet Deployment"
+    - "[Removed]: API override for PDB"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -360,7 +360,6 @@ NAME: my-release
 | apiVersionOverrides.certmanager | string | `""` | String to override apiVersion of cert-manager resources rendered by this helm chart |
 | apiVersionOverrides.cloudgoogle | string | `""` | String to override apiVersion of GKE resources rendered by this helm chart |
 | apiVersionOverrides.ingress | string | `""` | String to override apiVersion of ingresses rendered by this helm chart |
-| apiVersionOverrides.pdb | string | `""` | String to override apiVersion of pod disruption budgets rendered by this helm chart |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |

--- a/charts/argo-cd/templates/_versions.tpl
+++ b/charts/argo-cd/templates/_versions.tpl
@@ -35,19 +35,6 @@ Return the appropriate apiVersion for ingress
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for pod disruption budget
-*/}}
-{{- define "argo-cd.apiVersion.pdb" -}}
-{{- if .Values.apiVersionOverrides.pdb -}}
-{{- print .Values.apiVersionOverrides.pdb -}}
-{{- else if semverCompare "<1.21-0" (include "argo-cd.kubeVersion" .) -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
-{{- print "policy/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the appropriate apiVersion for cert-manager
 */}}
 {{- define "argo-cd.apiVersion.cert-manager" -}}

--- a/charts/argo-cd/templates/argocd-application-controller/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.controller.fullname" . }}

--- a/charts/argo-cd/templates/argocd-applicationset/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.applicationSet.enabled .Values.applicationSet.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.applicationSet.fullname" . }}

--- a/charts/argo-cd/templates/argocd-notifications/bots/slack/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/bots/slack/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.notifications.enabled .Values.notifications.bots.slack.enabled .Values.notifications.bots.slack.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.notifications.fullname" . }}-bot

--- a/charts/argo-cd/templates/argocd-notifications/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.notifications.enabled .Values.notifications.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.notifications.fullname" . }}

--- a/charts/argo-cd/templates/argocd-repo-server/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.repoServer.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.repoServer.fullname" . }}

--- a/charts/argo-cd/templates/argocd-server/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.server.fullname" . }}

--- a/charts/argo-cd/templates/dex/pdb.yaml
+++ b/charts/argo-cd/templates/dex/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.dex.enabled .Values.dex.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.dex.fullname" . }}

--- a/charts/argo-cd/templates/redis/pdb.yaml
+++ b/charts/argo-cd/templates/redis/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $redisHa := index .Values "redis-ha" -}}
 {{- if and .Values.redis.enabled (not $redisHa.enabled) .Values.redis.pdb.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.pdb" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-cd.redis.fullname" . }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -20,8 +20,6 @@ apiVersionOverrides:
   autoscaling: "" # autoscaling/v2
   # -- String to override apiVersion of ingresses rendered by this helm chart
   ingress: "" # networking.k8s.io/v1beta1
-  # -- String to override apiVersion of pod disruption budgets rendered by this helm chart
-  pdb: "" # policy/v1
 
 # -- Create clusterroles that extend existing clusterroles to interact with argo-cd crds
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles


### PR DESCRIPTION
Removed API override for PDBs as K8s 1.22 removed alpha interfaces.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
