### PR TITLE
fix(argo-cd):  fixed maxUnavailable value in redis-PDB

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.5.9
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.19.12
+version: 5.19.13
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Align changelog structure to show changelogs on Artifact Hub
+      description: Fixed maxUnavailable value in redis-PDB

--- a/charts/argo-cd/templates/redis/pdb.yaml
+++ b/charts/argo-cd/templates/redis/pdb.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.dex.pdb.maxUnavailable }}
+  {{- with .Values.redis.pdb.maxUnavailable }}
   maxUnavailable: {{ . }}
   {{- else }}
   minAvailable: {{ .Values.redis.pdb.minAvailable | default 0 }}


### PR DESCRIPTION
Signed-off-by: ArsenyBelorukov <arsenig.n@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
