### PR TITLE
chore(github): use table for Emeritus

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -4,9 +4,11 @@ These are the people who have been approvers in the past, and have since retired
 
 We thank them for their service to the project.
 
-* @oliverbaehler
-* @stefansedich
-* @paguos
-* @yann-soubeyrand
-* @davidkarlsen
-* @jbehling
+| Emeritus | GitHub ID |
+| -------- | --------- |
+| Oliver Bähler | [oliverbaehler](https://github.com/oliverbaehler) |
+| Stefan Sedich | [stefansedich](https://github.com/stefansedich) |
+| Pablo Osinaga | [paguos](https://github.com/paguos) |
+| Yann Soubeyrand | [yann-soubeyrand](https://github.com/yann-soubeyrand) |
+| David J. M. Karlsen | [davidkarlsen](https://github.com/davidkarlsen) |
+| John Behling | [jbehling](https://github.com/jbehling) |


### PR DESCRIPTION
## Summary

Use a table to list all Emeritus names and GH usernames

## Details

- matches how [`argoproj` lists Alumni](https://github.com/argoproj/argoproj/blob/6011d3e17300d4b642a1ab5bdb3551c5f6da9021/MAINTAINERS.md?plain=1#L56)
  - IMO, this feels a bit more formal/respectful to me as well than just a username with no link etc, but that's just my opinion
  - though it has more details including role and affiliation. could do that here too, but I don't know what all those are, so left those columns out
     - fortunately everyone's name was listed on their profile, so just copy+paste those! 

- See [Markdown Preview](https://github.com/argoproj/argo-helm/blob/14fdf91e7e3bf6c68b3b2add7c2a3a34f96afea9/EMERITUS.md)
  - confirmed that all profile links work

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [n/a] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [n/a] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [n/a] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [n/a] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
