### PR TITLE
docs(argo-cd): Remove incorrect deprecation note

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.0
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.20.1
+version: 5.20.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Sync latest ApplicationSet CRD
+    - kind: removed
+      description: Removed incorrect deprecation note

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -52,9 +52,6 @@ DEPRECATED option configs.gpgKeys - Use config.gpg.keys
 {{- if .Values.configs.gpgKeysAnnotations }}
 DEPRECATED option configs.gpgKeysAnnotations - Use config.gpg.annotations
 {{- end }}
-{{- if hasKey .Values "createAggregateRoles" }}
-DEPRECATED option createAggregateRoles - Use global.rbac.aggregatedRoles
-{{- end }}
 {{- if hasKey (.Values.controller.clusterAdminAccess | default dict) "enabled" }}
 DEPRECATED option .controller.clusterAdminAccess.enabled - Use createClusterRoles
 {{- end }}


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
