### PR TITLE
chore(github): Add tico24 to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,13 +2,13 @@
 *                              @mkilchhofer @jmeridth
 
 # Argo Workflows
-/charts/argo-workflows/        @vladlosev @jmeridth @yu-croco
+/charts/argo-workflows/        @vladlosev @jmeridth @yu-croco @tico24
 
 # Argo CD
-/charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil
+/charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil @tico24
 
 # Argo Events
-/charts/argo-events/           @pdrastil @jmeridth
+/charts/argo-events/           @pdrastil @jmeridth @tico24
 
 # Argo Rollouts
 /charts/argo-rollouts/         @jmeridth


### PR DESCRIPTION
At the requets of @jmeridth I have popped my name down on the products I'm most familiiar with to offer my services in reviewing/fixing helm things.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
