### PR TITLE
fix(argo-cd): Consolidate and fix container ports

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.7
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.19.0
+version: 5.19.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,6 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Option configs.ssh.extraHosts that allows to keep original SSH known list"
-    - "[Changed]: Option configs.knownHosts deprecated as moved to configs.ssh"
-    - "[Changed]: Option configs.tlsCerts deprecated as moved to configs.tls"
+    - "[Fixed]: Container port configuration now properly sets the listening port"
+    - "[Changed]: Container ports consolidated from various places to new containerPorts sections"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -462,7 +462,7 @@ NAME: my-release
 | controller.args | object | `{}` | DEPRECATED - Application controller commandline flags |
 | controller.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the application controller's ClusterRole resource |
 | controller.clusterRoleRules.rules | list | `[]` | List of custom rules for the application controller's ClusterRole resource |
-| controller.containerPort | int | `8082` | Application controller listening port |
+| controller.containerPorts.metrics | int | `8082` | Metrics container port |
 | controller.containerSecurityContext | object | See [values.yaml] | Application controller container-level security context |
 | controller.env | list | `[]` | Environment variables to pass to application controller |
 | controller.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to application controller |
@@ -539,7 +539,8 @@ NAME: my-release
 | repoServer.certificateSecret.labels | object | `{}` | Labels to be added to argocd-repo-server-tls secret |
 | repoServer.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the Repo server's Cluster Role resource |
 | repoServer.clusterRoleRules.rules | list | `[]` | List of custom rules for the Repo server's Cluster Role resource |
-| repoServer.containerPort | int | `8081` | Configures the repo server port |
+| repoServer.containerPorts.metrics | int | `8084` | Metrics container port |
+| repoServer.containerPorts.server | int | `8081` | Repo server container port |
 | repoServer.containerSecurityContext | object | See [values.yaml] | Repo server container-level security context |
 | repoServer.deploymentAnnotations | object | `{}` | Annotations to be added to repo server Deployment |
 | repoServer.env | list | `[]` | Environment variables to pass to repo server |
@@ -638,7 +639,8 @@ NAME: my-release
 | server.certificateSecret.enabled | bool | `false` | Create argocd-server-tls secret |
 | server.certificateSecret.key | string | `""` | Private Key of the certificate |
 | server.certificateSecret.labels | object | `{}` | Labels to be added to argocd-server-tls secret |
-| server.containerPort | int | `8080` | Configures the server port |
+| server.containerPorts.metrics | int | `8082` | Metrics container port |
+| server.containerPorts.server | int | `8080` | Server container port |
 | server.containerSecurityContext | object | See [values.yaml] | Server container-level security context |
 | server.deploymentAnnotations | object | `{}` | Annotations to be added to server Deployment |
 | server.env | list | `[]` | Environment variables to pass to Argo CD server |
@@ -728,7 +730,6 @@ NAME: my-release
 | server.service.labels | object | `{}` | Server service labels |
 | server.service.loadBalancerIP | string | `""` | LoadBalancer will get created with the IP specified in this field |
 | server.service.loadBalancerSourceRanges | list | `[]` | Source IP ranges to allow access to service from |
-| server.service.namedTargetPort | bool | `true` | Use named target port for argocd |
 | server.service.nodePortHttp | int | `30080` | Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort") |
 | server.service.nodePortHttps | int | `30443` | Server service https port for NodePort service type (only if `server.service.type` is set to "NodePort") |
 | server.service.servicePortHttp | int | `80` | Server service http port |
@@ -780,9 +781,9 @@ server:
 | dex.certificateSecret.enabled | bool | `false` | Create argocd-dex-server-tls secret |
 | dex.certificateSecret.key | string | `""` | Certificate private key |
 | dex.certificateSecret.labels | object | `{}` | Labels to be added to argocd-dex-server-tls secret |
