### PR TITLE
feat(argo-workflows): allow extraObjects to contain string template

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.3
+version: 0.27.0
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,5 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix Helm chart to correctly reference Kubernetes version in conditional check for HPA apiVersion
+    - kind: added
+      description: Allow extraObjects to contain string templates

--- a/charts/argo-workflows/templates/extra-manifests.yaml
+++ b/charts/argo-workflows/templates/extra-manifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

split of #1980

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
