### PR TITLE
fix(github): Align changelog structure to show changelogs on Artifact Hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,21 +80,35 @@ Changes on a chart must be documented in a chart specific changelog in the `Char
 
 A new `artifacthub.io/changes` needs to be written covering only the changes since the previous release.
 
-Each change requires a new bullet point following the pattern `- "[{type}]: {description}"`. You can use the following template:
+Each change requires a new bullet point following the pattern. See more information [Artifact Hub annotations in Helm Chart.yaml file](https://artifacthub.io/docs/topics/annotations/helm/).
+
+```yaml
+- kind: {type}
+  description: {description}
+```
+
+You can use the following template:
 
 ```yaml
 name: argo-cd
-version: 3.4.1
+version: 5.19.12
 ...
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Something New was added"
-    - "[Changed]: Changed Something within this chart"
-    - "[Changed]: Changed Something else within this chart"
-    - "[Deprecated]: Something deprecated"
-    - "[Removed]: Something was removed"
-    - "[Fixed]: Something was fixed"
-    - "[Security]: Some Security Patch was included"
+    - kind: added
+      description: Something New was added
+    - kind: changed
+      description: Changed Something within this chart
+    - kind: changed
+      description: Changed Something else within this chart
+    - kind: deprecated
+      description: Something deprecated
+    - kind: removed
+      description: Something was removed
+    - kind: fixed
+      description: Something was fixed
+    - kind: security
+      description: Some Security Patch was included
 ```
 
 ## Testing


### PR DESCRIPTION
relates to  https://github.com/argoproj/argo-helm/issues/1808. 

updated changelog structure worked, so I update doc. 🙋 

https://artifacthub.io/packages/helm/argo/argo-cd/5.19.12?modal=changelog&version=5.19.12
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/30188755/215337958-43026ece-1272-43ea-b7cb-200e106f5a20.png">


---

Signed-off-by: yu-croco <yu.croco@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
