### PR TITLE
feat(argocd-apps): add permitOnlyProjectScopedClusters flag

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: A Helm chart for managing additional Argo CD Applications and Projects
 type: application
-version: 1.2.0
+version: 1.3.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -18,4 +18,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Rollout strategy for ApplicationSet
+      description: add permitOnlyProjectScopedClusters flag to Projects defaulting to false

--- a/charts/argocd-apps/templates/projects.yaml
+++ b/charts/argocd-apps/templates/projects.yaml
@@ -22,7 +22,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  permitOnlyProjectScopedClusters: {{ .permitOnlyProjectScopedClusters | default false }}
+  {{- with .permitOnlyProjectScopedClusters }}
+  permitOnlyProjectScopedClusters: {{ . }}
+  {{- end }}
   description: {{ .description }}
   {{- with .sourceRepos }}
   sourceRepos:

--- a/charts/argocd-apps/templates/projects.yaml
+++ b/charts/argocd-apps/templates/projects.yaml
@@ -22,6 +22,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  permitOnlyProjectScopedClusters: {{ .permitOnlyProjectScopedClusters | default false }}
   description: {{ .description }}
   {{- with .sourceRepos }}
   sourceRepos:

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -48,6 +48,7 @@ projects: []
 #   namespace: argocd
 #   additionalLabels: {}
 #   additionalAnnotations: {}
+#   permitOnlyProjectScopedClusters: false
 #   finalizers:
 #   - resources-finalizer.argocd.argoproj.io
 #   description: Example Project


### PR DESCRIPTION
  # Context

  This flag was added in this PR https://github.com/argoproj/argo-cd/pull/10237/files but is not possible to set it using the argocd-apps chart.

  # What it does this PR

  - It adds this flag as a value of the chart for projects in argocd-apps

  # Proof

```
echo "projects:                                                                                                                                                                                                                                                         (⎈ |kind-hnc:hnc-system)
  - name: orka-extensibility
    namespace: cre-system
    description: orka-extensibility
    clusterResourceWhitelist:
    - group: '*'
      kind: '*'
    destinations:
    - namespace: '*'
      server: '*'
    orphanedResources:
      warn: true
    sourceRepos:
    - '*'
    roles:
    # A role which provides read-only access to all applications in the project
    - name: read-only
      description: Read-only privileges to orka-extensibility
      policies:
      - p, proj:orka-extensibility:read-only, applications, get, orka-extensibility/*, allow
      - p, proj:orka-extensibility:read-only, applicationsets, get, orka-extensibility/*, allow
      - p, proj:orka-extensibility:read-only, applications, sync, orka-extensibility/*, allow
      - p, proj:orka-extensibility:read-only, applicationsets, sync, orka-extensibility/*, allow
      groups:
      - OrkA Team
" > values-test.yaml

helm template . -f values-test.yaml

---
apiVersion: argoproj.io/v1alpha1
kind: AppProject
metadata:
  name: orka-extensibility
  namespace: cre-system
spec:
  permitOnlyProjectScopedClusters: false
  description: orka-extensibility
  sourceRepos:
    - '*'
  destinations:
    - namespace: '*'
      server: '*'
  clusterResourceWhitelist:
    - group: '*'
      kind: '*'
  orphanedResources:
    warn: true
  roles:
    - description: Read-only privileges to orka-extensibility
      groups:
      - OrkA Team
      name: read-only
      policies:
      - p, proj:orka-extensibility:read-only, applications, get, orka-extensibility/*,
        allow
      - p, proj:orka-extensibility:read-only, applicationsets, get, orka-extensibility/*,
        allow
      - p, proj:orka-extensibility:read-only, applications, sync, orka-extensibility/*,
        allow
      - p, proj:orka-extensibility:read-only, applicationsets, sync, orka-extensibility/*,
        allow

```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
