### PR TITLE
feat(argo-cd): Allow configuring Dex's init image resources separately

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.7
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.38.1
+version: 5.39.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Adding the option to set `annotations` for `Certificate` resources
+      description: Allow configuring Dex's init image resources separately

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -864,6 +864,7 @@ server:
 | dex.initContainers | list | `[]` | Init containers to add to the dex pod |
 | dex.initImage.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Argo CD init image imagePullPolicy |
 | dex.initImage.repository | string | `""` (defaults to global.image.repository) | Argo CD init image repository |
+| dex.initImage.resources | object | `{}` (defaults to dex.resources) | Argo CD init image resources |
 | dex.initImage.tag | string | `""` (defaults to global.image.tag) | Argo CD init image tag |
 | dex.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for Dex >= 2.28.0 |
 | dex.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -149,7 +149,7 @@ spec:
         - mountPath: /tmp
           name: dexconfig
         resources:
-          {{- toYaml .Values.dex.resources | nindent 10 }}
+          {{- toYaml (default .Values.dex.resources .Values.dex.initImage.resources) | nindent 10 }}
         {{- with .Values.dex.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -951,6 +951,15 @@ dex:
     # -- Argo CD init image imagePullPolicy
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: ""
+    # -- Argo CD init image resources
+    # @default -- `{}` (defaults to dex.resources)
+    resources: {}
+    #  requests:
+    #    cpu: 5m
+    #    memory: 96Mi
+    #  limits:
+    #    cpu: 10m
+    #    memory: 144Mi
 
   # -- Environment variables to pass to the Dex server
   env: []


### PR DESCRIPTION
Motivation:

The dex server, when running, can use as little as 1m CPU and 38Mi of memory:
```
> kubectl -n argocd top pod argo-cd-argocd-dex-server-549f5d748c-q8fmq
NAME                                         CPU(cores)   MEMORY(bytes)   
argo-cd-argocd-dex-server-549f5d748c-q8fmq   1m           38Mi            
```

However, using a low resource spec to match said usage, the init container can crash with an OOMKilled, leading to crashloopbackoffs from Dex:
```
argo-cd-argocd-dex-server-99794466c-d7zvr                   0/1     Init:OOMKilled      0                12s
```

Configuring the resources separately allows us to avoid the OOMKilled but also not overcommit resources to the long-running Dex server. I've made the change backwards compatible: it will fallback to Dex's resources in case the init container's are not configured.

One note: I've put the resources inside the `initImage` key, however I don't know if it's appropriate. I failed to find a better location though.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
