### PR TITLE
feat(argo-cd): added ability to install server ingress in different n…

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.22.1
+version: 5.23.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Grouped component templates together
+    - kind: added
+      description: ability to install argo-cd server ingress in different namespace than Release

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -682,6 +682,7 @@ NAME: my-release
 | server.ingress.https | bool | `false` | Uses `server.service.servicePortHttps` instead `server.service.servicePortHttp` |
 | server.ingress.ingressClassName | string | `""` | Defines which ingress controller will implement the resource |
 | server.ingress.labels | object | `{}` | Additional ingress labels |
+| server.ingress.namespace | string | `""` | Install ingress in the different namespace than Release  |
 | server.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | server.ingress.paths | list | `["/"]` | List of ingress paths |
 | server.ingress.tls | list | `[]` | Ingress TLS configuration |

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "argo-cd.server.fullname" . }}
+  namespace: {{ .Values.server.ingress.namespace | default .Release.Namespace }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     {{- with .Values.server.ingress.labels }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1693,6 +1693,8 @@ server:
   ingress:
     # -- Enable an ingress resource for the Argo CD server
     enabled: false
+    # -- Install ingress in the different namespace than Release 
+    namespace: ""
     # -- Additional ingress annotations
     annotations: {}
     # -- Additional ingress labels


### PR DESCRIPTION
This PR adds the ability to control a namespace in which ingress of argo-cd server is installed. This helps to use `.server.ingress.extraPaths` to reference the backend service that resides in the different namespace than argo-cd. It's a common use case for Istio Ingress Gateway combined with AWS ALB.

This PR solves: 
https://github.com/argoproj/argo-helm/issues/1761

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
