### PR TITLE
docs(github): comment out notational pieces of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
+<!--
 Note on DCO:
 
 If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
+-->
 
 Checklist:
 
@@ -11,4 +13,4 @@ Checklist:
 * [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
 * [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
 
-Changes are automatically published when merged to `main`. They are not published on branches.
+<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->


### PR DESCRIPTION
## Summary

Comment out two notational sentences in the PR template

## Details

- the DCO and publishing sentences are not filled out during PRs and are purely notational
  - comment them out with HTML comments, as is common practice - example from a repo I maintain: https://github.com/ezolenko/rollup-plugin-typescript2/blob/f6db59613a66f58c48310aa8fa785951970b5d6d/.github/issue_template.md?plain=1#L2 - I copied that from other repos too
  - these comments are still visible to the PR author, just not visible when rendered, keeping the PR more concise
  
Can see an example of what this looks like below vvv. If a maintainer clicks the edit button, will be able to see that the note is still there, just commented out and invisible when rendered.
  
## References

I so happened to stumble upon this while writing a different PR #1974, and just automatically commented it out; figured that tiny change could/should be contributed back too

<!-- 
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [N/A] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [N/A] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [N/A] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [N/A] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