-| dex.containerPortGrpc | int | `5557` | Container port for gRPC access |
-| dex.containerPortHttp | int | `5556` | Container port for HTTP access |
-| dex.containerPortMetrics | int | `5558` | Container port for metrics access |
+| dex.containerPorts.grpc | int | `5557` | gRPC container port |
+| dex.containerPorts.http | int | `5556` | HTTP container port |
+| dex.containerPorts.metrics | int | `5558` | Metrics container port |
 | dex.containerSecurityContext | object | See [values.yaml] | Dex container-level security context |
 | dex.deploymentAnnotations | object | `{}` | Annotations to be added to the Dex server Deployment |
 | dex.enabled | bool | `true` | Enable dex |
@@ -856,7 +857,8 @@ server:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | redis.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
-| redis.containerPort | int | `6379` | Redis container port |
+| redis.containerPorts.metrics | int | `9121` | Metrics container port |
+| redis.containerPorts.redis | int | `6379` | Redis container port |
 | redis.containerSecurityContext | object | See [values.yaml] | Redis container-level security context |
 | redis.deploymentAnnotations | object | `{}` | Annotations to be added to the Redis server Deployment |
 | redis.enabled | bool | `true` | Enable redis |
@@ -869,7 +871,6 @@ server:
 | redis.image.tag | string | `"7.0.5-alpine"` | Redis tag |
 | redis.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | redis.initContainers | list | `[]` | Init containers to add to the redis pod |
-| redis.metrics.containerPort | int | `9121` | Port to use for redis-exporter sidecar |
 | redis.metrics.containerSecurityContext | object | See [values.yaml] | Redis exporter security context |
 | redis.metrics.enabled | bool | `false` | Deploy metrics service and redis-exporter sidecar |
 | redis.metrics.image.imagePullPolicy | string | `"IfNotPresent"` | redis-exporter image PullPolicy |
@@ -962,9 +963,10 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 |-----|------|---------|-------------|
 | applicationSet.affinity | object | `{}` | Assign custom [affinity] rules |
 | applicationSet.args.dryRun | bool | `false` | Enable dry run mode |
-| applicationSet.args.metricsAddr | string | `":8080"` | The default metric address |
 | applicationSet.args.policy | string | `"sync"` | How application is synced between the generator and the cluster |
-| applicationSet.args.probeBindAddr | string | `":8081"` | The default health check port |
+| applicationSet.containerPorts.metrics | int | `8080` | Metrics container port |
+| applicationSet.containerPorts.probe | int | `8081` | Probe container port |
+| applicationSet.containerPorts.webhook | int | `7000` | Webhook container port |
 | applicationSet.containerSecurityContext | object | See [values.yaml] | ApplicationSet controller container-level security context |
 | applicationSet.deploymentAnnotations | object | `{}` | Annotations to be added to ApplicationSet controller Deployment |
 | applicationSet.enabled | bool | `true` | Enable ApplicationSet controller |
@@ -1067,6 +1069,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | notifications.bots.slack.serviceAccount.name | string | `"argocd-notifications-bot"` | The name of the service account to use. |
 | notifications.bots.slack.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | notifications.cm.create | bool | `true` | Whether helm chart creates notifications controller config map |
+| notifications.containerPorts.metrics | int | `9001` | Metrics container port |
 | notifications.containerSecurityContext | object | See [values.yaml] | Notification controller container-level security Context |
 | notifications.context | object | `{}` | Define user-defined context |
 | notifications.deploymentAnnotations | object | `{}` | Annotations to be applied to the notifications controller Deployment |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -88,6 +88,27 @@ REMOVED option applicationSet.args.debug - Use applicationSet.logLevel: debug
 {{- if .Values.applicationSet.args.enableLeaderElection }}
 REMOVED option applicationSet.args.enableLeaderElection - Value determined based on replicas
 {{- end }}
