### PR TITLE
fix(argo-events): use correct artifacthub annotation kind

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.6
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.3.1
+version: 2.3.2
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -15,5 +15,5 @@ maintainers:
     url: https://argoproj.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: chore
-      description: Update chart icon
+    - kind: fixed
+      description: Use correct artifacthub kind and get latest chart version to artifacthub


### PR DESCRIPTION
This is to get latest argo-workflows chart version out to artifacthub.

Can't get the previous ones that had incorrect kinds.

argoproj#2030 adds linting so this doesn't happen again. Will merge after argo-workflows and argo-events charts are fixed.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
