### PR TITLE
feat(argo-cd): Replace Application Controller StatefullSet with a Deployment and enabled autoscaling

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.4
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.25.0
+version: 5.25.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Add parameter env to redis exporter
+    - kind: changed
+      description: Replace Application Controller StatefullSet with a Deployment and enabled autoscaling

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -29,7 +29,9 @@ redis-ha:
   enabled: true
 
 controller:
-  replicas: 1
+  autoscaling:
+    enabled: true
+    minReplicas: 2
 
 server:
   autoscaling:
@@ -72,7 +74,7 @@ When installing Argo CD using this helm chart the user should have a similar exp
 
 To update the templates and default settings in `values.yaml` it may come in handy to look up the diff of the `manifests/install.yaml` between two versions accordingly. This can either be done directly via github and look for `manifests/install.yaml`:
 
-https://github.com/argoproj/argo-cd/compare/v1.8.7...v2.0.0#files_bucket
+<https://github.com/argoproj/argo-cd/compare/v1.8.7...v2.0.0#files_bucket>
 
 Or you clone the repository and do a local `git-diff`:
 
@@ -171,9 +173,9 @@ done
 
 This version **removes support for**:
 
-- deprecated repository credentials (parameter `configs.repositoryCredentials`)
-- option to run application controller as a Deployment
-- the parameters `server.additionalApplications` and `server.additionalProjects`
+* deprecated repository credentials (parameter `configs.repositoryCredentials`)
+* option to run application controller as a Deployment
+* the parameters `server.additionalApplications` and `server.additionalProjects`
 
 Please carefully read the following section if you are using these parameters!
 
@@ -351,8 +353,8 @@ server:
 
 ## Prerequisites
 
-- Kubernetes: `>=1.22.0-0`
-- Helm v3.0.0+
+* Kubernetes: `>=1.22.0-0`
+* Helm v3.0.0+
 
 ## Installing the Chart
 
@@ -956,7 +958,7 @@ server:
 
 ### Option 2 - Redis HA
 
-This option uses the following third-party chart to bootstrap a clustered Redis: https://github.com/DandyDeveloper/charts/tree/master/charts/redis-ha.
+This option uses the following third-party chart to bootstrap a clustered Redis: <https://github.com/DandyDeveloper/charts/tree/master/charts/redis-ha>.
 For all available configuration options, please read upstream README and/or chart source.
 The main options are listed here:
 

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
-  {{- with (mergeOverwrite (deepCopy .Values.global.statefulsetAnnotations) .Values.controller.statefulsetAnnotations) }}
+  {{- with (mergeOverwrite (deepCopy .Values.global.deploymentAnnotations) .Values.controller.deploymentAnnotations) }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
@@ -11,10 +11,10 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 spec:
+  {{- if not .Values.controller.autoscaling.enabled }}
   replicas: {{ .Values.controller.replicas }}
-  # TODO: Remove for breaking release as history limit cannot be patched
-  revisionHistoryLimit: 5
-  serviceName: {{ include "argo-cd.controller.fullname" . }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}

--- a/charts/argo-cd/templates/argocd-application-controller/hpa.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/hpa.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.controller.autoscaling.enabled }}
+apiVersion: {{ include "argo-cd.apiVersion.autoscaling" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" (printf "%s-hpa" .Values.controller.name)) | nindent 4 }}
+  name: {{ template "argo-cd.controller.fullname" . }}-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "argo-cd.controller.fullname" . }}
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if eq (include "argo-cd.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
+        target:
+          averageUtilization: {{ . }}
+          type: Utilization
+        {{- end }}
+  {{- end }}
+  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if eq (include "argo-cd.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
+        targetAverageUtilization: {{ . }}
+        {{- else }}
+        target:
+          averageUtilization: {{ . }}
+          type: Utilization
+        {{- end }}
+  {{- end }}
+  {{- with .Values.controller.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -67,9 +67,6 @@ global:
     # -- Set the global logging level. One of: `debug`, `info`, `warn` or `error`
     level: info
 
-  # -- Annotations for the all deployed Statefulsets
-  statefulsetAnnotations: {}
-
   # -- Annotations for the all deployed Deployments
   deploymentAnnotations: {}
 
@@ -505,6 +502,34 @@ controller:
   # Additional replicas will cause sharding of managed clusters across number of replicas.
   replicas: 1
 
+  ## Argo CD Application Controller Horizontal Pod Autoscaler
+  autoscaling:
+    # -- Enable Horizontal Pod Autoscaler ([HPA]) for the Argo CD Application Controller
+    enabled: false
+    # -- Minimum number of replicas for the Argo CD Application Controller [HPA]
+    minReplicas: 1
+    # -- Maximum number of replicas for the Argo CD Application Controller [HPA]
+    maxReplicas: 5
+    # -- Average CPU utilization percentage for the Argo CD Application Controller [HPA]
+    targetCPUUtilizationPercentage: 50
+    # -- Average memory utilization percentage for the Argo CD Application Controller [HPA]
+    targetMemoryUtilizationPercentage: 50
+    # -- Configures the scaling behavior of the target in both Up and Down directions.
+    # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
+    behavior: {}
+      # scaleDown:
+      #  stabilizationWindowSeconds: 300
+      #  policies:
+      #   - type: Pods
+      #     value: 1
+      #     periodSeconds: 180
+      # scaleUp:
+      #   stabilizationWindowSeconds: 300
+      #   policies:
+      #   - type: Pods
+      #     value: 2
+      #     periodSeconds: 60
+
   ## Application controller Pod Disruption Budget
   ## Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   pdb:
@@ -598,8 +623,8 @@ controller:
   #  - name: custom-tools
   #    emptyDir: {}
 
-  # -- Annotations for the application controller StatefulSet
-  statefulsetAnnotations: {}
+  # -- Annotations for the application controller Deployment
+  deploymentAnnotations: {}
 
   # -- Annotations to be added to application controller pods
   podAnnotations: {}


### PR DESCRIPTION
Hello everyone, this change that I propose is due to the fact that we are seeing an high CPU and RAM usage of the application controllers. We can increase the number of replicas but would prefer that it would be managed with autoscaling.
At the moment we have 3 replicas with the following resources used:
![image](https://user-images.githubusercontent.com/12953702/224377220-5c1e07b6-a32d-4f80-9d42-1dad6a067103.png)

Like with the repo-server and server pods the autoscaling enables new replicas to appear if needed. Fyi, at the momnet we have around 2k applications being managed in around 50 clusters. Most likely this is the reason why we have such high resource usage.

I've based my changes mostly on the examples already existent for the repo-server and server for the deployment file and the hpa. Let me now if I'm missing something or doing something wrong since it's my first contribution :)

Thanks!

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
