### PR TITLE
chore(argo-workflows): Add install guide on README

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.22.13
+version: 0.22.14
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -14,10 +14,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Added workflow startup option --log-format (defaults to 'text').
-    - kind: added
-      description: Added server startup option --log-format (defaults to 'text').
-    - kind: added
-      description: Added server startup option --loglevel (defaults to 'info').
-    - kind: added
-      description: Added server startup option --gloglevel (defaults to '0').
+      description: Add install guide on README.

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -28,6 +28,19 @@ kubectl apply -k "https://github.com/argoproj/argo-workflows/manifests/base/crds
 kubectl apply -k "https://github.com/argoproj/argo-workflows/manifests/base/crds/full?ref=v3.3.9"
 ```
 
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add argo https://argoproj.github.io/argo-helm
+"argo" has been added to your repositories
+
+$ helm install my-release argo/argo-workflows
+NAME: my-release
+...
+```
+
 ## Changelog
 
 For full list of changes, please check ArtifactHub [changelog].

--- a/charts/argo-workflows/README.md.gotmpl
+++ b/charts/argo-workflows/README.md.gotmpl
@@ -28,6 +28,19 @@ kubectl apply -k "https://github.com/argoproj/argo-workflows/manifests/base/crds
 kubectl apply -k "https://github.com/argoproj/argo-workflows/manifests/base/crds/full?ref=v3.3.9"
 ```
 
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add argo https://argoproj.github.io/argo-helm
+"argo" has been added to your repositories
+
+$ helm install my-release argo/argo-workflows
+NAME: my-release
+...
+```
+
 ## Changelog
 
 For full list of changes, please check ArtifactHub [changelog].


### PR DESCRIPTION
resolves https://github.com/argoproj/argo-helm/issues/1902 🙋 

---

Signed-off-by: yu-croco <yu.croco@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
