### PR TITLE
fix(argo-cd): ApplicationSet deployment uses global tolerations

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.3
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.24.0
+version: 5.24.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,6 +23,8 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: ApplicationSet utilizes global tolerations
     - kind: added
       description: Global nodeSelector configuration
     - kind: added

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -23,17 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
+    - kind: fixed
       description: ApplicationSet utilizes global tolerations
-    - kind: added
-      description: Global nodeSelector configuration
-    - kind: added
-      description: Global tolerations configuration
-    - kind: added
-      description: Global topologySpreadConstraints configuration
-    - kind: added
-      description: Missing component level topologySpreadConstraints configuration
-    - kind: added
-      description: Missing component level priorityClassName configuration
-    - kind: changed
-      description: Global affinity preset can be disabled

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -209,7 +209,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.applicationSet.tolerations }}
+      {{- with .Values.applicationSet.tolerations | default .Values.global.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Fixes #1880

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
