### PR TITLE
chore(argo-cd): Group component templates together

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.22.0
+version: 5.22.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Global affinity configuration
+    - kind: changed
+      description: Grouped component templates together

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -9,6 +9,17 @@ to 63 chars and it includes 10 chars of hash and a separating '-'.
 {{- end -}}
 
 {{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "argo-cd.controllerServiceAccountName" -}}
+{{- if .Values.controller.serviceAccount.create -}}
+    {{ default (include "argo-cd.controller.fullname" .) .Values.controller.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create dex name and version as used by the chart label.
 */}}
 {{- define "argo-cd.dex.fullname" -}}
@@ -25,6 +36,17 @@ Create Dex server endpoint
 {{- $port := int .Values.dex.servicePortHttp -}}
 {{- printf "%s://%s:%d" $scheme $host $port }}
 {{- end }}
+
+{{/*
+Create the name of the dex service account to use
+*/}}
+{{- define "argo-cd.dexServiceAccountName" -}}
+{{- if .Values.dex.serviceAccount.create -}}
+    {{ default (include "argo-cd.dex.fullname" .) .Values.dex.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.dex.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create redis name and version as used by the chart label.
@@ -54,56 +76,6 @@ Return Redis server endpoint
 {{- end -}}
 
 {{/*
-Create argocd server name and version as used by the chart label.
-*/}}
-{{- define "argo-cd.server.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.server.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create argocd repo-server name and version as used by the chart label.
-*/}}
-{{- define "argo-cd.repoServer.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.repoServer.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create argocd application set name and version as used by the chart label.
-*/}}
-{{- define "argo-cd.applicationSet.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.applicationSet.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create argocd notifications name and version as used by the chart label.
-*/}}
-{{- define "argo-cd.notifications.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.notifications.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create the name of the controller service account to use
-*/}}
-{{- define "argo-cd.controllerServiceAccountName" -}}
-{{- if .Values.controller.serviceAccount.create -}}
-    {{ default (include "argo-cd.controller.fullname" .) .Values.controller.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.controller.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the name of the dex service account to use
-*/}}
-{{- define "argo-cd.dexServiceAccountName" -}}
-{{- if .Values.dex.serviceAccount.create -}}
-    {{ default (include "argo-cd.dex.fullname" .) .Values.dex.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.dex.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create the name of the redis service account to use
 */}}
 {{- define "argo-cd.redisServiceAccountName" -}}
@@ -112,6 +84,13 @@ Create the name of the redis service account to use
 {{- else -}}
     {{ default "default" .Values.redis.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create argocd server name and version as used by the chart label.
+*/}}
+{{- define "argo-cd.server.fullname" -}}
+{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.server.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -126,6 +105,13 @@ Create the name of the Argo CD server service account to use
 {{- end -}}
 
 {{/*
+Create argocd repo-server name and version as used by the chart label.
+*/}}
+{{- define "argo-cd.repoServer.fullname" -}}
+{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.repoServer.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create the name of the repo-server service account to use
 */}}
 {{- define "argo-cd.repoServerServiceAccountName" -}}
@@ -137,6 +123,13 @@ Create the name of the repo-server service account to use
 {{- end -}}
 
 {{/*
+Create argocd application set name and version as used by the chart label.
+*/}}
+{{- define "argo-cd.applicationSet.fullname" -}}
+{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.applicationSet.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create the name of the application set service account to use
 */}}
 {{- define "argo-cd.applicationSetServiceAccountName" -}}
@@ -145,6 +138,13 @@ Create the name of the application set service account to use
 {{- else -}}
     {{ default "default" .Values.applicationSet.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create argocd notifications name and version as used by the chart label.
+*/}}
+{{- define "argo-cd.notifications.fullname" -}}
+{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.notifications.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Cosmetic change that groups all related component templates together.

---

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
