### PR TITLE
fix(argo-rollouts): Added missing permissions for argo rollouts dashboard cluster role

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.4.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.25.0
+version: 2.26.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -16,4 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Ability to provide additional volumes and volumeMounts
+      description: Missing permissions to leases under coordination api group

--- a/charts/argo-rollouts/templates/dashboard/clusterrole.yaml
+++ b/charts/argo-rollouts/templates/dashboard/clusterrole.yaml
@@ -71,4 +71,12 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
 {{- end }}


### PR DESCRIPTION
<!--
Following up this Issue: argoproj/argo-rollouts#2738

On ArgoRollouts chart version 2.23.0 running on k8s cluster v1.22.17-eks, It seems like the follwoing permissions are missing:

jfrog-argo-rollouts-dashboard" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace 

After this commit it seems like the issue is resolved:

time="2023-04-22T19:53:40Z" level=info msg="New leader elected: argo-rollouts-67fdd84bf6-q4ppv_c86f6b69-7aba-409d-a11c-1648edf1d8c3

Checklist:

 I have bumped the chart version according to versioning
 I have updated the documentation according to documentation
 I have updated the chart changelog with all the changes that come with this pull request according to changelog.
 Any new values are backwards compatible and/or have sensible default.
 I have signed off all my commits as required by DCO.
 My build is green (troubleshooting builds).
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
