### PR TITLE
fix(argo-workflows): Add namespace field to all namespace scoped resources because `helm template` doesn't add the namespace filed automatically

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.23.3
+version: 0.24.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.23.2
+version: 0.23.3
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,5 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo Workflows to v3.4.7.
+    - kind: fixed
+      description: Add namespace field to all namespace scoped resources because `helm template` doesn't add the namespace filed automatically.

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -7,6 +7,9 @@ kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
+  {{- if .Values.singleNamespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}-configmap
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" "cm") | nindent 4 }}
 data:

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -7,6 +7,9 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
+  {{- if .Values.singleNamespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 roleRef:
@@ -20,7 +23,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "argo-workflows.controllerServiceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 
 {{- if .Values.controller.clusterWorkflowTemplates.enabled }}
 ---
@@ -37,6 +40,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "argo-workflows.controllerServiceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 spec:

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     app.kubernetes.io/version: {{ include "argo-workflows.controller_chart_version_label" . }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
   {{- with .Values.controller.serviceAccount.labels  }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     app.kubernetes.io/version: {{ default (include "argo-workflows.defaultTag" .) .Values.controller.image.tag | trunc 63 | quote }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
-  {{- with .Values.controller.serviceMonitor.namespace }}
-  namespace: {{ . }}
+  {{- if .Values.controller.serviceMonitor.namespace }}
+  namespace: {{ .Values.controller.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
@@ -25,7 +27,7 @@ spec:
   {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ .Release.Namespace | quote }}
   selector:
     matchLabels:
       {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "argo-workflows.controller.fullname" . }}
-  {{- if .Values.controller.serviceMonitor.namespace }}
-  namespace: {{ .Values.controller.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.controller.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     {{- with .Values.controller.serviceMonitor.additionalLabels }}

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -7,6 +7,9 @@ kind: ClusterRole
   {{- end }}
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
+  {{- if .Values.singleNamespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 rules:

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -7,6 +7,9 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
+  {{- if .Values.singleNamespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 roleRef:
@@ -20,7 +23,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "argo-workflows.serverServiceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 
 {{- if .Values.server.clusterWorkflowTemplates.enabled }}
 ---
@@ -37,6 +40,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "argo-workflows.serverServiceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- end -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     app.kubernetes.io/version: {{ include "argo-workflows.server_chart_version_label" . }}

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
 {{- end }}
   name: {{ template "argo-workflows.server.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     {{- if .Values.server.ingress.labels }}

--- a/charts/argo-workflows/templates/server/server-sa.yaml
+++ b/charts/argo-workflows/templates/server/server-sa.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "argo-workflows.serverServiceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
   {{- with .Values.server.serviceAccount.labels  }}

--- a/charts/argo-workflows/templates/server/server-service.yaml
+++ b/charts/argo-workflows/templates/server/server-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "argo-workflows.server.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-workflows.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
     app.kubernetes.io/version: {{ include "argo-workflows.server_chart_version_label" . }}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/1952 .
Same change as https://github.com/argoproj/argo-helm/pull/1937 🙋 

`helm template` does not fulfill namespace field automatically to namespace scoped resources, so it would be trouble when users use Helm Chart via Terraform/Kustomize .
detail: https://github.com/argoproj/argo-helm/pull/1937#issuecomment-1503916625

---

Signed-off-by: yu-croco <yu.croco@gmail.com>

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
