### PR TITLE
fix(argo-cd): Evaluate namespace field via helm root scope

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.6.7
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.29.0
+version: 5.29.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -24,4 +24,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Add namespace field for namespace scoped resources
+      description: Namespace field for some namespaced resources needs to be evaluated via helm root scope

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "argo-cd.name" $ }}-cluster-{{ .name }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}
     {{- with .labels }}

--- a/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-repo-creds-{{ $repo_cred_key }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     argocd.argoproj.io/secret-type: repo-creds
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-configs/repository-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/repository-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-repo-{{ $repo_key }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     argocd.argoproj.io/secret-type: repository
     {{- include "argo-cd.labels" (dict "context" $) | nindent 4 }}


### PR DESCRIPTION
This was missed in PR #1937

Fixes:
- #1961
- #1962 

---
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
