### PR TITLE
feat(argo-cd): Add support for configuring argo-notifications log level and format

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.6
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.36.6
+version: 5.36.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -28,4 +28,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Add `ARGOCD_NOTIFICATIONS_CONTROLLER_LOGLEVEL` and `ARGOCD_NOTIFICATIONS_CONTROLLER_LOGFORMAT` env vars to argo-notifications Deployment
-

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,7 +26,6 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo CD to v2.7.6
-    - kind: changed
-      description: applicationSet.containerPorts.metrics to 8085
+    - kind: added
+      description: Add `ARGOCD_NOTIFICATIONS_CONTROLLER_LOGLEVEL` and `ARGOCD_NOTIFICATIONS_CONTROLLER_LOGFORMAT` env vars to argo-notifications Deployment
+

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.6
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.36.7
+version: 5.36.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -66,10 +66,22 @@ spec:
             {{- range .Values.notifications.extraArgs }}
             - {{ . | squote }}
             {{- end }}
-          {{- with (concat .Values.global.env .Values.notifications.extraEnv) }}
           env:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- with (concat .Values.global.env .Values.notifications.extraEnv) }}
+              {{- toYaml . | nindent 12 }}
+             {{- end }}
+            - name: ARGOCD_NOTIFICATIONS_CONTROLLER_LOGLEVEL
+              valueFrom:
+                configMapKeyRef:
+                  key: notificationscontroller.log.level
+                  name: argocd-cmd-params-cm
+                  optional: true              
+            - name: ARGOCD_NOTIFICATIONS_CONTROLLER_LOGFORMAT
+              valueFrom:
+                configMapKeyRef:
+                  key: notificationscontroller.log.format
+                  name: argocd-cmd-params-cm
+                  optional: true
           {{- with .Values.notifications.extraEnvFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           env:
             {{- with (concat .Values.global.env .Values.notifications.extraEnv) }}
               {{- toYaml . | nindent 12 }}
-             {{- end }}
+            {{- end }}
             - name: ARGOCD_NOTIFICATIONS_CONTROLLER_LOGLEVEL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/pull/13605 introduced two new environment variables that allow a user to configure the log-level of argo-notifications-controller similar to how other Argo controllers are configured.  This PR adds those environment variables to the notifications _Deployment_ -- similar to how they exist for other controller's _Deployments_.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
