### PR TITLE
fix(argo-cd): Added pod exec permission to argo-server Role when exec.enabled is True.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -23,5 +23,6 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed typos in values.yaml and README.md
+    - kind: added
+      description: Added pod exec permission to argo-server Role when exec.enabled is True.
+      

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.23.2
+version: 5.23.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -25,4 +25,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added pod exec permission to argo-server Role when exec.enabled is True.
-      

--- a/charts/argo-cd/templates/argocd-server/role.yaml
+++ b/charts/argo-cd/templates/argocd-server/role.yaml
@@ -42,3 +42,11 @@ rules:
   verbs:
   - create
   - list
+{{- if eq (toString (index (coalesce .Values.server.config .Values.configs.cm) "exec.enabled")) "true" }}
+- apiGroups:
+  - ""
+resources:
+  - pods/exec
+verbs:
+  - create
+{{- end }}


### PR DESCRIPTION
As per issue #1866 , attempting to fix this by adding the relevant code to grant the pod/exec create permission to the argo-server Role when exec.enabled is True.

The argocd-server Role requires the pods/exec create permission in order to be able to start the web based terminal as per: https://argo-cd.readthedocs.io/en/stable/operator-manual/web_based_terminal/

This brings the Role in line with the ClusterRole change already made

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:


- [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)

* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
