### PR TITLE
fix(argo-cd): Use ingress crt for dex when enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.7
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.41.0
+version: 5.41.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Make ServiceMonitor deployment conditional on CRD existence
+    - kind: fixed
+      description: Fix SAML auth when using private CA with Ingress

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -303,6 +303,11 @@ spec:
           name: styles
         - mountPath: /tmp
           name: tmp
+        {{- if .Values.server.certificate.enabled -}}
+        - mountPath: /etc/ssl/certs/ingress-ca-certificates.crt
+          name: ingress-ca-certificate
+          subPath: ca.crt
+        {{- end }}
         {{- if .Values.server.extensions.enabled }}
         - mountPath: /tmp/extensions
           name: extensions
@@ -423,17 +428,22 @@ spec:
             path: ca.crt
       - name: argocd-dex-server-tls
         secret:
-          {{- if .Values.server.certificate.enabled -}}
-          secretName: {{ .Values.server.certificate.secretName }}
-          {{- else }}
           secretName: argocd-dex-server-tls
-          {{- end }}
           optional: true
           items:
           - key: tls.crt
             path: tls.crt
           - key: ca.crt
             path: ca.crt
+      {{- if .Values.server.certificate.enabled -}}
+      - name: ingress-ca-certificate
+        secret:
+          secretName: {{ .Values.server.certificate.secretName }}
+          optional: true
+          items:
+            - key: ca.crt
+              path: ca.crt
+      {{- end }}
       {{- if .Values.server.hostNetwork }}
       hostNetwork: {{ .Values.server.hostNetwork }}
       {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -423,7 +423,11 @@ spec:
             path: ca.crt
       - name: argocd-dex-server-tls
         secret:
+          {{- if .Values.server.certificate.enabled -}}
+          secretName: {{ .Values.server.certificate.secretName }}
+          {{- else -}}
           secretName: argocd-dex-server-tls
+          {{- end }}
           optional: true
           items:
           - key: tls.crt

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -425,7 +425,7 @@ spec:
         secret:
           {{- if .Values.server.certificate.enabled -}}
           secretName: {{ .Values.server.certificate.secretName }}
-          {{- else -}}
+          {{- else }}
           secretName: argocd-dex-server-tls
           {{- end }}
           optional: true


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo-helm/issues/2171


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
