### PR TITLE
feat(argo-c): Entrypoint can be configured now

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.4
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.26.0
+version: 5.26.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: Added
-      description: ConfigMap for Config Management Plugins using sidecar approach
+    - kind: changed
+      description: entrypoint usage can be configured

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -394,6 +394,8 @@ NAME: my-release
 | global.affinity.nodeAffinity.type | string | `"hard"` | Default node affinity rules. Either: `none`, `soft` or `hard` |
 | global.affinity.podAntiAffinity | string | `"soft"` | Default pod anti-affinity rules. Either: `none`, `soft` or `hard` |
 | global.deploymentAnnotations | object | `{}` | Annotations for the all deployed Deployments |
+| global.entrypoint.entrypoint | string | `"entrypoint.sh"` | The entrypoint to use for the containers. |
+| global.entrypoint.useImplicit | bool | `false` | Implicitly use the docker image's entrypoint. This requires the image to have ENTRYPOINT set properly |
 | global.hostAliases | list | `[]` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files |
 | global.image.imagePullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to all Argo CD deployments |
 | global.image.repository | string | `"quay.io/argoproj/argocd"` | If defined, a repository applied to all Argo CD deployments |

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -51,8 +51,11 @@ spec:
         - name: {{ .Values.applicationSet.name }}
           image: {{ default .Values.global.image.repository .Values.applicationSet.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.applicationSet.image.tag }}
           imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.applicationSet.image.imagePullPolicy }}
+          {{- if not .Values.global.entrypoint.useImplicit }}
           command:
-            - entrypoint.sh
+            - {{ .Values.global.entrypoint.entrypoint | quote }}
+          {{- end }}
+          args:
             - argocd-applicationset-controller
             - --metrics-addr=:{{ .Values.applicationSet.containerPorts.metrics }}
             - --probe-addr=:{{ .Values.applicationSet.containerPorts.probe }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -56,8 +56,10 @@ spec:
       - name: {{ .Values.repoServer.name }}
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
+        {{- if not .Values.global.entrypoint.useImplicit }}
         command:
-        - entrypoint.sh
+          - {{ .Values.global.entrypoint.entrypoint | quote }}
+        {{- end }}
         args:
         - argocd-repo-server
         - --port={{ .Values.repoServer.containerPorts.server }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -132,6 +132,14 @@ global:
     #   topologyKey: topology.kubernetes.io/zone
     #   whenUnsatisfiable: DoNotSchedule
 
+  # POD entrypoint configuration
+  entrypoint:
+    # -- Implicitly use the docker image's entrypoint. This requires the image to have
+    # ENTRYPOINT set properly
+    useImplicit: false
+    # -- The entrypoint to use for the containers.
+    entrypoint: "entrypoint.sh"
+
 
 ## Argo Configs
 configs:


### PR DESCRIPTION
This PR prepares the argo-cd chart for https://github.com/argoproj/argo-helm/issues/1883

Two new global values has been introduced:
`global.entrypoint.useImplicit`: defaults to false, if true, then containers are not explicitly declaring an entrypoint with `command`.
`global.entrypoint.entrypoint`: Currently defaults to `entrypoint.sh`, in case `useImplicit` is false, the entrypoint specified here will be used in the command.

Aftger the argo2.7 release, `useImplicit` can be set to true, and for safety reasons entrypoint should be set to the tini using an absolute path.

Having this little mechanic accessable beforehand provides no incompatible changes, and also allows the argocd helm chart users to run their deployments with directly tini or any other way (currently it's not configurable).


Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
