### PR TITLE
chore(argo-cd): Remove legacy API versions for Ingresses

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.12
+version: 5.16.13
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Removed]: API override for PDB"
+    - "[Removed]: Legacy API versions for Ingresses"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -359,7 +359,6 @@ NAME: my-release
 | apiVersionOverrides.autoscaling | string | `""` | String to override apiVersion of autoscaling rendered by this helm chart |
 | apiVersionOverrides.certmanager | string | `""` | String to override apiVersion of cert-manager resources rendered by this helm chart |
 | apiVersionOverrides.cloudgoogle | string | `""` | String to override apiVersion of GKE resources rendered by this helm chart |
-| apiVersionOverrides.ingress | string | `""` | String to override apiVersion of ingresses rendered by this helm chart |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |

--- a/charts/argo-cd/templates/_versions.tpl
+++ b/charts/argo-cd/templates/_versions.tpl
@@ -20,21 +20,6 @@ Return the appropriate apiVersion for autoscaling
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress
-*/}}
-{{- define "argo-cd.apiVersion.ingress" -}}
-{{- if .Values.apiVersionOverrides.ingress -}}
-{{- print .Values.apiVersionOverrides.ingress -}}
-{{- else if semverCompare "<1.14-0" (include "argo-cd.kubeVersion" .) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "<1.19-0" (include "argo-cd.kubeVersion" .) -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the appropriate apiVersion for cert-manager
 */}}
 {{- define "argo-cd.apiVersion.cert-manager" -}}

--- a/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
@@ -1,29 +1,26 @@
 {{- if and .Values.applicationSet.enabled .Values.applicationSet.webhook.ingress.enabled -}}
-{{- $serviceName := include "argo-cd.applicationSet.fullname" . -}}
 {{- $servicePort := .Values.applicationSet.service.portName -}}
 {{- $paths := .Values.applicationSet.webhook.ingress.paths -}}
 {{- $extraPaths := .Values.applicationSet.webhook.ingress.extraPaths -}}
 {{- $pathType := .Values.applicationSet.webhook.ingress.pathType -}}