+{{- if .Values.controller.containerPort }}
+REMOVED option controller.containerPort - Use controller.containerPorts
+{{- end }}
+{{- if .Values.server.containerPort }}
+REMOVED option server.containerPort - Use server.containerPorts
+{{- end }}
+{{- if .Values.repoServer.containerPort }}
+REMOVED option repoServer.containerPort - Use repoServer.containerPorts
+{{- end }}
+{{- if .Values.applicationSet.args.metricsAddr }}
+REMOVED option applicationSet.args.metricsAddr - Use applicationSet.containerPorts
+{{- end }}
+{{- if .Values.applicationSet.args.probeBindAddr }}
+REMOVED option applicationSet.args.probeBindAddr - Use applicationSet.containerPorts
+{{- end }}
+{{- if .Values.redis.containerPort }}
+REMOVED option redis.containerPort - Use redis.containerPorts
+{{- end }}
+{{- if .Values.redis.metrics.containerPort }}
+REMOVED option redis.metrics.containerPort - Use redis.containerPorts
+{{- end }}
 
 In order to access the server UI you have the following options:
 

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -44,6 +44,13 @@ spec:
       containers:
       - command:
         - argocd-application-controller
+        - --metrics-port={{ .Values.controller.containerPorts.metrics }}
+        {{- if .Values.controller.metrics.applicationLabels.enabled }}
+        {{- range .Values.controller.metrics.applicationLabels.labels }}
+        - --metrics-application-labels
+        - {{ . }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.controller.args.statusProcessors }}
         - --status-processors
         - {{ . | quote }}
@@ -75,12 +82,6 @@ spec:
         {{- with .Values.controller.logLevel }}
         - --loglevel
         - {{ . | quote }}
-        {{- end }}
-        {{- if .Values.controller.metrics.applicationLabels.enabled }}
-        {{- range .Values.controller.metrics.applicationLabels.labels }}
-        - --metrics-application-labels
-        - {{ . }}
-        {{- end }}
         {{- end }}
         {{- with .Values.controller.extraArgs }}
           {{- toYaml . | nindent 8 }}
@@ -232,7 +233,7 @@ spec:
         {{- end }}
         ports:
         - name: metrics
-          containerPort: {{ .Values.controller.containerPort }}
+          containerPort: {{ .Values.controller.containerPorts.metrics }}
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -51,10 +51,11 @@ spec:
           command:
             - entrypoint.sh
             - argocd-applicationset-controller
+            - --metrics-addr=:{{ .Values.applicationSet.containerPorts.metrics }}
+            - --probe-addr=:{{ .Values.applicationSet.containerPorts.probe }}
+            - --webhook-addr=:{{ .Values.applicationSet.containerPorts.webhook }}
             - --argocd-repo-server={{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
             - --enable-leader-election={{ gt ( .Values.applicationSet.replicaCount | int64) 1 }}
-            - --metrics-addr={{ .Values.applicationSet.args.metricsAddr }}
-            - --probe-addr={{ .Values.applicationSet.args.probeBindAddr }}
             - --policy={{ .Values.applicationSet.args.policy }}
             - --dry-run={{ .Values.applicationSet.args.dryRun }}
             - --logformat
@@ -78,13 +79,13 @@ spec:
           {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ (split ":" .Values.applicationSet.args.metricsAddr)._1 }}
+              containerPort: {{ .Values.applicationSet.containerPorts.metrics }}
               protocol: TCP
             - name: probe
-              containerPort: {{ (split ":" .Values.applicationSet.args.probeBindAddr)._1 }}
+              containerPort: {{ .Values.applicationSet.containerPorts.probe }}
               protocol: TCP
             - name: webhook
-              containerPort: 7000
+              containerPort: {{ .Values.applicationSet.containerPorts.webhook }}
               protocol: TCP
           {{- if .Values.applicationSet.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -48,9 +48,9 @@ spec:
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.notifications.image.imagePullPolicy }}
           command:
             - argocd-notifications
+            - --metrics-port={{ .Values.notifications.containerPorts.metrics }}
             - --loglevel={{ default .Values.global.logging.level .Values.notifications.logLevel }}
             - --logformat={{ default .Values.global.logging.format .Values.notifications.logFormat }}
-            - --metrics-port={{ .Values.notifications.metrics.port }}
             - --namespace={{ .Release.Namespace }}
             - --argocd-repo-server={{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
             {{- range .Values.notifications.extraArgs }}
@@ -66,7 +66,7 @@ spec:
           {{- end }}
           ports:
           - name: metrics
-            containerPort: {{ .Values.notifications.metrics.port }}
+            containerPort: {{ .Values.notifications.containerPorts.metrics }}
             protocol: TCP
           resources:
             {{- toYaml .Values.notifications.resources | nindent 12 }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -53,6 +53,8 @@ spec:
         - entrypoint.sh
         args:
         - argocd-repo-server
+        - --port={{ .Values.repoServer.containerPorts.server }}
+        - --metrics-port={{ .Values.repoServer.containerPorts.metrics }}
         {{- with .Values.repoServer.logFormat }}
         - --logformat
         - {{ . | quote }}
@@ -236,10 +238,10 @@ spec:
           name: tmp
         ports:
         - name: repo-server
-          containerPort: {{ .Values.repoServer.containerPort }}
+          containerPort: {{ .Values.repoServer.containerPorts.server }}
           protocol: TCP
         - name: metrics
-          containerPort: 8084
+          containerPort: {{ .Values.repoServer.containerPorts.metrics }}
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/charts/argo-cd/templates/argocd-server/aws/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/service.yaml
@@ -12,11 +12,11 @@ spec:
   - name: {{ .Values.server.service.servicePortHttpName }}
     protocol: TCP
     port: {{ .Values.server.service.servicePortHttp }}
-    targetPort: {{- if .Values.server.service.namedTargetPort }} {{ .Values.server.name }} {{- else }} {{ .Values.server.containerPort }} {{- end }}
+    targetPort: server
   - name: {{ .Values.server.service.servicePortHttpsName }}
     protocol: TCP
     port: {{ .Values.server.service.servicePortHttps }}
-    targetPort: {{- if .Values.server.service.namedTargetPort }} {{ .Values.server.name }} {{- else }} {{ .Values.server.containerPort }} {{- end }}
+    targetPort: server
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 4 }}
   sessionAffinity: None

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -47,6 +47,8 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.server.image.imagePullPolicy }}
         command:
         - argocd-server
