### PR TITLE
fix(argo-workflows): Drop .Values.useDefaultArtifactRepo flag to simplify usage

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.25.2
+version: 0.26.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -14,4 +14,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: fix
-      description: Add missing argo-workflows.apiVersion.autoscaling helper function used for HPA configuration
+      description: Drop .Values.useDefaultArtifactRepo flag to simplify usage

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -308,8 +308,7 @@ Fields to note:
 | artifactRepository.azure | object | `{}` (See [values.yaml]) | Store artifact in Azure Blob Storage |
 | artifactRepository.gcs | object | `{}` (See [values.yaml]) | Store artifact in a GCS object store |
 | artifactRepository.s3 | object | See [values.yaml] | Store artifact in a S3-compliant object store |
-| customArtifactRepository | object | `{}` | The section of custom artifact repository. Will be added to the config in case useDefaultArtifactRepo is set to false |
-| useDefaultArtifactRepo | bool | `false` | Influences the creation of the ConfigMap for the workflow-controller itself. |
+| customArtifactRepository | object | `{}` | The section of custom artifact repository. Utilize a custom artifact repository that is not one of the current base ones (s3, gcs, azure) |
 | useStaticCredentials | bool | `true` | Use static credentials for S3 (eg. when not using AWS IRSA) |
 
 ## Breaking changes from the deprecated `argo` chart

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -55,7 +55,6 @@ data:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
-    {{- if .Values.useDefaultArtifactRepo }}
     artifactRepository:
       {{- if .Values.artifactRepository.archiveLogs }}
       archiveLogs: {{ .Values.artifactRepository.archiveLogs }}
@@ -96,10 +95,8 @@ data:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       {{- end }}
-    {{- else }}
-      {{- if .Values.customArtifactRepository }}
-    artifactRepository: {{- toYaml .Values.customArtifactRepository | nindent 6 }}
-      {{- end }}
+    {{- if .Values.customArtifactRepository }}
+    {{- toYaml .Values.customArtifactRepository | nindent 6 }}
     {{- end }}
     {{- if .Values.controller.metricsConfig.enabled }}
     metricsConfig:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -639,8 +639,6 @@ extraObjects: []
   #       secretName: argo-server-sso-secrets-store
   #       type: Opaque
 
-# -- Influences the creation of the ConfigMap for the workflow-controller itself.
-useDefaultArtifactRepo: false
 # -- Use static credentials for S3 (eg. when not using AWS IRSA)
 useStaticCredentials: true
 artifactRepository:
@@ -702,18 +700,16 @@ artifactRepository:
   #  key: account-access-key
 
 # -- The section of custom artifact repository.
-# Will be added to the config in case useDefaultArtifactRepo is set to false
+# Utilize a custom artifact repository that is not one of the current base ones (s3, gcs, azure)
 customArtifactRepository: {}
-# customArtifactRepository:
-#   archiveLogs: true
-#   artifactory:
-#     repoUrl: https://artifactory.example.com/raw
-#     usernameSecret:
-#       name: artifactory-creds
-#       key: username
-#     passwordSecret:
-#       name: artifactory-creds
-#       key: password
+# artifactory:
+#   repoUrl: https://artifactory.example.com/raw
+#   usernameSecret:
+#     name: artifactory-creds
+#     key: username
+#   passwordSecret:
+#     name: artifactory-creds
+#     key: password
 
 emissary:
   # -- The command/args for each image on workflow, needed when the command is not specified and the emissary executor is used.


### PR DESCRIPTION
Fixes #1140

- [x] remove `.Values.useDefaultArtifactRepo` to ensure if items populated they get into the configmap.
- [x] change structure of `.Values.customArtifactRepository` to only include the custom information

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
