### PR TITLE
fix(argo-cd): Disable Redis exporter by default

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.8
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.19.7
+version: 5.19.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,4 +23,6 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: Update Argo CD to v2.5.8"
+    - "[Changed]: Disable Redis exporter by default"
+    - "[Changed]: Use bitnami Redis exporter image for redis-ha"
+    - "[Docs]: Fixed defaults for Redis exporter"

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -865,14 +865,14 @@ server:
 | redis.env | list | `[]` | Environment variables to pass to the Redis server |
 | redis.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the Redis server |
 | redis.exporter.containerSecurityContext | object | See [values.yaml] | Redis exporter security context |
-| redis.exporter.enabled | bool | `true` | Enable Prometheus redis-exporter sidecar |
-| redis.exporter.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Redis exporter |
-| redis.exporter.image.repository | string | `"public.ecr.aws/bitnami/redis-exporter"` | redis-exporter image repository |
-| redis.exporter.image.tag | string | `"1.45.0"` | redis-exporter image tag |
+| redis.exporter.enabled | bool | `false` | Enable Prometheus redis-exporter sidecar |
+| redis.exporter.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the redis-exporter |
+| redis.exporter.image.repository | string | `"public.ecr.aws/bitnami/redis-exporter"` | Repository to use for the redis-exporter |
+| redis.exporter.image.tag | string | `"1.45.0"` | Tag to use for the redis-exporter |
 | redis.exporter.resources | object | `{}` | Resource limits and requests for redis-exporter sidecar |
 | redis.extraArgs | list | `[]` | Additional command line arguments to pass to redis-server |
 | redis.extraContainers | list | `[]` | Additional containers to be added to the redis pod |
-| redis.image.imagePullPolicy | string | `"IfNotPresent"` | Redis imagePullPolicy |
+| redis.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Redis image pull policy |
 | redis.image.repository | string | `"public.ecr.aws/docker/library/redis"` | Redis repository |
 | redis.image.tag | string | `"7.0.5-alpine"` | Redis tag |
 | redis.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
@@ -927,7 +927,9 @@ The main options are listed here:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | redis-ha.enabled | bool | `false` | Enables the Redis HA subchart and disables the custom Redis single node deployment |
-| redis-ha.exporter.enabled | bool | `true` | If `true`, the prometheus exporter sidecar is enabled |
+| redis-ha.exporter.enabled | bool | `false` | Enable Prometheus redis-exporter sidecar |
+| redis-ha.exporter.image | string | `"public.ecr.aws/bitnami/redis-exporter"` | Repository to use for the redis-exporter |
+| redis-ha.exporter.tag | string | `"1.45.0"` | Tag to use for the redis-exporter |
 | redis-ha.haproxy.enabled | bool | `true` | Enabled HAProxy LoadBalancing/Proxy |
 | redis-ha.haproxy.metrics.enabled | bool | `true` | HAProxy enable prometheus metric scraping |
 | redis-ha.image.tag | string | `"7.0.5-alpine"` | Redis tag |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -988,21 +988,21 @@ redis:
     repository: public.ecr.aws/docker/library/redis
     # -- Redis tag
     tag: 7.0.5-alpine
-    # -- Redis imagePullPolicy
-    imagePullPolicy: IfNotPresent
+    # -- Redis image pull policy
+    # @default -- `""` (defaults to global.image.imagePullPolicy)
+    imagePullPolicy: ""
 
-  # Prometheus redis-exporter sidecar
+  ## Prometheus redis-exporter sidecar
   exporter:
     # -- Enable Prometheus redis-exporter sidecar
-    enabled: true
-
-    # Prometheus redis-exporter image
+    enabled: false
+    ## Prometheus redis-exporter image
     image:
-      # -- redis-exporter image repository
+      # -- Repository to use for the redis-exporter
       repository: public.ecr.aws/bitnami/redis-exporter
-      # -- redis-exporter image tag
+      # -- Tag to use for the redis-exporter
       tag: 1.45.0
-      # -- Image pull policy for the Redis exporter
+      # -- Image pull policy for the redis-exporter
       # @default -- `""` (defaults to global.image.imagePullPolicy)
       imagePullPolicy: ""
 
@@ -1190,9 +1190,14 @@ redis:
 redis-ha:
   # -- Enables the Redis HA subchart and disables the custom Redis single node deployment
   enabled: false
+  ## Prometheus redis-exporter sidecar
   exporter:
-    # -- If `true`, the prometheus exporter sidecar is enabled
-    enabled: true
+    # -- Enable Prometheus redis-exporter sidecar
+    enabled: false
+    # -- Repository to use for the redis-exporter
+    image: public.ecr.aws/bitnami/redis-exporter
+    # -- Tag to use for the redis-exporter
+    tag: 1.45.0
   persistentVolume:
     # -- Configures persistency on Redis nodes
     enabled: false


### PR DESCRIPTION
Resolves:
- https://github.com/argoproj/argo-helm/issues/1796

After discussion with @mkilchhofer it was decided to disable redis exporter by default to not impact people running on ARM and use Redis image everywhere as it's geared toward enterprise use.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
