### PR TITLE
feat(argo-cd): Added Config Management Plugins cm

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.3
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.24.1
+version: 5.24.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: ApplicationSet utilizes global tolerations
+    - kind: Added
+      description: ConfigMap for Config Management Plugins using sidecar approach

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -428,7 +428,7 @@ NAME: my-release
 | configs.cm.create | bool | `true` | Create the argocd-cm configmap for [declarative setup] |
 | configs.cm.url | string | `""` | Argo CD's externally facing base URL (optional). Required when configuring SSO |
 | configs.cmp.annotations | object | `{}` | Annotations to be added to argocd-cmp-cm configmap |
-| configs.cmp.create | bool | `true` | Create the argocd-cmp-cm configmap |
+| configs.cmp.create | bool | `false` | Create the argocd-cmp-cm configmap |
 | configs.cmp.plugins | object | `{}` | Plugin yaml files to be added to argocd-cmp-cm |
 | configs.credentialTemplates | object | `{}` | Repository credentials to be used as Templates for other repos |
 | configs.credentialTemplatesAnnotations | object | `{}` | Annotations to be added to `configs.credentialTemplates` Secret |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -427,6 +427,9 @@ NAME: my-release
 | configs.cm.annotations | object | `{}` | Annotations to be added to argocd-cm configmap |
 | configs.cm.create | bool | `true` | Create the argocd-cm configmap for [declarative setup] |
 | configs.cm.url | string | `""` | Argo CD's externally facing base URL (optional). Required when configuring SSO |
+| configs.cmp.annotations | object | `{}` | Annotations to be added to argocd-cmp-cm configmap |
+| configs.cmp.create | bool | `true` | Create the argocd-cmp-cm configmap |
+| configs.cmp.plugins | object | `{}` | Plugin yaml files to be added to argocd-cmp-cm |
 | configs.credentialTemplates | object | `{}` | Repository credentials to be used as Templates for other repos |
 | configs.credentialTemplatesAnnotations | object | `{}` | Annotations to be added to `configs.credentialTemplates` Secret |
 | configs.gpg.annotations | object | `{}` | Annotations to be added to argocd-gpg-keys-cm configmap |