+        - --port={{ .Values.server.containerPorts.server }}
+        - --metrics-port={{ .Values.server.containerPorts.metrics }}
         {{- with .Values.server.logFormat }}
         - --logformat
         - {{ . | quote }}
@@ -287,16 +289,16 @@ spec:
           name: extensions
         {{- end }}
         ports:
-        - name: {{ .Values.server.name }}
-          containerPort: {{ .Values.server.containerPort }}
+        - name: server
+          containerPort: {{ .Values.server.containerPorts.server }}
           protocol: TCP
         - name: metrics
-          containerPort: 8083
+          containerPort: {{ .Values.server.containerPorts.metrics }}
           protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz?full=true
-            port: {{ .Values.server.containerPort }}
+            port: server
           initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
@@ -305,7 +307,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.server.containerPort }}
+            port: server
           initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}

--- a/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/service.yaml
@@ -19,14 +19,14 @@ spec:
   - name: {{ .Values.server.service.servicePortHttpName }}
     protocol: TCP
     port: {{ .Values.server.service.servicePortHttp }}
-    targetPort: {{- if .Values.server.service.namedTargetPort }} {{ .Values.server.name }} {{- else }} {{ .Values.server.containerPort }} {{- end }}
+    targetPort: {{ .Values.server.containerPorts.server }}
     {{- if eq .Values.server.service.type "NodePort" }}
     nodePort: {{ .Values.server.service.nodePortHttp }}
     {{- end }}
   - name: {{ .Values.server.service.servicePortHttpsName }}
     protocol: TCP
     port: {{ .Values.server.service.servicePortHttps }}
