### PR TITLE
chore(argo-cd): Add `app.kubernetes.io/version` label

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.36.3
+version: 5.36.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix helm lint error when `extraObjects` is defined
+    - kind: added
+      description: Add `app.kubernetes.io/version` label

--- a/charts/argo-cd/templates/_common.tpl
+++ b/charts/argo-cd/templates/_common.tpl
@@ -46,6 +46,7 @@ helm.sh/chart: {{ include "argo-cd.chart" .context }}
 {{ include "argo-cd.selectorLabels" (dict "context" .context "component" .component "name" .name) }}
 app.kubernetes.io/managed-by: {{ .context.Release.Service }}
 app.kubernetes.io/part-of: argocd
+app.kubernetes.io/version: {{ include "argo-cd.defaultTag" .context }}
 {{- with .context.Values.global.additionalLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -123,7 +124,7 @@ nodeAffinity:
 
 {{/*
 Common deployment strategy definition
-- Recreate don't have additional fields, we need to remove them if added by the mergeOverwrite 
+- Recreate don't have additional fields, we need to remove them if added by the mergeOverwrite
 */}}
 {{- define "argo-cd.strategy" -}}
 {{- $preset := . -}}


### PR DESCRIPTION
resolves https://github.com/argoproj/argo-helm/issues/2118 🙋 

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
