### PR TITLE
fix(argo-cd): Allow to disable containerSecurityContext

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.2
 kubeVersion: ">=1.22.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.34.3
+version: 5.34.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Align with upstream dex initContainers
+      description: Allow to disable containerSecurityContext

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -255,10 +255,10 @@ spec:
           failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
-        {{- if .Values.controller.containerSecurityContext.enabled }}
+        {{- with .Values.controller.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.controller.containerSecurityContext "enabled" | toYaml | nindent 10 }}
-          {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         workingDir: /home/argocd
         volumeMounts:
         {{- with .Values.controller.volumeMounts }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -255,8 +255,10 @@ spec:
           failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
+        {{- if .Values.controller.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.controller.containerSecurityContext | nindent 10 }}
+          {{- end }}
         workingDir: /home/argocd
         volumeMounts:
         {{- with .Values.controller.volumeMounts }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -257,7 +257,7 @@ spec:
           {{- toYaml .Values.controller.resources | nindent 10 }}
         {{- if .Values.controller.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.controller.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.controller.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           {{- end }}
         workingDir: /home/argocd
         volumeMounts:

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -182,9 +182,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.applicationSet.resources | nindent 12 }}
-          {{- if .Values.applicationSet.containerSecurityContext.enabled }}
+          {{- with .Values.applicationSet.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.applicationSet.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- with .Values.applicationSet.extraVolumeMounts }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -184,7 +184,7 @@ spec:
             {{- toYaml .Values.applicationSet.resources | nindent 12 }}
           {{- if .Values.applicationSet.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.applicationSet.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.applicationSet.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- with .Values.applicationSet.extraVolumeMounts }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -182,8 +182,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.applicationSet.resources | nindent 12 }}
+          {{- if .Values.applicationSet.containerSecurityContext.enabled }}
           securityContext:
             {{- toYaml .Values.applicationSet.containerSecurityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- with .Values.applicationSet.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             {{- toYaml .Values.notifications.resources | nindent 12 }}
           {{- if .Values.notifications.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.notifications.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.notifications.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           workingDir: /app
           volumeMounts:

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -80,9 +80,9 @@ spec:
             protocol: TCP
           resources:
             {{- toYaml .Values.notifications.resources | nindent 12 }}
-          {{- if .Values.notifications.containerSecurityContext.enabled }}
+          {{- with .Values.notifications.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.notifications.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           workingDir: /app
           volumeMounts:

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -80,8 +80,10 @@ spec:
             protocol: TCP
           resources:
             {{- toYaml .Values.notifications.resources | nindent 12 }}
+          {{- if .Values.notifications.containerSecurityContext.enabled }}
           securityContext:
             {{- toYaml .Values.notifications.containerSecurityContext | nindent 12 }}
+          {{- end }}
           workingDir: /app
           volumeMounts:
             - name: tls-certs

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -273,8 +273,10 @@ spec:
           failureThreshold: {{ .Values.repoServer.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.repoServer.resources | nindent 10 }}
+        {{- if .Values.repoServer.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
+        {{- end }}
         {{- with .Values.repoServer.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}
@@ -295,9 +297,11 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.repoServer.containerSecurityContext.enabled }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         volumeMounts:
         - mountPath: /var/run/argocd

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -273,7 +273,7 @@ spec:
           failureThreshold: {{ .Values.repoServer.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.repoServer.resources | nindent 10 }}
-        {{- if .Values.repoServer.containerSecurityContext }}
+        {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -273,9 +273,9 @@ spec:
           failureThreshold: {{ .Values.repoServer.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.repoServer.resources | nindent 10 }}
-        {{- if .Values.repoServer.containerSecurityContext.enabled }}
+        {{- if .Values.repoServer.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.repoServer.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.repoServer.lifecycle }}
         lifecycle:
@@ -297,11 +297,9 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if .Values.repoServer.containerSecurityContext.enabled }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
-          {{- omit . "enabled" | toYaml | nindent 10 }}
-        {{- end }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
         - mountPath: /var/run/argocd

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -275,7 +275,7 @@ spec:
           {{- toYaml .Values.repoServer.resources | nindent 10 }}
         {{- if .Values.repoServer.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.repoServer.containerSecurityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- with .Values.repoServer.lifecycle }}
         lifecycle:
@@ -300,7 +300,7 @@ spec:
         {{- if .Values.repoServer.containerSecurityContext.enabled }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
-          {{- toYaml . | nindent 10 }}
+          {{- omit . "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -334,9 +334,9 @@ spec:
           failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.server.resources | nindent 10 }}
-        {{- if .Values.repoServer.containerSecurityContext.enabled }}
+        {{- if .Values.server.containerSecurityContext.enabled }}
         securityContext:
-          {{- omit .Values.repoServer.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+          {{- omit .Values.server.containerSecurityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- with .Values.server.lifecycle }}
         lifecycle:
@@ -351,7 +351,7 @@ spec:
         {{- if .Values.server.extensions.containerSecurityContext.enabled }}
         securityContext:
           {{- omit .Values.server.extensions.containerSecurityContext "enabled" | toYaml | nindent 10 }}
-          {{- end }}
+        {{- end }}
         volumeMounts:
           - name: extensions
             mountPath: /tmp/extensions/

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -334,8 +334,10 @@ spec:
           failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.server.resources | nindent 10 }}
+        {{- if .Values.repoServer.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.server.containerSecurityContext | nindent 10 }}
+          {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
+        {{- end }}
         {{- with .Values.server.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}
@@ -346,8 +348,10 @@ spec:
         imagePullPolicy: {{ .Values.server.extensions.image.imagePullPolicy }}
         resources:
           {{- toYaml .Values.server.extensions.resources | nindent 10 }}
+        {{- if .Values.server.extensions.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.server.extensions.containerSecurityContext | nindent 10 }}
+          {{-end }}
         volumeMounts:
           - name: extensions
             mountPath: /tmp/extensions/

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -351,7 +351,7 @@ spec:
         {{- if .Values.server.extensions.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.server.extensions.containerSecurityContext | nindent 10 }}
-          {{-end }}
+          {{- end }}
         volumeMounts:
           - name: extensions
             mountPath: /tmp/extensions/

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -336,7 +336,7 @@ spec:
           {{- toYaml .Values.server.resources | nindent 10 }}
         {{- if .Values.repoServer.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.repoServer.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.repoServer.containerSecurityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- with .Values.server.lifecycle }}
         lifecycle:
@@ -350,7 +350,7 @@ spec:
           {{- toYaml .Values.server.extensions.resources | nindent 10 }}
         {{- if .Values.server.extensions.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.server.extensions.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.server.extensions.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           {{- end }}
         volumeMounts:
           - name: extensions

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -334,9 +334,9 @@ spec:
           failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
         resources:
           {{- toYaml .Values.server.resources | nindent 10 }}
-        {{- if .Values.server.containerSecurityContext.enabled }}
+        {{- with .Values.server.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.server.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.server.lifecycle }}
         lifecycle:
@@ -348,9 +348,9 @@ spec:
         imagePullPolicy: {{ .Values.server.extensions.image.imagePullPolicy }}
         resources:
           {{- toYaml .Values.server.extensions.resources | nindent 10 }}
-        {{- if .Values.server.extensions.containerSecurityContext.enabled }}
+        {{- with .Values.server.extensions.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.server.extensions.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
           - name: extensions

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -117,8 +117,10 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.dex.resources | nindent 10 }}
+        {{- if .Values.dex.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
+          {{- end }}
         volumeMounts:
         {{- with .Values.dex.volumeMounts }}
           {{- toYaml . | nindent 8 }}
@@ -148,8 +150,10 @@ spec:
           name: dexconfig
         resources:
           {{- toYaml .Values.dex.resources | nindent 10 }}
+        {{- if .Values.dex.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
+          {{- end}}
       {{- with .Values.dex.initContainers }}
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -117,10 +117,10 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.dex.resources | nindent 10 }}
-        {{- if .Values.dex.containerSecurityContext.enabled }}
+        {{- with .Values.dex.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.dex.containerSecurityContext "enabled" | toYaml | nindent 10 }}
-          {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{- with .Values.dex.volumeMounts }}
           {{- toYaml . | nindent 8 }}
@@ -150,10 +150,10 @@ spec:
           name: dexconfig
         resources:
           {{- toYaml .Values.dex.resources | nindent 10 }}
-        {{- if .Values.dex.containerSecurityContext.enabled }}
+        {{- with .Values.dex.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.dex.containerSecurityContext "enabled" | toYaml | nindent 10 }}
-          {{- end}}
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
       {{- with .Values.dex.initContainers }}
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -153,7 +153,7 @@ spec:
         {{- with .Values.dex.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
-        {{- end}}
+        {{- end }}
       {{- with .Values.dex.initContainers }}
         {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           {{- toYaml .Values.dex.resources | nindent 10 }}
         {{- if .Values.dex.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.dex.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           {{- end }}
         volumeMounts:
         {{- with .Values.dex.volumeMounts }}
@@ -152,7 +152,7 @@ spec:
           {{- toYaml .Values.dex.resources | nindent 10 }}
         {{- if .Values.dex.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.dex.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.dex.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           {{- end}}
       {{- with .Values.dex.initContainers }}
         {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -41,9 +41,11 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.redis.containerSecurityContext.enabled }}
       {{- with .Values.redis.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- omit . "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.redis.priorityClassName | default .Values.global.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -75,8 +75,10 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.resources | nindent 10 }}
+        {{- if .Values.redis.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.redis.containerSecurityContext | nindent 10 }}
+        {{- end }}
         {{- with .Values.redis.volumeMounts }}
         volumeMounts:
           {{- toYaml . | nindent 10 }}
@@ -99,8 +101,10 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.exporter.resources | nindent 10 }}
+        {{- if .Values.redis.exporter.containerSecurityContext.enabled }}
         securityContext:
           {{- toYaml .Values.redis.exporter.containerSecurityContext | nindent 10 }}
+          {{- end }}
       {{- end }}
       {{- with .Values.redis.extraContainers }}
         {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -41,11 +41,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.redis.containerSecurityContext.enabled }}
       {{- with .Values.redis.securityContext }}
       securityContext:
-        {{- omit . "enabled" | toYaml | nindent 8 }}
-      {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.redis.priorityClassName | default .Values.global.priorityClassName }}
       priorityClassName: {{ . }}
@@ -77,9 +75,9 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.resources | nindent 10 }}
-        {{- if .Values.redis.containerSecurityContext.enabled }}
+        {{- with .Values.redis.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.redis.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.redis.volumeMounts }}
         volumeMounts:
@@ -103,10 +101,10 @@ spec:
           protocol: TCP
         resources:
           {{- toYaml .Values.redis.exporter.resources | nindent 10 }}
-        {{- if .Values.redis.exporter.containerSecurityContext.enabled }}
+        {{- with .Values.redis.exporter.containerSecurityContext }}
         securityContext:
-          {{- omit .Values.redis.exporter.containerSecurityContext "enabled" | toYaml | nindent 10 }}
-          {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.redis.extraContainers }}
         {{- tpl (toYaml .) $ | nindent 6 }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           {{- toYaml .Values.redis.resources | nindent 10 }}
         {{- if .Values.redis.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.redis.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.redis.containerSecurityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
         {{- with .Values.redis.volumeMounts }}
         volumeMounts:
@@ -103,7 +103,7 @@ spec:
           {{- toYaml .Values.redis.exporter.resources | nindent 10 }}
         {{- if .Values.redis.exporter.containerSecurityContext.enabled }}
         securityContext:
-          {{- toYaml .Values.redis.exporter.containerSecurityContext | nindent 10 }}
+          {{- omit .Values.redis.exporter.containerSecurityContext "enabled" | toYaml | nindent 10 }}
           {{- end }}
       {{- end }}
       {{- with .Values.redis.extraContainers }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -699,7 +699,6 @@ controller:
   # -- Application controller container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -1018,7 +1017,6 @@ dex:
   # -- Dex container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -1170,7 +1168,6 @@ redis:
     # -- Redis exporter security context
     # @default -- See [values.yaml]
     containerSecurityContext:
-      enabled: true
       runAsNonRoot: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -1264,7 +1261,6 @@ redis:
   # -- Redis container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -1528,7 +1524,6 @@ server:
     # -- Server UI extensions container-level security context
     # @default -- See [values.yaml]
     containerSecurityContext:
-      enabled: true
       runAsNonRoot: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -1633,7 +1628,6 @@ server:
   # -- Server container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -2165,7 +2159,6 @@ repoServer:
   # -- Repo server container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -2519,7 +2512,6 @@ applicationSet:
   # -- ApplicationSet controller container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -2858,7 +2850,6 @@ notifications:
   # -- Notification controller container-level security Context
   # @default -- See [values.yaml]
   containerSecurityContext:
-    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -699,6 +699,7 @@ controller:
   # -- Application controller container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -1017,6 +1018,7 @@ dex:
   # -- Dex container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -1168,6 +1170,7 @@ redis:
     # -- Redis exporter security context
     # @default -- See [values.yaml]
     containerSecurityContext:
+      enabled: true
       runAsNonRoot: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -1261,6 +1264,7 @@ redis:
   # -- Redis container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -1524,6 +1528,7 @@ server:
     # -- Server UI extensions container-level security context
     # @default -- See [values.yaml]
     containerSecurityContext:
+      enabled: true
       runAsNonRoot: true
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -1628,6 +1633,7 @@ server:
   # -- Server container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -2159,6 +2165,7 @@ repoServer:
   # -- Repo server container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -2512,6 +2519,7 @@ applicationSet:
   # -- ApplicationSet controller container-level security context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -2850,6 +2858,7 @@ notifications:
   # -- Notification controller container-level security Context
   # @default -- See [values.yaml]
   containerSecurityContext:
+    enabled: true
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false


### PR DESCRIPTION
Use `with` so (parts of) the securityContext can be `null`ed out. Fixes https://github.com/argoproj/argo-helm/issues/2071

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