-    targetPort: {{- if .Values.server.service.namedTargetPort }} {{ .Values.server.name }} {{- else }} {{ .Values.server.containerPort }} {{- end }}
+    targetPort: {{ .Values.server.containerPorts.server }}
     {{- if eq .Values.server.service.type "NodePort" }}
     nodePort: {{ .Values.server.service.nodePortHttps }}
     {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -70,13 +70,13 @@ spec:
         {{- end }}
         ports:
         - name: http
-          containerPort: {{ .Values.dex.containerPortHttp }}
+          containerPort: {{ .Values.dex.containerPorts.http }}
           protocol: TCP
         - name: grpc
-          containerPort: {{ .Values.dex.containerPortGrpc }}
+          containerPort: {{ .Values.dex.containerPorts.grpc }}
           protocol: TCP
         - name: metrics
-          containerPort: {{ .Values.dex.containerPortMetrics }}
+          containerPort: {{ .Values.dex.containerPorts.metrics }}
           protocol: TCP
         {{- if .Values.dex.livenessProbe.enabled }}
         livenessProbe:

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         {{- end }}
         ports:
         - name: redis
-          containerPort: {{ .Values.redis.containerPort }}
+          containerPort: {{ .Values.redis.containerPorts.redis }}
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.resources | nindent 10 }}
@@ -79,12 +79,12 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.redis.metrics.image.imagePullPolicy }}
         env:
         - name: REDIS_ADDR
-          value: {{ printf "redis://localhost:%v" .Values.redis.containerPort }}
+          value: {{ printf "redis://localhost:%v" .Values.redis.containerPorts.redis }}
         - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-          value: {{ printf "0.0.0.0:%v" .Values.redis.metrics.containerPort }}
+          value: {{ printf "0.0.0.0:%v" .Values.redis.containerPorts.metrics }}
         ports:
         - name: metrics
-          containerPort: {{ .Values.redis.metrics.containerPort }}
+          containerPort: {{ .Values.redis.containerPorts.metrics }}
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.metrics.resources | nindent 10 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -575,6 +575,11 @@ controller:
   #    cpu: 250m
   #    memory: 256Mi
 
+  # Application controller container ports
+  containerPorts:
+    # -- Metrics container port
+    metrics: 8082
+
   # -- Application controller container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
@@ -586,9 +591,6 @@ controller:
     capabilities:
       drop:
       - ALL
-
-  # -- Application controller listening port
-  containerPort: 8082
 
   # Rediness probe for application controller
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
@@ -866,6 +868,16 @@ dex:
   #    cpu: 10m
   #    memory: 32Mi
 
+  # Dex container ports
+  # NOTE: These ports are currently hardcoded and cannot be changed
+  containerPorts:
+    # -- HTTP container port
+    http: 5556
+    # -- gRPC container port
+    grpc: 5557
+    # -- Metrics container port
+    metrics: 5558
+
   # -- Dex container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
@@ -893,6 +905,7 @@ dex:
     successThreshold: 1
     # -- Number of seconds after which the [probe] times out
     timeoutSeconds: 1
+
   readinessProbe:
     # -- Enable Kubernetes readiness probe for Dex >= 2.28.0
     enabled: false
@@ -917,20 +930,14 @@ dex:
     # -- Automount API credentials for the Service Account
     automountServiceAccountToken: true
 
-  # -- Container port for HTTP access
-  containerPortHttp: 5556
   # -- Service port for HTTP access
   servicePortHttp: 5556
   # -- Service port name for HTTP access
   servicePortHttpName: http
-  # -- Container port for gRPC access
-  containerPortGrpc: 5557
   # -- Service port for gRPC access
   servicePortGrpc: 5557
   # -- Service port name for gRPC access
   servicePortGrpcName: grpc
-  # -- Container port for metrics access
-  containerPortMetrics: 5558
   # -- Service port for metrics access
   servicePortMetrics: 5558
 
@@ -1044,6 +1051,13 @@ redis:
     seccompProfile:
       type: RuntimeDefault
 
+  # Redis container ports
+  containerPorts:
+    # -- Redis container port
+    redis: 6379
+    # -- Metrics container port
+    metrics: 9121
+
   # -- Redis container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
@@ -1052,8 +1066,6 @@ redis:
       drop:
       - ALL
 
-  # -- Redis container port
-  containerPort: 6379
   # -- Redis service port
   servicePort: 6379
 
@@ -1103,8 +1115,6 @@ redis:
       tag: 1.26.0-debian-10-r2
       # -- redis-exporter image PullPolicy
       imagePullPolicy: IfNotPresent
-    # -- Port to use for redis-exporter sidecar
-    containerPort: 9121
 
     # -- Redis exporter security context
     # @default -- See [values.yaml]
