### PR TITLE
fix(argo-cd): Use default metrics port for APIServer

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.5
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.26.2
+version: 5.26.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -23,5 +23,5 @@ dependencies:
     condition: redis-ha.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Use global.nodeSelector value as default value for nodeSelector on ApplicationSet
+    - kind: fixed
+      description: Use default metrics port for argocd-server

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -670,7 +670,7 @@ NAME: my-release
 | server.certificateSecret.enabled | bool | `false` | Create argocd-server-tls secret |
 | server.certificateSecret.key | string | `""` | Private Key of the certificate |
 | server.certificateSecret.labels | object | `{}` | Labels to be added to argocd-server-tls secret |
-| server.containerPorts.metrics | int | `8082` | Metrics container port |
+| server.containerPorts.metrics | int | `8083` | Metrics container port |
 | server.containerPorts.server | int | `8080` | Server container port |
 | server.containerSecurityContext | object | See [values.yaml] | Server container-level security context |
 | server.deploymentAnnotations | object | `{}` | Annotations to be added to server Deployment |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1573,7 +1573,7 @@ server:
     # -- Server container port
     server: 8080
     # -- Metrics container port
-    metrics: 8082
+    metrics: 8083
 
   # -- Host Network for Server pods
   hostNetwork: false


### PR DESCRIPTION
Resolves #1910 

Related to:
- https://github.com/argoproj/argo-helm/pull/1788 (mistakenly introduced)
- details https://github.com/argoproj/argo-helm/pull/1788/files#diff-1817bb061b5ceed1dabf4e30ac6445a132baa3884c3278be3e97d166a25e3a3bL294
- https://github.com/argoproj/argo-cd/blob/v2.6.5/common/common.go#L46-L52

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
