### PR TITLE
feat(argo-cd): Allow templated values for init and extra containers

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.15
+version: 5.17.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,7 +23,6 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Option createClusterRoles to enable cluster roles from one place"
-    - "[Deprecated]: Option controller.clusterAdminAccess.enabled"
-    - "[Deprecated]: Option server.clusterAdminAccess.enabled"
-    - "[Deprecated]: Option repoServer.clusterAdminAccess.enabled"
+    - "[Added]: Support for extraContainers and initContainers for applicationSet and notifications"
+    - "[Added]: Support for use of Helm templates for extraContainers and initContainers"
+    - "[Docs]: Added notes about custom Helm template support"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -970,6 +970,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the ApplicationSet controller |
 | applicationSet.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the ApplicationSet controller |
 | applicationSet.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | If defined, uses a Secret to pull an image from a private Docker registry or repository. |
+| applicationSet.initContainers | list | `[]` | Init containers to add to the ApplicationSet controller pod |
 | applicationSet.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for ApplicationSet controller |
 | applicationSet.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | applicationSet.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
@@ -1063,6 +1064,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.deploymentAnnotations | object | `{}` | Annotations to be applied to the notifications controller Deployment |
 | notifications.enabled | bool | `true` | Enable notifications controller |
 | notifications.extraArgs | list | `[]` | Extra arguments to provide to the notifications controller |
+| notifications.extraContainers | list | `[]` | Additional containers to be added to the notifications controller pod |
 | notifications.extraEnv | list | `[]` | Additional container environment variables |
 | notifications.extraEnvFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the notifications controller |
 | notifications.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
@@ -1071,6 +1073,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the notifications controller |
 | notifications.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the notifications controller |
 | notifications.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
