### PR TITLE
chore(argo-events): Upgrade Argo Events to v1.7.5

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.7.4
+appVersion: v1.7.5
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-events/assets/logo.png
 keywords:
@@ -15,4 +15,4 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Additional manifests to deploy within the chart"
+    - "[Changed]: Update Argo Events to v1.7.5"

--- a/charts/argo-events/templates/argo-events-controller/rbac.yaml
+++ b/charts/argo-events/templates/argo-events-controller/rbac.yaml
@@ -71,7 +71,6 @@ rules:
   - pods
   - pods/exec
   - configmaps
-  - secrets
   - services
   - persistentvolumeclaims
   verbs:
@@ -79,6 +78,17 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
   - update
   - patch
   - delete


### PR DESCRIPTION
[Diff between 1.7.4 and 1.7.5](https://github.com/argoproj/argo-events/compare/v1.7.4...v1.7.5)

```
# Secrets privileges are used to manage the NATs auth secrets. This can be removed from the ClusterRole and granted granularly per Namespace as needed
```

from [here](https://github.com/argoproj/argo-events/compare/v1.7.4...v1.7.5#diff-10c209cdb869ddd4c8a374b1db219d2473a6cade1ee8b04c4f80e0447d39563aR62)

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