-apiVersion: {{ include "argo-cd.apiVersion.ingress" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-{{- if .Values.applicationSet.webhook.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.applicationSet.webhook.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-{{- end }}
-  name: {{ template "argo-cd.applicationSet.fullname" . }}
+  name: {{ include "argo-cd.applicationSet.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
-    {{- if .Values.applicationSet.webhook.ingress.labels }}
-    {{- toYaml .Values.applicationSet.webhook.ingress.labels | nindent 4 }}
+    {{- with .Values.applicationSet.webhook.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.applicationSet.webhook.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
-  {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
   {{- with .Values.applicationSet.webhook.ingress.ingressClassName }}
   ingressClassName: {{ . }}
-  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.applicationSet.webhook.ingress.hosts }}
@@ -31,59 +28,45 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: {{ $pathType }}
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
-                name: {{ $serviceName }}
+                name: {{ include "argo-cd.applicationSet.fullname" $ }}
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{- end }}
           {{- end -}}
     {{- end -}}
   {{- else }}
     - http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: {{ $pathType }}
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
-                name: {{ $serviceName }}
+                name: {{ include "argo-cd.applicationSet.fullname" $ }}
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{- end }}
           {{- end -}}
   {{- end -}}
-  {{- if .Values.applicationSet.webhook.ingress.tls }}
+  {{- with .Values.applicationSet.webhook.ingress.tls }}
   tls:
-    {{- toYaml .Values.applicationSet.webhook.ingress.tls | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -1,29 +1,26 @@
 {{- if and .Values.server.ingressGrpc.enabled (not .Values.server.ingressGrpc.isAWSALB) -}}
-{{- $serviceName := include "argo-cd.server.fullname" . -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingressGrpc.https -}}
 {{- $paths := .Values.server.ingressGrpc.paths -}}
 {{- $extraPaths := .Values.server.ingressGrpc.extraPaths -}}
 {{- $pathType := .Values.server.ingressGrpc.pathType -}}
-apiVersion: {{ include "argo-cd.apiVersion.ingress" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-{{- if .Values.server.ingressGrpc.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.server.ingressGrpc.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-{{- end }}
-  name: {{ template "argo-cd.server.fullname" . }}-grpc
+  name: {{ include "argo-cd.server.fullname" . }}-grpc
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    {{- if .Values.server.ingressGrpc.labels }}
-    {{- toYaml .Values.server.ingressGrpc.labels | nindent 4 }}
+    {{- with .Values.server.ingressGrpc.labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.server.ingressGrpc.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
-  {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
   {{- with .Values.server.ingressGrpc.ingressClassName }}
   ingressClassName: {{ . }}
-  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.server.ingressGrpc.hosts }}
@@ -31,59 +28,45 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
-          {{- end -}}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: {{ $pathType }}
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
-                name: {{ $serviceName }}
+                name: {{ include "argo-cd.server.fullname" $ }}
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{- end }}
           {{- end -}}
     {{- end -}}
   {{- else }}
     - http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
-          {{- end -}}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: {{ $pathType }}
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
-                name: {{ $serviceName }}
+                name: {{ include "argo-cd.server.fullname" $ }}
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{- end }}
           {{- end -}}
   {{- end -}}
-  {{- if .Values.server.ingressGrpc.tls }}
+  {{- with .Values.server.ingressGrpc.tls }}
   tls:
-    {{- toYaml .Values.server.ingressGrpc.tls | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -1,33 +1,30 @@
 {{- if .Values.server.ingress.enabled -}}
-{{- $serviceName := include "argo-cd.server.fullname" . -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingress.https -}}
 {{- $paths := .Values.server.ingress.paths -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
 {{- $pathType := .Values.server.ingress.pathType -}}
-apiVersion: {{ include "argo-cd.apiVersion.ingress" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-{{- if .Values.server.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.server.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- if and .Values.server.ingressGrpc.isAWSALB .Values.server.ingressGrpc.enabled }}
-    alb.ingress.kubernetes.io/conditions.{{ template "argo-cd.server.fullname" . }}-grpc: |
-      [{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]
-  {{- end }}
-{{- end }}
-  name: {{ template "argo-cd.server.fullname" . }}
+  name: {{ include "argo-cd.server.fullname" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    {{- if .Values.server.ingress.labels }}
-    {{- toYaml .Values.server.ingress.labels | nindent 4 }}
+    {{- with .Values.server.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.server.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.server.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if and .Values.server.ingressGrpc.isAWSALB .Values.server.ingressGrpc.enabled }}
+    alb.ingress.kubernetes.io/conditions.{{ template "argo-cd.server.fullname" . }}-grpc: |
+      [{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]
+    {{- end }}
+  {{- end }}
 spec:
-  {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
   {{- with .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ . }}
-  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.server.ingress.hosts }}
@@ -35,17 +32,14 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           {{- if and $.Values.server.ingressGrpc.isAWSALB $.Values.server.ingressGrpc.enabled }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: Prefix
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
                 name: {{ template "argo-cd.server.fullname" $ }}-grpc
                 port:
@@ -54,60 +48,42 @@ spec:
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ template "argo-cd.server.fullname" $ }}-grpc
-              servicePort: {{ $servicePort }}
-              {{- end }}
             {{- end }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: {{ $pathType }}
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
-                name: {{ $serviceName }}
+                name: {{ include "argo-cd.server.fullname" $ }}
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{- end }}
           {{- end -}}
     {{- end -}}
   {{- else }}
     - http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
-            {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
             pathType: {{ $pathType }}
-            {{- end }}
             backend:
-              {{- if eq (include "argo-cd.apiVersion.ingress" $) "networking.k8s.io/v1" }}
               service:
-                name: {{ $serviceName }}
+                name: {{ include "argo-cd.server.fullname" $ }}
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-              {{- else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{- end }}
           {{- end -}}
   {{- end -}}
-  {{- if .Values.server.ingress.tls }}
+  {{- with .Values.server.ingress.tls }}
   tls:
-    {{- toYaml .Values.server.ingress.tls | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -18,8 +18,6 @@ apiVersionOverrides:
   cloudgoogle: "" # cloud.google.com/v1
   # -- String to override apiVersion of autoscaling rendered by this helm chart
   autoscaling: "" # autoscaling/v2
-  # -- String to override apiVersion of ingresses rendered by this helm chart
-  ingress: "" # networking.k8s.io/v1beta1
 
 # -- Create clusterroles that extend existing clusterroles to interact with argo-cd crds
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
@@ -1590,8 +1588,7 @@ server:
     ## Argo Ingress.
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace
-    hosts:
-      []
+    hosts: []
       # - argocd.example.com
 
     # -- List of ingress paths
@@ -1600,13 +1597,7 @@ server:
     # -- Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`
     pathType: Prefix
     # -- Additional ingress paths
-    extraPaths:
-      []
-      # - path: /*
-      #   backend:
-      #     serviceName: ssl-redirect
-      #     servicePort: use-annotation
-      ## for Kubernetes >=1.19 (when "networking.k8s.io/v1" is used)
+    extraPaths: []
       # - path: /*
       #   pathType: Prefix
       #   backend:
@@ -1616,8 +1607,7 @@ server:
       #         name: use-annotation
 
     # -- Ingress TLS configuration
-    tls:
-      []
+    tls: []
       # - secretName: your-certificate-name
       #   hosts:
       #     - argocd.example.com
@@ -1656,8 +1646,7 @@ server:
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace
     ##
-    hosts:
-      []
+    hosts: []
       # - argocd.example.com
 
     # -- List of ingress paths for dedicated [gRPC-ingress]
@@ -1666,13 +1655,7 @@ server:
     # -- Ingress path type for dedicated [gRPC-ingress]. One of `Exact`, `Prefix` or `ImplementationSpecific`
     pathType: Prefix
     # -- Additional ingress paths for dedicated [gRPC-ingress]
-    extraPaths:
-      []
-      # - path: /*
-      #   backend:
-      #     serviceName: ssl-redirect
-      #     servicePort: use-annotation
-      ## for Kubernetes >=1.19 (when "networking.k8s.io/v1" is used)
+    extraPaths: []
       # - path: /*
       #   pathType: Prefix
       #   backend:
@@ -1682,8 +1665,7 @@ server:
       #         name: use-annotation
 
     # -- Ingress TLS configuration for dedicated [gRPC-ingress]
-    tls:
-      []
+    tls: []
       # - secretName: your-certificate-name
       #   hosts:
       #     - argocd.example.com


### PR DESCRIPTION
- Removed overrides and code for legacy Ingress API versions.
- Simplify code if -> with

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
