### PR TITLE
feat(argo-workflows): Add helper function to determine image value, minus tag

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.22.7
+version: 0.22.8
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support podGCDeleteDelayDuration and podGCGracePeriodSeconds"
+    - "[Added]: Helm helper function to allow image registry to be absent"

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -142,3 +142,14 @@ Return the default Argo Workflows app version
 {{- define "argo-workflows.defaultTag" -}}
   {{- default .Chart.AppVersion .Values.images.tag }}
 {{- end -}}
+
+{{/*
+Return full image name including or excluding registry based on existence
+*/}}
+{{- define "argo-workflows.image" -}}
+{{- if and .image.registry .image.repository -}}
+  {{ .image.registry }}/{{ .image.repository }}
+{{- else -}}
+  {{ .image.repository }}
+{{- end -}}
+{{- end -}}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -34,14 +34,14 @@ spec:
       {{- end }}
       containers:
         - name: controller
-          image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag }}"
+          image: "{{- include "argo-workflows.image" (dict "context" . "image" .Values.controller.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: [ "workflow-controller" ]
           args:
           - "--configmap"
           - "{{ template "argo-workflows.controller.fullname" . }}-configmap"
           - "--executor-image"
-          - "{{ .Values.executor.image.registry }}/{{ .Values.executor.image.repository }}:{{ default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag }}"
+          - "{{- include "argo-workflows.image" (dict "context" . "image" .Values.executor.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag }}"
           - "--loglevel"
           - "{{ .Values.controller.logging.level }}"
           - "--gloglevel"

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
         - name: argo-server
-          image: "{{ .Values.server.image.registry }}/{{ .Values.server.image.repository }}:{{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag }}"
+          image: "{{- include "argo-workflows.image" (dict "context" . "image" .Values.server.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           securityContext:
             {{- toYaml .Values.server.securityContext | nindent 12 }}


### PR DESCRIPTION
We have a situation where we want to exclude the registry so that images can be pulled from in-network mirrors. Currently when you exclude the registry, you get stuck with a prefixing forward slash.

Had to keep the tags in the manifest files because helm template requires a colon in the image value.  Otherwise I'd move it into the helper function.

image entries changed: server, controller, executor

<details>
  <summary>Example when registry is default `quay.io` like current:</summary>

```
✗ helm template --release-name argo-workflows -f values.yaml --namespace argo . --debug --include-crds | grep "image" -C2                                                14:12:08
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/jasonmeridth/code/argo-helm/charts/argo-workflows

feat(argo-workflows): Add helper function to determine image value, minus tag
      containers:
        - name: controller
          image: "quay.io/argoproj/workflow-controller:v3.4.4"
          imagePullPolicy: Always
          command: [ "workflow-controller" ]
          args:
          - "--configmap"
          - "argo-workflows-workflow-controller-configmap"
          - "--executor-image"
          - "quay.io/argoproj/argoexec:v3.4.4"
          - "--loglevel"
--
      containers:
        - name: argo-server
          image: "quay.io/argoproj/argocli:v3.4.4"
          imagePullPolicy: Always
          securityContext:
            allowPrivilegeEscalation: false
```

</details>

<details>
  <summary>Example when registry is empty:</summary>

```
✗ helm template --release-name argo-workflows -f values.yaml --namespace argo . --debug --include-crds | grep "image" -C2                                                14:12:08
install.go:192: [debug] Original chart version: ""
install.go:209: [debug] CHART PATH: /Users/jasonmeridth/code/argo-helm/charts/argo-workflows

feat(argo-workflows): Add helper function to determine image value, minus tag
      containers:
        - name: controller
          image: "argoproj/workflow-controller:v3.4.4"
          imagePullPolicy: Always
          command: [ "workflow-controller" ]
          args:
          - "--configmap"
          - "argo-workflows-workflow-controller-configmap"
          - "--executor-image"
          - "argoproj/argoexec:v3.4.4"
          - "--loglevel"
--
      containers:
        - name: argo-server
          image: "argoproj/argocli:v3.4.4"
          imagePullPolicy: Always
          securityContext:
            allowPrivilegeEscalation: false
```

</details>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
