### PR TITLE
fix(argo-workflows): fix clusterworkflowtemplates disabled flag

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.1
+version: 0.26.2
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.26.3
+version: 0.26.4
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -14,4 +14,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix Helm chart to correctly reference Kubernetes version in conditional check for HPA apiVersion
+      description: Create clusterWorkflowTemplates CRD only when enabled in Helm values.

--- a/charts/argo-workflows/templates/crds/argoproj.io_clusterworkflowtemplates.yaml
+++ b/charts/argo-workflows/templates/crds/argoproj.io_clusterworkflowtemplates.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.crds.install }}
+{{- if or (.Values.server.clusterWorkflowTemplates.enabled) (.Values.controller.clusterWorkflowTemplates.enabled) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -42,4 +43,5 @@ spec:
         type: object
     served: true
     storage: true
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Fix for https://github.com/argoproj/argo-helm/issues/1925

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