+| notifications.initContainers | list | `[]` | Init containers to add to the notifications controller pod |
 | notifications.logFormat | string | `""` (defaults to global.logging.format) | Notifications controller log format. Either `text` or `json` |
 | notifications.logLevel | string | `""` (defaults to global.logging.level) | Notifications controller log level. One of: `debug`, `info`, `warn`, `error` |
 | notifications.metrics.enabled | bool | `false` | Enables prometheus metrics server |

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -257,7 +257,11 @@ spec:
         - mountPath: /home/argocd
           name: argocd-home
       {{- with .Values.controller.extraContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      {{- with .Values.controller.initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
@@ -304,10 +308,6 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
-      {{- with .Values.controller.initContainers }}
-      initContainers:
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
       {{- with .Values.controller.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -125,8 +125,12 @@ spec:
             - mountPath: /tmp
               name: tmp
         {{- with .Values.applicationSet.extraContainers }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
+      {{- with .Values.applicationSet.initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
       {{- with .Values.applicationSet.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -81,12 +81,39 @@ spec:
             {{- with .Values.notifications.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- with .Values.notifications.extraContainers }}
+          {{- tpl (toYaml . ) $ | nindent 8 }}
+        {{- end }}
+      {{- with .Values.notifications.initContainers }}
+      initContainers:
+        {{- tpl (toYaml . ) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.notifications.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.notifications.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.notifications.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.notifications.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
-        - configMap:
+        {{- with .Values.notifications.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: tls-certs
+          configMap:
             name: argocd-tls-certs-cm
-          name: tls-certs
         - name: argocd-repo-server-tls
           secret:
+            secretName: argocd-repo-server-tls
+            optional: true
             items:
             - key: tls.crt
               path: tls.crt
@@ -94,24 +121,4 @@ spec:
               path: tls.key
             - key: ca.crt
               path: ca.crt
-            optional: true
-            secretName: argocd-repo-server-tls
-        {{- with .Values.notifications.extraVolumes }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- with .Values.notifications.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.notifications.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.notifications.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.notifications.priorityClassName }}
-      priorityClassName: {{ . }}
-    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -264,7 +264,30 @@ spec:
         securityContext:
           {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
       {{- with .Values.repoServer.extraContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      initContainers:
+      - command:
+        - cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd-cmp-server
+        image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
+        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
+        name: copyutil
+        {{- with .Values.repoServer.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.repoServer.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+      {{- with .Values.repoServer.initContainers }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- with .Values.repoServer.nodeSelector }}
       nodeSelector:
@@ -328,29 +351,6 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
-      initContainers:
-      - command:
-        - cp
-        - -n
-        - /usr/local/bin/argocd
-        - /var/run/argocd/argocd-cmp-server
-        image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
-        name: copyutil
-        {{- with .Values.repoServer.resources }}
-        resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        {{- with .Values.repoServer.containerSecurityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        volumeMounts:
-        - mountPath: /var/run/argocd
-          name: var-files
-      {{- with .Values.repoServer.initContainers }}
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
       {{- with .Values.repoServer.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -319,9 +319,6 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- with .Values.server.extraContainers }}
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
       {{- if .Values.server.extensions.enabled }}
       - name: argocd-extensions
         image: {{ .Values.server.extensions.image.repository }}:{{ .Values.server.extensions.image.tag }}
@@ -335,6 +332,13 @@ spec:
             mountPath: /tmp/extensions/
           - name: tmp
             mountPath: /tmp
+      {{- end }}
+      {{- with .Values.server.extraContainers }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      {{- with .Values.server.initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
@@ -406,10 +410,6 @@ spec:
             path: tls.crt
           - key: ca.crt
             path: ca.crt
-      {{- with .Values.server.initContainers }}
-      initContainers:
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
       {{- with .Values.server.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -43,27 +43,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-      - name: copyutil
-        image: {{ default .Values.global.image.repository .Values.dex.initImage.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.dex.initImage.tag }}
-        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.initImage.imagePullPolicy }}
-        command:
-        - cp
-        - -n
-        - /usr/local/bin/argocd
-        - /shared/argocd-dex
-        volumeMounts:
-        - mountPath: /shared
-          name: static-files
-        - mountPath: /tmp
-          name: dexconfig
-        resources:
-          {{- toYaml .Values.dex.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
-      {{- with .Values.dex.initContainers }}
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
       containers:
       - name: {{ .Values.dex.name }}
         image: {{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}
@@ -136,7 +115,28 @@ spec:
         - name: argocd-dex-server-tls
           mountPath: /tls
       {{- with .Values.dex.extraContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      initContainers:
+      - name: copyutil
+        image: {{ default .Values.global.image.repository .Values.dex.initImage.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.dex.initImage.tag }}
+        imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.initImage.imagePullPolicy }}
+        command:
+        - cp
+        - -n
+        - /usr/local/bin/argocd
+        - /shared/argocd-dex
+        volumeMounts:
+        - mountPath: /shared
+          name: static-files
+        - mountPath: /tmp
+          name: dexconfig
+        resources:
+          {{- toYaml .Values.dex.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
+      {{- with .Values.dex.initContainers }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- with .Values.dex.nodeSelector }}
       nodeSelector:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -41,10 +41,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "argo-cd.redisServiceAccountName" . }}
-      {{- with .Values.redis.initContainers }}
-      initContainers:
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
       containers:
       - name: {{ .Values.redis.name }}
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
@@ -96,7 +92,11 @@ spec:
           {{- toYaml .Values.redis.metrics.containerSecurityContext | nindent 10 }}
       {{- end }}
       {{- with .Values.redis.extraContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
+      {{- with .Values.redis.initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -439,6 +439,7 @@ configs:
   #  }
 
 # -- Array of extra K8s manifests to deploy
+## Note: Supports use of custom Helm templates
 extraObjects: []
   # - apiVersion: secrets-store.csi.x-k8s.io/v1
   #   kind: SecretProviderClass
@@ -538,12 +539,14 @@ controller:
   #     name: secret-name
 
   # -- Additional containers to be added to the application controller pod
+  ## Note: Supports use of custom Helm templates
   extraContainers: []
 
   # -- Init containers to add to the application controller pod
   ## If your target Kubernetes cluster(s) require a custom credential (exec) plugin
   ## you could use this (and the same in the server pod) to provide such executable
   ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+  ## Note: Supports use of custom Helm templates
   initContainers: []
   #  - name: download-tools
   #    image: alpine:3
@@ -827,9 +830,11 @@ dex:
   #     name: secret-name
 
   # -- Additional containers to be added to the dex pod
+  ## Note: Supports use of custom Helm templates
   extraContainers: []
 
   # -- Init containers to add to the dex pod
+  ## Note: Supports use of custom Helm templates
   initContainers: []
 
   # -- Additional volumeMounts to the dex main container
@@ -1012,9 +1017,11 @@ redis:
   #     name: secret-name
 
   # -- Additional containers to be added to the redis pod
+  ## Note: Supports use of custom Helm templates
   extraContainers: []
 
   # -- Init containers to add to the redis pod
+  ## Note: Supports use of custom Helm templates
   initContainers: []
 
   # -- Additional volumeMounts to the redis container
@@ -1353,7 +1360,7 @@ server:
     #    memory: 64Mi
 
   # -- Additional containers to be added to the server pod
-  ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
+  ## Note: Supports use of custom Helm templates
   extraContainers: []
   # - name: my-sidecar
   #   image: nginx:latest
@@ -1846,11 +1853,13 @@ repoServer:
 
   # -- Additional containers to be added to the repo server pod
   ## Ref: https://argo-cd.readthedocs.io/en/stable/user-guide/config-management-plugins/
+  ## Note: Supports use of custom Helm templates
   extraContainers: []
   # - name: cmp
   #   # Entrypoint should be Argo CD lightweight CMP server i.e. argocd-cmp-server
   #   command: [/var/run/argocd/argocd-cmp-server]
-  #   image: busybox # This can be off-the-shelf or custom-built image
+  #   # This can be off-the-shelf or custom-built image
+  #   image: busybox
   #   securityContext:
   #     runAsNonRoot: true
   #     runAsUser: 999
@@ -2134,7 +2143,12 @@ applicationSet:
     #     name: secret-name
 
   # -- Additional containers to be added to the ApplicationSet controller pod
+  ## Note: Supports use of custom Helm templates
   extraContainers: []
+
+  # -- Init containers to add to the ApplicationSet controller pod
+  ## Note: Supports use of custom Helm templates
+  initContainers: []
 
   # -- List of extra mounts to add (normally used with extraVolumes)
   extraVolumeMounts: []
@@ -2381,6 +2395,14 @@ notifications:
     #     name: config-map-name
     # - secretRef:
     #     name: secret-name
+
+  # -- Additional containers to be added to the notifications controller pod
+  ## Note: Supports use of custom Helm templates
+  extraContainers: []
+
+  # -- Init containers to add to the notifications controller pod
+  ## Note: Supports use of custom Helm templates
+  initContainers: []
 
   # -- List of extra mounts to add (normally used with extraVolumes)
   extraVolumeMounts: []


### PR DESCRIPTION
Resolves: https://github.com/argoproj/argo-helm/issues/1490

Allows users to create custom configuration structures for sidecars / init containers that can be templated with Helm values. Mainly intended for use with CMP plugins but is useful also for custom auth plugins that needs to be injected into multiple components.

Example use:

```yaml
busybox:
  image:
    repository: busybox
    tag: latest

repoServer:
  extraContainers:
  - name: busybox
    image: "{{ .Values.busybox.repository }}:{{ .Values.busybox.tag }}"
```

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
