### PR TITLE
fix(github): ignore argo-lite package so we can finalize artifacthub official-ness

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,5 +1,7 @@
 # Artifact Hub repository metadata file
 repositoryID: 05f5fe20-d21b-4413-8327-715958b51bde
 owners:
-- name: jmeridth
-  email: jmeridth@gmail.com
+  - name: jmeridth
+    email: jmeridth@gmail.com
+ignore:
+  - name: argo-lite


### PR DESCRIPTION
Base on converation had [here](https://github.com/artifacthub/hub/issues/3052#issuecomment-1543770355)

This should finalize our getting our argo artifacthub project marked as official

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
