### PR TITLE
feat(argo-rollouts): Upgrade Argo Rollouts to v1.5.1

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.5.0
+appVersion: v1.5.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.31.0
+version: 2.31.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Support Traffic Router Plugins
+    - kind: changed
+      description: Update to app version 1.5.1

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -3328,7 +3328,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                   loadBalancer:
@@ -3341,7 +3340,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                   stableTargetGroup:
@@ -3354,7 +3352,6 @@ spec:
                         type: string
                     required:
                     - arn
-                    - fullName
                     - name
                     type: object
                 type: object


### PR DESCRIPTION
Upgrade Argo Rollouts to v1.5.1

release: https://github.com/argoproj/argo-rollouts/releases/tag/v1.5.1

diff: https://github.com/argoproj/argo-rollouts/compare/v1.5.0...v1.5.1

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
