### PR TITLE
fix(argo-workflows): Change argo-workflows-server crb creation conditions

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.8
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.29.2
+version: 0.29.3
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for UI columns configuration
+    - kind: fixed
+      description: Modify to allow ClusterRoleBinding to be created even if the server's ServiceAccount is not created

--- a/charts/argo-workflows/templates/server/server-crb.yaml
+++ b/charts/argo-workflows/templates/server/server-crb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.enabled .Values.server.serviceAccount.create .Values.server.rbac.create -}}
+{{- if and .Values.server.enabled .Values.server.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespace }}
 kind: RoleBinding


### PR DESCRIPTION
Currently, because the creation of ServiceAccount is included in the conditions for creating ClusterRoleBinding in argo-workflows-server, it is not possible to create only ClusterRoleBinding in a case where ServiceAccount is not created in helm. 

Modify so that ClusterRoleBinding is created if `rbac: true` is set even in the case where ServiceAccount is not created.

This is my first commit to this repository, so please let me know if I am doing something wrong!

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
