### PR TITLE
fix(argo-cd): Add quotes on Ingress Host to allow wildcards

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.1
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.20.4
+version: 5.20.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed invalid ApplicationSet progressive sync parameter
+      description: Fixed missing quotes on Ingress host

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -29,7 +29,7 @@ spec:
   rules:
   {{- if .Values.server.ingress.hosts }}
     {{- range $host := .Values.server.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote }}
       http:
         paths:
           {{- with $extraPaths }}


### PR DESCRIPTION
This change fixes a bug that prevents wildcards from being used in Ingress' `host`.
Currently there are no quotes surrounding the host, therefore it cannot begin with a wildcard, which should be possible as per [Ingress specification](https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards).
Note that without this quotes, hostnames starting with wildcard make the Helm Chart installation fail as follows:

```
Error: YAML parse error on argo-cd/templates/argocd-server/ingress.yaml: error converting YAML to JSON: yaml: line 26: did not find expected alphabetic or numeric character
helm.go:84: [debug] error converting YAML to JSON: yaml: line 26: did not find expected alphabetic or numeric character
YAML parse error on argo-cd/templates/argocd-server/ingress.yaml
```