### PR TITLE
fix(argo-cd): Fix annotations for ssh and tls configs

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.7
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.19.4
+version: 5.19.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Decoupled redis metrics exporter from metrics service"
+    - "[Fixed]: Annotations for tls and ssh sections works as expected"

--- a/charts/argo-cd/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-ssh-known-hosts-cm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-ssh-known-hosts-cm
   labels:
     {{- include "argo-cd.labels" (dict "context" . "name" "ssh-known-hosts-cm") | nindent 4 }}
-  {{- with (mergeOverwrite (deepCopy .Values.configs.ssh.annotations) (.Values.configs.knownHostsAnnotations | default dict)) -}}
+  {{- with (mergeOverwrite (deepCopy .Values.configs.ssh.annotations) (.Values.configs.knownHostsAnnotations | default dict)) }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-tls-certs-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-tls-certs-cm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-tls-certs-cm
   labels:
     {{- include "argo-cd.labels" (dict "context" . "name" "tls-certs-cm") | nindent 4 }}
-  {{- with (mergeOverwrite (deepCopy .Values.configs.ssh.annotations) (.Values.configs.tlsCertsAnnotations | default dict)) -}}
+  {{- with (mergeOverwrite (deepCopy .Values.configs.tls.annotations) (.Values.configs.tlsCertsAnnotations | default dict)) }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
Fixed copy & paste errors when adding new annotations options.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
