### PR TITLE
chore(argo-cd): Add pdrastil as Argo CD codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 /charts/argo-workflows/ @stefansedich @paguos @vladlosev @yann-soubeyrand @jmeridth @yu-croco
 
 # Argo CD
-/charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1 @mkilchhofer @yu-croco @jmeridth
+/charts/argo-cd/ @davidkarlsen @mr-sour @yann-soubeyrand @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil
 
 # Argo Events
 /charts/argo-events/ @jbehling @VaibhavPage @pdrastil


### PR DESCRIPTION
Signed-off-by: Petr Drastil <petr.drastil@gmail.com>
