### PR TITLE
fix(argo-workflows): change chart icon to match other charts

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,8 +3,8 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.0
-icon: https://raw.githubusercontent.com/argoproj/argo-workflows/master/docs/assets/argo.png
+version: 0.26.1
+icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
   - https://github.com/argoproj/argo-workflows
@@ -13,5 +13,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: fix
-      description: Drop .Values.useDefaultArtifactRepo flag to simplify usage
+    - kind: chore
+      description: Update Chart icon


### PR DESCRIPTION
This will make the charts all look nice when you go to https://artifacthub.io/packages/search?repo=argo&sort=relevance&page=1

Current view on artifacthub:

![Screenshot 2023-05-06 at 10 03 19 AM](https://user-images.githubusercontent.com/35014/236632119-737345aa-d5b9-4991-9d99-969d83b25271.png)

Before argo-workflows chart image:

![Screenshot 2023-05-06 at 10 04 24 AM](https://user-images.githubusercontent.com/35014/236632161-11395dc8-25cf-441d-a4b4-cd542b178668.png)

After argo-workflows chart image:

![Screenshot 2023-05-06 at 10 04 50 AM](https://user-images.githubusercontent.com/35014/236632182-eed26d96-c31f-4543-89f3-0438dacd9b21.png)



<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
