### PR TITLE
chore(argo-workflows): expose option to control the log format/level

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.22.12
+version: 0.22.13
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,5 +13,11 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update documentation to explain why CRDs are in templates folder
+    - kind: added
+      description: Added workflow startup option --log-format (defaults to 'text').
+    - kind: added
+      description: Added server startup option --log-format (defaults to 'text').
+    - kind: added
+      description: Added server startup option --loglevel (defaults to 'info').
+    - kind: added
+      description: Added server startup option --gloglevel (defaults to '0').

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -106,6 +106,7 @@ Fields to note:
 | controller.links | list | `[]` | Configure Argo Server to show custom [links] |
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
 | controller.loadBalancerSourceRanges | list | `[]` | Source ranges to allow access to service from. Only applies to service type `LoadBalancer` |
+| controller.logging.format | string | `"text"` | Set the logging format (one of: `text`, `json`) |
 | controller.logging.globallevel | string | `"0"` | Set the glog logging level |
 | controller.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | controller.metricsConfig.enabled | bool | `false` | Enables prometheus metrics server |
@@ -214,6 +215,9 @@ Fields to note:
 | server.ingress.tls | list | `[]` | Ingress TLS configuration |
 | server.loadBalancerIP | string | `""` | Static IP address to assign to loadBalancer service type `LoadBalancer` |
 | server.loadBalancerSourceRanges | list | `[]` | Source ranges to allow access to service from. Only applies to service type `LoadBalancer` |
+| server.logging.format | string | `"text"` | Set the logging format (one of: `text`, `json`) |
+| server.logging.globallevel | string | `"0"` | Set the glog logging level |
+| server.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | server.name | string | `"server"` | Server name string |
 | server.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | [Node selector] |
 | server.pdb.enabled | bool | `false` | Configure [Pod Disruption Budget] for the server pods |

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -46,6 +46,8 @@ spec:
           - "{{ .Values.controller.logging.level }}"
           - "--gloglevel"
           - "{{ .Values.controller.logging.globallevel }}"
+          - "--log-format"
+          - "{{ .Values.controller.logging.format }}"
           {{- if .Values.singleNamespace }}
           - "--namespaced"
           {{- end }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -49,6 +49,12 @@ spec:
           {{- if .Values.singleNamespace }}
           - "--namespaced"
           {{- end }}
+          - "--loglevel"
+          - "{{ .Values.server.logging.level }}"
+          - "--gloglevel"
+          - "{{ .Values.server.logging.globallevel }}"
+          - "--log-format"
+          - "{{ .Values.server.logging.format }}"
           ports:
           - name: web
             containerPort: 2746

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -216,6 +216,8 @@ controller:
     level: info
     # -- Set the glog logging level
     globallevel: "0"
+    # -- Set the logging format (one of: `text`, `json`)
+    format: "text"
 
   # -- Service type of the controller Service
   serviceType: ClusterIP
@@ -468,6 +470,14 @@ server:
   # uncomment the lines below and comment out the default empty list `extraArgs: []` above:
   # extraArgs:
   # - --auth-mode=server
+
+  logging:
+    # -- Set the logging level (one of: `debug`, `info`, `warn`, `error`)
+    level: info
+    # -- Set the glog logging level
+    globallevel: "0"
+    # -- Set the logging format (one of: `text`, `json`)
+    format: "text"
 
   # -- Additional volume mounts to the server main container.
   volumeMounts: []


### PR DESCRIPTION
Currently, the log format is always "text" (default) causing the logs to be marked as error on Stackdriver (https://github.com/argoproj/argo-workflows/issues/5135)

The format can be changed since this commit was merged: https://github.com/argoproj/argo-workflows/pull/5158/files
More specifically this line: https://github.com/argoproj/argo-workflows/pull/5158/files#diff-ac70cda72859a5b0b5cdeee97288452ad053332df4b27e37f9647addc0ef510eR72

The change on this PR adds a helm value to control the startup option --log-format 


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
