### PR TITLE
[argo-event] allow extraObjects to contain string template

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v2
 appVersion: v1.4.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
+<<<<<<< HEAD
 version: 2.26.1
+=======
+version: 2.27.0
+>>>>>>> 9389c7b ([argo-event] allow extraObjects to contain string template)
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -16,4 +20,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Missing permissions to leases under coordination api group
+      description: Allow extraObjects to contain string templates

--- a/charts/argo-rollouts/templates/extra-manifests.yaml
+++ b/charts/argo-rollouts/templates/extra-manifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

split of #1980 

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
