### PR TITLE
fix(argo-workflows): Add missing argo-workflows.apiVersion.autoscaling helper function for HPA configuration

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.25.1
+version: 0.25.2
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,5 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Add Prometheus ServiceMonitor relabelings, metricRelabelings & targetLabels
+    - kind: fix
+      description: Add missing argo-workflows.apiVersion.autoscaling helper function used for HPA configuration

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -153,3 +153,16 @@ Return full image name including or excluding registry based on existence
   {{ .image.repository }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for autoscaling
+*/}}
+{{- define "argo-workflows.apiVersion.autoscaling" -}}
+{{- if .Values.apiVersionOverrides.autoscaling -}}
+{{- print .Values.apiVersionOverrides.autoscaling -}}
+{{- else if semverCompare "<1.23-0" (include "argo-cd.kubeVersion" .) -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Helper fucntion copied from argo-cd helper functions [here](https://github.com/argoproj/argo-helm/blob/bb4d3154e63c89939c732ef89e404f2cba2f03e9/charts/argo-cd/templates/_versions.tpl#L12)

Function used [here](https://github.com/argoproj/argo-helm/blame/bb4d3154e63c89939c732ef89e404f2cba2f03e9/charts/argo-workflows/templates/server/server-deployment-hpa.yaml#L21) but missing.

Issue risen from community member @usulkies in CNCF slack [here](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1683204130449969).

ERROR

```
Error: template: argo-workflows/templates/server/server-deployment-hpa.yaml:21:19: 
executing "argo-workflows/templates/server/server-deployment-hpa.yaml" at 
<include "argo-workflows.apiVersion.autoscaling" $>: error calling include: 
template: no template "argo-workflows.apiVersion.autoscaling" associated with 
template "gotpl"
```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