--- a/charts/argo-cd/templates/argocd-configs/argocd-cmp-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-cmp-cm.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.configs.cmp.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmp-cm
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" "cmp-cm") | nindent 4 }}
+  {{- with .Values.configs.cmp.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+data:
+  {{- range $cmp_plugin, $cmp_plugin_config := .Values.configs.cmp.plugins }}
+  {{ $cmp_plugin }}.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: {{ $cmp_plugin }}
+    spec:
+      {{- toYaml $cmp_plugin_config | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -331,6 +331,49 @@ configs:
       #   ...
       #   -----END CERTIFICATE-----
 
+  # ConfigMap for Config Management Plugins
+  # Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/
+  cmp:
+    # -- Create the argocd-cmp-cm configmap
+    create: true
+
+    # -- Annotations to be added to argocd-cmp-cm configmap
+    annotations: {}
+
+    # -- Plugin yaml files to be added to argocd-cmp-cm
+    plugins: {}
+      # --- First plugin
+      # my-plugin:
+      #   init:
+      #     command: [sh]
+      #     args: [-c, 'echo "Initializing..."']
+      #   generate:
+      #     command: [sh, -c]
+      #     args:
+      #       - |
+      #         echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"
+      #   discover:
+      #     fileName: "./subdir/s*.yaml"
+      #     find:
+      #       glob: "**/Chart.yaml"
+      #       command: [sh, -c, find . -name env.yaml]
+
+      # --- Second plugin
+      # my-plugin2:
+      #   init:
+      #     command: [sh]
+      #     args: [-c, 'echo "Initializing..."']
+      #   generate:
+      #     command: [sh, -c]
+      #     args:
+      #       - |
+      #         echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"KubeVersion\": \"$KUBE_VERSION\", \"KubeApiVersion\": \"$KUBE_API_VERSIONS\",\"Bar\": \"baz\"}}}"
+      #   discover:
+      #     fileName: "./subdir/s*.yaml"
+      #     find:
+      #       glob: "**/Chart.yaml"
+      #       command: [sh, -c, find . -name env.yaml]
+
   # -- Provide one or multiple [external cluster credentials]
   # @default -- `[]` (See [values.yaml])
   ## Ref:
@@ -1961,27 +2004,46 @@ repoServer:
   ## Ref: https://argo-cd.readthedocs.io/en/stable/user-guide/config-management-plugins/
   ## Note: Supports use of custom Helm templates
   extraContainers: []
-  # - name: cmp
-  #   # Entrypoint should be Argo CD lightweight CMP server i.e. argocd-cmp-server
-  #   command: [/var/run/argocd/argocd-cmp-server]
-  #   # This can be off-the-shelf or custom-built image
-  #   image: busybox
-  #   securityContext:
-  #     runAsNonRoot: true
-  #     runAsUser: 999
-  #   volumeMounts:
-  #     - mountPath: /var/run/argocd
-  #       name: var-files
-  #     - mountPath: /home/argocd/cmp-server/plugins
-  #       name: plugins
-  #     # Remove this volumeMount if you've chosen to bake the config file into the sidecar image.
-  #     - mountPath: /home/argocd/cmp-server/config/plugin.yaml
-  #       subPath: plugin.yaml
-  #       name: cmp-plugin
-  #     # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps
-  #     # mitigate path traversal attacks.
-  #     - mountPath: /tmp
-  #       name: cmp-tmp
+    # - name: cmp-my-plugin
+    #   command:
+    #     - "/var/run/argocd/argocd-cmp-server"
+    #   image: busybox
+    #   securityContext:
+    #     runAsNonRoot: true
+    #     runAsUser: 999
+    #   volumeMounts:
+    #     - mountPath: /var/run/argocd
+    #       name: var-files
+    #     - mountPath: /home/argocd/cmp-server/plugins
+    #       name: plugins
+    #     # Remove this volumeMount if you've chosen to bake the config file into the sidecar image.
+    #     - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+    #       subPath: my-plugin.yaml
+    #       name: argocd-cmp-cm
+    #     # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps
+    #     # mitigate path traversal attacks.
+    #     - mountPath: /tmp
+    #       name: cmp-tmp
+    # - name: cmp-my-plugin2
+    #   command:
+    #     - "/var/run/argocd/argocd-cmp-server"
+    #   image: busybox
+    #   securityContext:
+    #     runAsNonRoot: true
+    #     runAsUser: 999
+    #   volumeMounts:
+    #     - mountPath: /var/run/argocd
+    #       name: var-files
+    #     # Remove this volumeMount if you've chosen to bake the config file into the sidecar image.
+    #     - mountPath: /home/argocd/cmp-server/plugins
+    #       name: plugins
+    #     - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+    #       subPath: my-plugin2.yaml
+    #       name: argocd-cmp-cm
+    #     # Starting with v2.4, do NOT mount the same tmp volume as the repo-server container. The filesystem separation helps
+    #     # mitigate path traversal attacks.
+    #     - mountPath: /tmp
+    #       name: cmp-tmp
 
   # -- Init containers to add to the repo server pods
   initContainers: []
@@ -1991,9 +2053,9 @@ repoServer:
 
   # -- Additional volumes to the repo server pod
   volumes: []
-  #  - name: cmp-plugin
+  #  - name: argocd-cmp-cm
   #    configMap:
-  #      name: cmp-plugin
+  #      name: argocd-cmp-cm
   #  - name: cmp-tmp
   #    emptyDir: {}
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -335,7 +335,7 @@ configs:
   # Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/
   cmp:
     # -- Create the argocd-cmp-cm configmap
-    create: true
+    create: false
 
     # -- Annotations to be added to argocd-cmp-cm configmap
     annotations: {}


### PR DESCRIPTION
Added ConfigMap creation bits named `argocd-cmp-cm` for Config Management Plugins using sidecar approach.

For an working example, you can run a kind cluster with ArgoCD setup under git repo [NIXKnight/ArgoCD-Demo](https://github.com/NIXKnight/ArgoCD-Demo/tree/NIXKnight/add-argocd-cmp-plugins-configmap) branch `NIXKnight/add-argocd-cmp-plugins-configmap` following the [README.md](https://github.com/NIXKnight/ArgoCD-Demo/blob/NIXKnight/add-argocd-cmp-plugins-configmap/README.md). The vault setup under the repo uses one of the plugins to deploy.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
