### PR TITLE
fix(argo-cd): Disable hostNetwork field when is set to false

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.7
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.27.3
+version: 5.27.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -312,7 +312,9 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
+      {{- if .Values.controller.hostNetwork }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
+      {{- end }}
       {{- with .Values.controller.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -355,7 +355,9 @@ spec:
             path: tls.key
           - key: ca.crt
             path: ca.crt
+      {{- if .Values.repoServer.hostNetwork }}
       hostNetwork: {{ .Values.repoServer.hostNetwork }}
+      {{- end }}
       {{- with .Values.repoServer.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -421,7 +421,9 @@ spec:
             path: tls.crt
           - key: ca.crt
             path: ca.crt
+      {{- if .Values.server.hostNetwork }}
       hostNetwork: {{ .Values.server.hostNetwork }}
+      {{- end }}
       {{- with .Values.server.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Surround with if `hostNetwork` field to disable it when is set to false

When create deployment with hostNetwork set to false kubernetes remove field.
This is break idempotency with tools like terraform