### PR TITLE
chore(argo-events): Update chart icon to standard image

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 appVersion: v1.7.6
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.3.0
+version: 2.3.1
 home: https://github.com/argoproj/argo-helm
-icon: https://argoproj.github.io/argo-events/assets/logo.png
+icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
   - argoproj
   - argo-events
@@ -15,5 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Allow extraObjects to contain string templates
+    - kind: chore
+      description: Update chart icon


### PR DESCRIPTION
This will make the charts all look nice when you go to https://artifacthub.io/packages/search?repo=argo&sort=relevance&page=1

![image](https://user-images.githubusercontent.com/35014/236659117-4c06d4e0-4874-406a-bc81-16b68267d62b.png)

Before argo-events chart icon:

<img width="167" alt="Screenshot 2023-05-07 at 12 16 16 AM" src="https://user-images.githubusercontent.com/35014/236659136-e2c3bf3a-791c-45ad-9a92-9b8e8d3410e4.png">

After argo-events chart icon:

<img width="231" alt="Screenshot 2023-05-07 at 12 16 52 AM" src="https://user-images.githubusercontent.com/35014/236659148-f62053a4-c82d-43d3-927f-9bfbb9119f43.png">

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