@@ -1415,8 +1425,24 @@ server:
   #    cpu: 50m
   #    memory: 64Mi
 
-  # -- Configures the server port
-  containerPort: 8080
+  # Server container ports
+  containerPorts:
+    # -- Server container port
+    server: 8080
+    # -- Metrics container port
+    metrics: 8082
+
+  # -- Server container-level security context
+  # @default -- See [values.yaml]
+  containerSecurityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   ## Readiness and liveness probes for default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
@@ -1431,6 +1457,7 @@ server:
     successThreshold: 1
     # -- Number of seconds after which the [probe] times out
     timeoutSeconds: 1
+
   livenessProbe:
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
@@ -1460,18 +1487,6 @@ server:
 
   # -- Priority class for the Argo CD server
   priorityClassName: ""
-
-  # -- Server container-level security context
-  # @default -- See [values.yaml]
-  containerSecurityContext:
-    runAsNonRoot: true
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
-    seccompProfile:
-      type: RuntimeDefault
-    capabilities:
-      drop:
-      - ALL
 
   # TLS certificate configuration via cert-manager
   ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#tls-certificates-used-by-argocd-server
@@ -1546,10 +1561,6 @@ server:
     servicePortHttpName: http
     # -- Server service https port name, can be used to route traffic via istio
     servicePortHttpsName: https
-    # -- Use named target port for argocd
-    ## Named target ports are not supported by GCE health checks, so when deploying argocd on GKE
-    ## and exposing it via GCE ingress, the health checks fail and the load balancer returns a 502.
-    namedTargetPort: true
     # -- LoadBalancer will get created with the IP specified in this field
     loadBalancerIP: ""
     # -- Source IP ranges to allow access to service from
@@ -1897,8 +1908,24 @@ repoServer:
   #    cpu: 10m
   #    memory: 64Mi
 
-  # -- Configures the repo server port
-  containerPort: 8081
+  # Repo server container ports
+  containerPorts:
+    # -- Repo server container port
+    server: 8081
+    # -- Metrics container port
+    metrics: 8084
+
+  # -- Repo server container-level security context
+  # @default -- See [values.yaml]
+  containerSecurityContext:
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
 
   ## Readiness and liveness probes for default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
@@ -1913,6 +1940,7 @@ repoServer:
     successThreshold: 1
     # -- Number of seconds after which the [probe] times out
     timeoutSeconds: 1
+
   livenessProbe:
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
@@ -1942,18 +1970,6 @@ repoServer:
 
   # -- Priority class for the repo server
   priorityClassName: ""
-
-  # -- Repo server container-level security context
-  # @default -- See [values.yaml]
-  containerSecurityContext:
-    runAsNonRoot: true
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
-    seccompProfile:
-      type: RuntimeDefault
-    capabilities:
-      drop:
-      - ALL
 
   # TLS certificate configuration via Secret
   ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#configuring-tls-to-argocd-repo-server
@@ -2105,10 +2121,6 @@ applicationSet:
   logLevel: ""
 
   args:
-    # -- The default metric address
-    metricsAddr: :8080
-    # -- The default health check port
-    probeBindAddr: :8081
     # -- How application is synced between the generator and the cluster
     policy: sync
     # -- Enable dry run mode
@@ -2220,6 +2232,15 @@ applicationSet:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+  # ApplicationSet controller container ports
+  containerPorts:
+    # -- Metrics container port
+    metrics: 8080
+    # -- Probe container port
+    probe: 8081
+    # -- Webhook container port
+    webhook: 7000
 
   # -- ApplicationSet controller container-level security context
   # @default -- See [values.yaml]
@@ -2485,6 +2506,11 @@ notifications:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+  # Notification controller container ports
+  containerPorts:
+    # -- Metrics container port
+    metrics: 9001
 
   # -- Notification controller container-level security Context
   # @default -- See [values.yaml]


### PR DESCRIPTION
Container ports are now scattered on multiple places (individual variables, args, sometimes service ports). This PR moves all of them under containerPorts and clearly marks what does the port do. It also provides arguments to pods so the port is actually properly reconfigured.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
