### PR TITLE
fix(argo-workflows): Fix templating in several places

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix Helm chart to correctly reference Kubernetes version in conditional check for HPA apiVersion
+      description: Fix Helm templating in S3 config and extra init containers

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.3
+version: 0.26.4
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -60,10 +60,10 @@ data:
       archiveLogs: {{ .Values.artifactRepository.archiveLogs }}
       {{- end }}
       {{- with .Values.artifactRepository.gcs }}
-      gcs: {{- toYaml . | nindent 8 }}
+      gcs: {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.artifactRepository.azure }}
-      azure: {{- toYaml . | nindent 8 }}
+      azure: {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- if and  (not .Values.artifactRepository.gcs) (not .Values.artifactRepository.azure) }}
       s3:

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -69,20 +69,20 @@ data:
       s3:
         {{- if .Values.useStaticCredentials }}
         accessKeySecret:
-          key: {{ .Values.artifactRepository.s3.accessKeySecret.key }}
-          name: {{ .Values.artifactRepository.s3.accessKeySecret.name }}
+          key: {{ tpl .Values.artifactRepository.s3.accessKeySecret.key . }}
+          name: {{ tpl .Values.artifactRepository.s3.accessKeySecret.name . }}
         secretKeySecret:
-          key: {{ .Values.artifactRepository.s3.secretKeySecret.key }}
-          name: {{ .Values.artifactRepository.s3.secretKeySecret.name }}
+          key: {{ tpl .Values.artifactRepository.s3.secretKeySecret.key . }}
+          name: {{ tpl .Values.artifactRepository.s3.secretKeySecret.name . }}
         {{- end }}
-        bucket: {{ .Values.artifactRepository.s3.bucket }}
-        endpoint: {{ .Values.artifactRepository.s3.endpoint }}
+        bucket: {{ tpl (.Values.artifactRepository.s3.bucket | default "") . }}
+        endpoint: {{ tpl (.Values.artifactRepository.s3.endpoint | default "") . }}
         insecure: {{ .Values.artifactRepository.s3.insecure }}
         {{- if .Values.artifactRepository.s3.keyFormat }}
         keyFormat: {{ .Values.artifactRepository.s3.keyFormat | quote }}
         {{- end }}
         {{- if .Values.artifactRepository.s3.region }}
-        region: {{ .Values.artifactRepository.s3.region }}
+        region: {{ tpl .Values.artifactRepository.s3.region $ }}
         {{- end }}
         {{- if .Values.artifactRepository.s3.roleARN }}
         roleARN: {{ .Values.artifactRepository.s3.roleARN }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.extraInitContainers }}
       initContainers:
-        {{- tpl . $ | toYaml | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       containers:
         - name: controller

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- with .Values.controller.extraInitContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl . $ | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: controller

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- with .Values.server.extraInitContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl . $ | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: argo-server

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- with .Values.server.extraInitContainers }}
       initContainers:
-        {{- tpl . $ | toYaml | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       containers:
         - name: argo-server

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -655,10 +655,10 @@ artifactRepository:
     # Note the `key` attribute is not the actual secret, it's the PATH to
     # the contents in the associated secret, as defined by the `name` attribute.
     accessKeySecret:
-      # name: <releaseName>-minio
+      name: "{{ .Release.Name }}-minio"
       key: accesskey
     secretKeySecret:
-      # name: <releaseName>-minio
+      name: "{{ .Release.Name }}-minio"
       key: secretkey
     # insecure will disable TLS. Primarily used for minio installs not configured with TLS
     insecure: false


### PR DESCRIPTION
Templating is not supported for several variables in the Argo Workflows helm chart.
The `values.yaml` file is hinting at it, but the current charts would not support it...
So I've also updated the `values.yaml` file to indicate the correct usage (which works together with the other changes of this PR)
```
     ---    # name: <releaseName>-minio
     +++ name: "{{ .Release.Name }}-minio"
```

Opened this PR as a replacement for https://github.com/argoproj/argo-helm/pull/2003 which I messed up a bit while rebasing/merging different remote origins.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->