### PR TITLE
chore(argo-cd): Upgrade Redis exporter image

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.7
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.19.5
+version: 5.19.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,4 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Fixed]: Annotations for tls and ssh sections works as expected"
+    - "[Changed]: Upgrade Redis exporter image to 1.45.0"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -868,7 +868,7 @@ server:
 | redis.exporter.enabled | bool | `true` | Enable Prometheus redis-exporter sidecar |
 | redis.exporter.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Redis exporter |
 | redis.exporter.image.repository | string | `"public.ecr.aws/bitnami/redis-exporter"` | redis-exporter image repository |
-| redis.exporter.image.tag | string | `"1.26.0-debian-10-r2"` | redis-exporter image tag |
+| redis.exporter.image.tag | string | `"1.45.0"` | redis-exporter image tag |
 | redis.exporter.resources | object | `{}` | Resource limits and requests for redis-exporter sidecar |
 | redis.extraArgs | list | `[]` | Additional command line arguments to pass to redis-server |
 | redis.extraContainers | list | `[]` | Additional containers to be added to the redis pod |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1001,7 +1001,7 @@ redis:
       # -- redis-exporter image repository
       repository: public.ecr.aws/bitnami/redis-exporter
       # -- redis-exporter image tag
-      tag: 1.26.0-debian-10-r2
+      tag: 1.45.0
       # -- Image pull policy for the Redis exporter
       # @default -- `""` (defaults to global.image.imagePullPolicy)
       imagePullPolicy: ""


### PR DESCRIPTION
Upgrade exporter image that is long past due. New image is scanned for Log4Shell and Text4Shell vulnerabilities.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
