### PR TITLE
fix(github): fix error in codeowners file and update README about security

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 *                              @mkilchhofer @jmeridth
 
 # Argo Workflows
-/charts/argo-workflows/        @vladlosev @yann-soubeyrand @jmeridth @yu-croco
+/charts/argo-workflows/        @vladlosev @jmeridth @yu-croco
 
 # Argo CD
 /charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=v2.4.9"
 
 ### Security Policy
 
-If you have a security concern relating to either this project repo or an individual helm chart, please [open an issue](https://github.com/argoproj/argo-helm/issues/new/choose) or [start a discussion](https://github.com/argoproj/argo-helm/discussions/new).
+Please refer to [SECURITY.md](SECURITY.md) for details on how to report security issues.
 
 ### Changelog
 


### PR DESCRIPTION
Error in `CODEOWNERS`

<img width="659" alt="Screenshot 2023-05-06 at 5 41 40 AM" src="https://user-images.githubusercontent.com/35014/236619373-b94f4815-f706-4d68-b5dd-227266e1aff8.png">

This is a follow-up of #2006.

We cleared out users who have not contributed in the last year and moved them to EMERITUS.md

We also created SECURITY.md
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
