### PR TITLE
fix(argo-workflows): Allow templating in extraInitContainers and artifactRepository in Argo Workflows helm chart

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.2
+version: 0.25.3
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -13,5 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: chore
-      description: Update Chart icon
+    - kind: fix
+      description: Add missing argo-workflows.apiVersion.autoscaling helper function used for HPA configuration

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,8 +3,8 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.1
-icon: https://argoproj.github.io/argo-workflows/assets/logo.png
+version: 0.25.2
+icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
   - https://github.com/argoproj/argo-workflows

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.25.2
+version: 0.26.2
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.25.3
+version: 0.26.0
 icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -14,4 +14,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: fix
-      description: Add missing argo-workflows.apiVersion.autoscaling helper function used for HPA configuration
+      description: Drop .Values.useDefaultArtifactRepo flag to simplify usage

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -69,20 +69,20 @@ data:
       s3:
         {{- if .Values.useStaticCredentials }}
         accessKeySecret:
-          key: {{ .Values.artifactRepository.s3.accessKeySecret.key }}
-          name: {{ .Values.artifactRepository.s3.accessKeySecret.name }}
+          key: {{ tpl .Values.artifactRepository.s3.accessKeySecret.key $ }}
+          name: {{ tpl .Values.artifactRepository.s3.accessKeySecret.name $ }}
         secretKeySecret:
-          key: {{ .Values.artifactRepository.s3.secretKeySecret.key }}
-          name: {{ .Values.artifactRepository.s3.secretKeySecret.name }}
+          key: {{ tpl .Values.artifactRepository.s3.secretKeySecret.key $ }}
+          name: {{ tpl .Values.artifactRepository.s3.secretKeySecret.name $ }}
         {{- end }}
-        bucket: {{ .Values.artifactRepository.s3.bucket }}
-        endpoint: {{ .Values.artifactRepository.s3.endpoint }}
+        bucket: {{ tpl .Values.artifactRepository.s3.bucket $ }}
+        endpoint: {{ tpl .Values.artifactRepository.s3.endpoint $ }}
         insecure: {{ .Values.artifactRepository.s3.insecure }}
         {{- if .Values.artifactRepository.s3.keyFormat }}
         keyFormat: {{ .Values.artifactRepository.s3.keyFormat | quote }}
         {{- end }}
         {{- if .Values.artifactRepository.s3.region }}
-        region: {{ .Values.artifactRepository.s3.region }}
+        region: {{ tpl .Values.artifactRepository.s3.region $ }}
         {{- end }}
         {{- if .Values.artifactRepository.s3.roleARN }}
         roleARN: {{ .Values.artifactRepository.s3.roleARN }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -69,14 +69,14 @@ data:
       s3:
         {{- if .Values.useStaticCredentials }}
         accessKeySecret:
-          key: {{ tpl .Values.artifactRepository.s3.accessKeySecret.key $ }}
-          name: {{ tpl .Values.artifactRepository.s3.accessKeySecret.name $ }}
+          key: {{ tpl .Values.artifactRepository.s3.accessKeySecret.key . }}
+          name: {{ tpl .Values.artifactRepository.s3.accessKeySecret.name . }}
         secretKeySecret:
-          key: {{ tpl .Values.artifactRepository.s3.secretKeySecret.key $ }}
-          name: {{ tpl .Values.artifactRepository.s3.secretKeySecret.name $ }}
+          key: {{ tpl .Values.artifactRepository.s3.secretKeySecret.key . }}
+          name: {{ tpl .Values.artifactRepository.s3.secretKeySecret.name . }}
         {{- end }}
-        bucket: {{ tpl .Values.artifactRepository.s3.bucket $ }}
-        endpoint: {{ tpl .Values.artifactRepository.s3.endpoint $ }}
+        bucket: {{ tpl (.Values.artifactRepository.s3.bucket | default "") . }}
+        endpoint: {{ tpl (.Values.artifactRepository.s3.endpoint | default "") . }}
         insecure: {{ .Values.artifactRepository.s3.insecure }}
         {{- if .Values.artifactRepository.s3.keyFormat }}
         keyFormat: {{ .Values.artifactRepository.s3.keyFormat | quote }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.extraInitContainers }}
       initContainers:
-        {{- tpl . $ | toYaml . | nindent 8 }}
+        {{- tpl . $ | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: controller

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.extraInitContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl . $ | toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: controller

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- with .Values.server.extraInitContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl . $ | toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: argo-server

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- with .Values.server.extraInitContainers }}
       initContainers:
-        {{- tpl . $ | toYaml . | nindent 8 }}
+        {{- tpl . $ | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: argo-server

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -650,10 +650,10 @@ artifactRepository:
     # Note the `key` attribute is not the actual secret, it's the PATH to
     # the contents in the associated secret, as defined by the `name` attribute.
     accessKeySecret:
-      # name: <releaseName>-minio
+      name: "{{ .Release.Name }}-minio"
       key: accesskey
     secretKeySecret:
-      # name: <releaseName>-minio
+      name: "{{ .Release.Name }}-minio"
       key: secretkey
     # insecure will disable TLS. Primarily used for minio installs not configured with TLS
     insecure: false


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
