### PR TITLE
feat(argo-rollouts): support setting pod annotations separately on controller and dashboard

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.4.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.22.3
+version: 2.23.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -15,7 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo Rollouts to v.1.4.1
     - kind: added
-      description: Put Changelog URL on README.md
+      description: Added the ability to set pod annotations separately on controller and dashboard deployment

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -95,13 +95,14 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.pdb.labels | object | `{}` | Labels to be added to controller [Pod Disruption Budget] |
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
+| controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the controller |
-| podAnnotations | object | `{}` | Annotations to be added to the Rollout pods |
+| podAnnotations | object | `{}` | Annotations for the all deployed pods |
 | podLabels | object | `{}` | Labels to be added to the Rollout pods |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
@@ -139,6 +140,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.labels | object | `{}` | Labels to be added to dashboard [Pod Disruption Budget] |
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
+| dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -15,9 +15,11 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with (mergeOverwrite (deepCopy .Values.podAnnotations) .Values.controller.podAnnotations) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}

--- a/charts/argo-rollouts/templates/dashboard/deployment.yaml
+++ b/charts/argo-rollouts/templates/dashboard/deployment.yaml
@@ -16,9 +16,11 @@ spec:
   replicas: {{ .Values.dashboard.replicas }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with (mergeOverwrite (deepCopy .Values.podAnnotations) .Values.dashboard.podAnnotations) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -41,6 +41,8 @@ extraObjects: []
 controller:
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-controller
+  # -- Annotations to be added to application controller pods
+  podAnnotations: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
@@ -164,7 +166,7 @@ serviceAccount:
 # -- Annotations to be added to all CRDs
 crdAnnotations: {}
 
-# -- Annotations to be added to the Rollout pods
+# -- Annotations for the all deployed pods
 podAnnotations: {}
 
 # -- Security Context to set on pod level
@@ -217,6 +219,8 @@ dashboard:
   readonly: false
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-dashboard
+  # -- Annotations to be added to application dashboard pods
+  podAnnotations: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints


### PR DESCRIPTION
Hello 👋 
The current "global" `podAnnotations` config adds annotations to all pods, including the Dashboard if it is enabled. This PR gives us the ability to add pod annotations to controller & dashboard deployment separately.

The idea of this PR is similar to the one in ArgoCD's chart, in the future we probably have `global` section to include other configs as well if needed.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
