### PR TITLE
fix(argo-cd): helm lint error when `extraObjects` is defined

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.36.2
+version: 5.36.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo CD to v2.7.5
+    - kind: fixed
+      description: Fix helm lint error when `extraObjects` is defined

--- a/charts/argo-cd/templates/extra-manifests.yaml
+++ b/charts/argo-cd/templates/extra-manifests.yaml
@@ -1,6 +1,6 @@
 {{ range .Values.extraObjects }}
 ---
-{{- if typeIs "string" . }}
+{{ if typeIs "string" . }}
     {{- tpl . $ }}
 {{- else }}
     {{- tpl (toYaml .) $ }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

`helm lint` fails with `extraObjects` defined.

```
Adding repo argocd https://argoproj.github.io/argo-helm
"argocd" has been added to your repositories

Fetching argocd/argo-cd
Linting release=argocd, chart=/var/folders/6v/cdcp2ltn42j79tbmktqpfbyr0000gq/T/helmfile2380798123/argocd/argocd/argocd/argo-cd/5.34.6/argo-cd
==> Linting /var/folders/6v/cdcp2ltn42j79tbmktqpfbyr0000gq/T/helmfile2380798123/argocd/argocd/argocd/argo-cd/5.34.6/argo-cd
[ERROR] templates/extra-manifests.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: generators.external-secrets.io/v1alpha1
[ERROR] templates/extra-manifests.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: external-secrets.io/v1beta1
[ERROR] templates/extra-manifests.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1
```

This is because the template removes the newline character between `---` and `apiVersion`. This issue is described in https://github.com/helm/helm/issues/10149.

This PR keeps this newline and passes lint.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
