### PR TITLE
fix(argocd-image-updater): Align changelog structure

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: v0.12.0
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -15,4 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - "[Changed]: avoid app.kubernetes.io/version kubernetes label from exceeding maximum length (63)"
+    - kind: fixed
+      description: Align changelog structure to show changelogs on Artifact Hub


### PR DESCRIPTION
relates to #1808

Was fixed already for:

- [x] [argo-cd](#1810)
- [x] [argo-workflows](#1812)
- [x] [argo-events](#1813)
- [x] [argo-rollouts](#1814)
- [x] [argocd-apps](#1815)

Signed-off-by: jmeridth <jmeridth@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
