### PR TITLE
feat(argo-workflows): simplify image values so registry is included

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.22.8
+version: 0.23.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,4 +13,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Helm helper function to allow image registry to be absent"
+    - "[Removed]: Removed image registry key from values.yaml for controller, executor and server"

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -80,8 +80,7 @@ Fields to note:
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
-| controller.image.registry | string | `"quay.io"` | Registry to use for the controller |
-| controller.image.repository | string | `"argoproj/workflow-controller"` | Registry to use for the controller |
+| controller.image.repository | string | `"quay.io/argoproj/workflow-controller"` | Repository to use for the controller |
 | controller.image.tag | string | `""` | Image tag for the workflow controller. Defaults to `.Values.images.tag`. |
 | controller.initialDelay | string | `nil` | Resolves ongoing, uncommon AWS EKS bug: https://github.com/argoproj/argo-workflows/pull/4224 |
 | controller.instanceID.enabled | bool | `false` | Configures the controller to filter workflow submissions to only those which have a matching instanceID attribute. |
@@ -166,8 +165,7 @@ Fields to note:
 |-----|------|---------|-------------|
 | executor.env | list | `[]` | Adds environment variables for the executor. |
 | executor.image.pullPolicy | string | `""` | Image PullPolicy to use for the Workflow Executors. Defaults to `.Values.images.pullPolicy`. |
-| executor.image.registry | string | `"quay.io"` | Registry to use for the Workflow Executors |
-| executor.image.repository | string | `"argoproj/argoexec"` | Repository to use for the Workflow Executors |
+| executor.image.repository | string | `"quay.io/argoproj/argoexec"` | Repository to use for the Workflow Executors |
 | executor.image.tag | string | `""` | Image tag for the workflow executor. Defaults to `.Values.images.tag`. |
 | executor.resources | object | `{}` | Resource limits and requests for the Workflow Executors |
 | executor.securityContext | object | `{}` | sets security context for the executor container |
@@ -185,8 +183,7 @@ Fields to note:
 | server.extraArgs | list | `[]` | Extra arguments to provide to the Argo server binary, such as for disabling authentication. |
 | server.extraContainers | list | `[]` | Extra containers to be added to the server deployment |
 | server.extraEnv | list | `[]` | Extra environment variables to provide to the argo-server container |
-| server.image.registry | string | `"quay.io"` | Registry to use for the server |
-| server.image.repository | string | `"argoproj/argocli"` | Repository to use for the server |
+| server.image.repository | string | `"quay.io/argoproj/argocli"` | Repository to use for the server |
 | server.image.tag | string | `""` | Image tag for the Argo Workflows server. Defaults to `.Values.images.tag`. |
 | server.ingress.annotations | object | `{}` | Additional ingress annotations |
 | server.ingress.enabled | bool | `false` | Enable an ingress resource |
@@ -243,17 +240,6 @@ Fields to note:
 
 1. the `installCRD` value has been removed. CRDs are now only installed from the conventional crds/ directory
 1. the CRDs were updated to `apiextensions.k8s.io/v1`
-1. the container image registry/project/tag format was changed to be more in line with the more common
-
-   ```yaml
-   image:
-     registry: quay.io
-     repository: argoproj/argocli
-     tag: v3.0.1
-   ```
-
-   this also makes it easier for automatic update tooling (eg. renovate bot) to detect and update images.
-
 1. switched to quay.io as the default registry for all images
 1. removed any included usage of Minio
 1. aligned the configuration of serviceAccounts with the argo-cd chart, ie: what used to be `server.createServiceAccount` is now `server.serviceAccount.create`

--- a/charts/argo-workflows/README.md.gotmpl
+++ b/charts/argo-workflows/README.md.gotmpl
@@ -115,17 +115,6 @@ Fields to note:
 
 1. the `installCRD` value has been removed. CRDs are now only installed from the conventional crds/ directory
 1. the CRDs were updated to `apiextensions.k8s.io/v1`
