### PR TITLE
feat(argo-workflows): Add option for controller to read all secrets

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Add option for workflow controller to read all secrets in its namespace.
+      description: Add option for workflow controller to read all secrets.

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.24.0
+version: 0.24.1
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,5 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Add namespace field to all namespace scoped resources because `helm template` doesn't add the namespace filed automatically.
+    - kind: added
+      description: Add option for workflow controller to read all secrets in its namespace.

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -174,6 +174,7 @@ Fields to note:
 | controller.podLabels | object | `{}` | Optional labels to add to the controller pods |
 | controller.podSecurityContext | object | `{}` | SecurityContext to set on the controller pods |
 | controller.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages. |
+| controller.rbac.accessAllSecrets | bool | `false` | Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty. |
 | controller.rbac.create | bool | `true` | Adds Role and RoleBinding for the controller. |
 | controller.rbac.secretWhitelist | list | `[]` | Allows controller to get, list, and watch certain k8s secrets |
 | controller.rbac.writeConfigMaps | bool | `false` | Allows controller to create and update ConfigMaps. Enables memoization feature |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -174,7 +174,7 @@ Fields to note:
 | controller.podLabels | object | `{}` | Optional labels to add to the controller pods |
 | controller.podSecurityContext | object | `{}` | SecurityContext to set on the controller pods |
 | controller.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages. |
-| controller.rbac.accessAllSecrets | bool | `false` | Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty. |
+| controller.rbac.accessAllSecrets | bool | `false` | Allows controller to get, list and watch all k8s secrets. Can only be used if secretWhitelist is empty. |
 | controller.rbac.create | bool | `true` | Adds Role and RoleBinding for the controller. |
 | controller.rbac.secretWhitelist | list | `[]` | Allows controller to get, list, and watch certain k8s secrets |
 | controller.rbac.writeConfigMaps | bool | `false` | Allows controller to create and update ConfigMaps. Enables memoization feature |

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -187,6 +187,16 @@ rules:
   - watch
   resourceNames: {{- toYaml . | nindent 4 }}
 {{- end }}
+{{- if and (not .Values.controller.rbac.secretWhitelist) (.Values.controller.rbac.accessAllSecrets) }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 
 {{- if .Values.controller.clusterWorkflowTemplates.enabled }}
 ---

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -74,6 +74,8 @@ controller:
     create: true
     # -- Allows controller to get, list, and watch certain k8s secrets
     secretWhitelist: []
+    # -- Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty.
+    accessAllSecrets: false
     # -- Allows controller to create and update ConfigMaps. Enables memoization feature
     writeConfigMaps: false
 

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -74,7 +74,7 @@ controller:
     create: true
     # -- Allows controller to get, list, and watch certain k8s secrets
     secretWhitelist: []
-    # -- Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty.
+    # -- Allows controller to get, list and watch all k8s secrets. Can only be used if secretWhitelist is empty.
     accessAllSecrets: false
     # -- Allows controller to create and update ConfigMaps. Enables memoization feature
     writeConfigMaps: false


### PR DESCRIPTION
Fixes #1966

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.



# Testing

I tested with a dummy template just for ease of showing my work.

For a given test template:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test
rules:
{{- with .Values.rbac.secretWhitelist }}
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
  resourceNames: {{- toYaml . | nindent 4 }}
{{- end }}
{{- if and (not .Values.rbac.secretWhitelist) (.Values.rbac.accessAllSecrets) }}
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
{{- end }}
```

---
## Test 1
Enable new accessAllSecrets setting and leave secretWhitelist empty
```yaml
rbac:
  # -- Adds Role and RoleBinding for the controller.
  create: true
  # -- Allows controller to get, list, and watch certain k8s secrets
  secretWhitelist: []
  # -- Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty.
  accessAllSecrets: true

Output:
# Source: test/templates/test.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test
rules:
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
```
---
## Test 2
Disable new accessAllSecrets setting and populate secretWhitelist
```yaml
rbac:
  # -- Adds Role and RoleBinding for the controller.
  create: true
  # -- Allows controller to get, list, and watch certain k8s secrets
  secretWhitelist:
  - "test"
  # -- Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty.
  accessAllSecrets: false

Output:
---
# Source: test/templates/test.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test
rules:
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
  resourceNames:
    - test
```

---
## Test 3
Enable new accessAllSecrets setting and populate secretWhitelist
```yaml
rbac:
  # -- Adds Role and RoleBinding for the controller.
  create: true
  # -- Allows controller to get, list, and watch certain k8s secrets
  secretWhitelist:
  - "test"
  # -- Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty.
  accessAllSecrets: true


Output:
# Source: test/templates/test.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test
rules:
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
  resourceNames:
    - test
```

---
## Test 4
Disable new accessAllSecrets setting and and leave secretWhitelist empty
```yaml
rbac:
  # -- Adds Role and RoleBinding for the controller.
  create: true
  # -- Allows controller to get, list, and watch certain k8s secrets
  secretWhitelist: []
  # -- Allows controller to get, list and watch all k8s secrets in the namespace. Can only be used if secretWhitelist is empty.
  accessAllSecrets: false

# Source: test/templates/test.yml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test
rules:
```
