### PR TITLE
chore(github): Generate release notes

### DIFF
--- a/.github/configs/cr.yaml
+++ b/.github/configs/cr.yaml
@@ -6,3 +6,7 @@ sign: true
 key: Argo Helm maintainers
 # keyring:          # Set via env variable CR_KEYRING
 # passphrase-file:  # Set via env variable CR_PASSPHRASE_FILE
+
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
Fixes #1721 

Enables release note generation via an [option](https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages) provided by `chart-releaser`. `chart-releaser` uses GitHub's feature for automatic release note generation (https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).