### PR TITLE
fix(argo-cd): Ensure `app.kubernetes.io/version` label is valid

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.7
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.39.0
+version: 5.39.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Allow configuring Dex's init image resources separately
+    - kind: fixed
+      description: Ensure `app.kubernetes.io/version` label is valid

--- a/charts/argo-cd/templates/_common.tpl
+++ b/charts/argo-cd/templates/_common.tpl
@@ -39,6 +39,13 @@ Create Argo CD app version
 {{- end -}}
 
 {{/*
+Return valid version label
+*/}}
+{{- define "argo-cd.versionLabelValue" -}}
+{{ regexReplaceAll "[^-A-Za-z0-9_.]" (include "argo-cd.defaultTag" .) "-" | trunc 63 | trimAll "-" | trimAll "_" | trimAll "." | quote }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "argo-cd.labels" -}}
@@ -46,7 +53,7 @@ helm.sh/chart: {{ include "argo-cd.chart" .context }}
 {{ include "argo-cd.selectorLabels" (dict "context" .context "component" .component "name" .name) }}
 app.kubernetes.io/managed-by: {{ .context.Release.Service }}
 app.kubernetes.io/part-of: argocd
-app.kubernetes.io/version: {{ include "argo-cd.defaultTag" .context }}
+app.kubernetes.io/version: {{ include "argo-cd.versionLabelValue" .context }}
 {{- with .context.Values.global.additionalLabels }}
 {{ toYaml . }}
 {{- end }}


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Before:

```console
$ helm template  charts/argo-cd/ | grep /version | head -1
    app.kubernetes.io/version: v2.7.7
$   # ^^^ This one is valid
$ helm template --set global.image.tag=v2.7.5@sha256:d93e1c2fa8c806b339d9288a4de59bff293f2f81e8efbcb charts/argo-cd/ | grep /version | head -1
    app.kubernetes.io/version: v2.7.5@sha256:d93e1c2fa8c806b339d9288a4de59bff293f2f81e8efbcb
$   # ^^^ This one is invalid!
```

After:

```console
$ helm template  charts/argo-cd/ | grep /version | head -1
    app.kubernetes.io/version: "v2.7.7"
$   # ^^^ This one is valid, and unchanged
$ helm template --set global.image.tag=.v2.7.5@sha256:d93e1c2fa8c806b339d9288a4de59bff293f2f81e8efbcb. charts/argo-cd/ | grep /version | head -1
    app.kubernetes.io/version: "v2.7.5-sha256-d93e1c2fa8c806b339d9288a4de59bff293f2f81e8efbcb"
$   # ^^^ This one is now valid
```
