### PR TITLE
fix(argo-cd): Fully disable Dex when setting `dex.enabled: false`

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.16.14
+version: 5.16.15
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -23,6 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Docs]: Added sample how to provide K8s credentials plugin"
-    - "[Docs]: Added sample how to provide Argo config management plugin"
-    - "[Docs]: Removed samples that injects tools into incorrect controllers"
+    - "[Fixed]: Disabling Dex completely"

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -98,12 +98,14 @@ spec:
                 name: argocd-cmd-params-cm
                 key: repo.server
                 optional: true
+          {{- if and .Values.dex.enabled }}
           - name: ARGOCD_SERVER_DEX_SERVER
             valueFrom:
               configMapKeyRef:
                 name: argocd-cmd-params-cm
                 key: server.dex.server
                 optional: true
+          {{- end }}
           - name: ARGOCD_SERVER_DISABLE_AUTH
             valueFrom:
               configMapKeyRef:
@@ -146,18 +148,22 @@ spec:
                 name: argocd-cmd-params-cm
                 key: server.repo.server.strict.tls
                 optional: true
+          {{- if and .Values.dex.enabled }}
           - name: ARGOCD_SERVER_DEX_SERVER_PLAINTEXT
             valueFrom:
               configMapKeyRef:
                 name: argocd-cmd-params-cm
                 key: server.dex.server.plaintext
                 optional: true
+          {{- end }}
+          {{- if and .Values.dex.enabled .Values.dex.certificateSecret.enabled }}
           - name: ARGOCD_SERVER_DEX_SERVER_STRICT_TLS
             valueFrom:
               configMapKeyRef:
                 name: argocd-cmd-params-cm
                 key: server.dex.server.strict.tls
                 optional: true
+          {{- end }}
           - name: ARGOCD_TLS_MIN_VERSION
             valueFrom:
               configMapKeyRef:
@@ -274,8 +280,10 @@ spec:
           name: tls-certs
         - mountPath: /app/config/server/tls
           name: argocd-repo-server-tls
+        {{- if and .Values.dex.enabled .Values.dex.certificateSecret.enabled }}
         - mountPath: /app/config/dex/tls
           name: argocd-dex-server-tls
+        {{- end }}
         - mountPath: /home/argocd
           name: plugins-home
         - mountPath: /shared/app/custom
@@ -397,6 +405,7 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
+      {{- if and .Values.dex.enabled .Values.dex.certificateSecret.enabled }}
       - name: argocd-dex-server-tls
         secret:
           secretName: argocd-dex-server-tls
@@ -406,6 +415,7 @@ spec:
             path: tls.crt
           - key: ca.crt
             path: ca.crt
+      {{- end }}
       {{- with .Values.server.initContainers }}
       initContainers:
         {{- toYaml . | nindent 6 }}

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dex.metrics.enabled .Values.dex.metrics.serviceMonitor.enabled }}
+{{- if and .Values.dex.enabled .Values.dex.metrics.enabled .Values.dex.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