-1. the container image registry/project/tag format was changed to be more in line with the more common
-
-   ```yaml
-   image:
-     registry: quay.io
-     repository: argoproj/argocli
-     tag: v3.0.1
-   ```
-
-   this also makes it easier for automatic update tooling (eg. renovate bot) to detect and update images.
-
 1. switched to quay.io as the default registry for all images
 1. removed any included usage of Minio
 1. aligned the configuration of serviceAccounts with the argo-cd chart, ie: what used to be `server.createServiceAccount` is now `server.serviceAccount.create`

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -142,14 +142,3 @@ Return the default Argo Workflows app version
 {{- define "argo-workflows.defaultTag" -}}
   {{- default .Chart.AppVersion .Values.images.tag }}
 {{- end -}}
-
-{{/*
-Return full image name including or excluding registry based on existence
-*/}}
-{{- define "argo-workflows.image" -}}
-{{- if and .image.registry .image.repository -}}
-  {{ .image.registry }}/{{ .image.repository }}
-{{- else -}}
-  {{ .image.repository }}
-{{- end -}}
-{{- end -}}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -34,14 +34,14 @@ spec:
       {{- end }}
       containers:
         - name: controller
-          image: "{{- include "argo-workflows.image" (dict "context" . "image" .Values.controller.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag }}"
+          image: "{{ .Values.controller.image.repository }}:{{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           command: [ "workflow-controller" ]
           args:
           - "--configmap"
           - "{{ template "argo-workflows.controller.fullname" . }}-configmap"
           - "--executor-image"
-          - "{{- include "argo-workflows.image" (dict "context" . "image" .Values.executor.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag }}"
+          - "{{ .Values.executor.image.repository }}:{{ default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag }}"
           - "--loglevel"
           - "{{ .Values.controller.logging.level }}"
           - "--gloglevel"

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
         - name: argo-server
-          image: "{{- include "argo-workflows.image" (dict "context" . "image" .Values.server.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag }}"
+          image: "{{ .Values.server.image.repository }}:{{ default (include "argo-workflows.defaultTag" .) .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           securityContext:
             {{- toYaml .Values.server.securityContext | nindent 12 }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -54,10 +54,8 @@ workflow:
 
 controller:
   image:
-    # -- Registry to use for the controller
-    registry: quay.io
-    # -- Registry to use for the controller
-    repository: argoproj/workflow-controller
+    # -- Repository to use for the controller
+    repository: quay.io/argoproj/workflow-controller
     # -- Image tag for the workflow controller. Defaults to `.Values.images.tag`.
     tag: ""
   # -- parallelism dictates how many workflows can be running at the same time
@@ -340,10 +338,8 @@ mainContainer:
 # executor controls how the init and wait container should be customized
 executor:
   image:
-    # -- Registry to use for the Workflow Executors
-    registry: quay.io
     # -- Repository to use for the Workflow Executors
-    repository: argoproj/argoexec
+    repository: quay.io/argoproj/argoexec
     # -- Image tag for the workflow executor. Defaults to `.Values.images.tag`.
     tag: ""
     # -- Image PullPolicy to use for the Workflow Executors. Defaults to `.Values.images.pullPolicy`.
@@ -364,10 +360,8 @@ server:
   ## https://github.com/argoproj/argo-workflows/issues/716#issuecomment-433213190
   baseHref: /
   image:
-    # -- Registry to use for the server
-    registry: quay.io
     # -- Repository to use for the server
-    repository: argoproj/argocli
+    repository: quay.io/argoproj/argocli
     # -- Image tag for the Argo Workflows server. Defaults to `.Values.images.tag`.
     tag: ""
   # -- optional map of annotations to be applied to the ui Deployment


### PR DESCRIPTION
In #1754 I added helper function to fix issue if image registry is left empty in values.yaml so a prefixing forward slash is left.

I noticed the argo-cd chart values.yaml doesn't have a separate key for image registry.  This simplifies the including or excluding an image registry.

- [x] remove helper function from previous PR
- [x] update README
  - [x] remove [controller|executor|server].image.registry
  - [x] update [controller|executor|server].image.repository to include `quay.io` registry prefix by default
  - [x] remove mention of registry key in update from old argo chart at bottom
- [x] update image.repository to include default quay.io registry value
- [x] simplify image value usage

Signed-off-by: jmeridth <jmeridth@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
