### PR TITLE
fix(argo-rollouts): Use annotation cont metrics

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -18,7 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update to app version 1.5.1
     - kind: fixed
       description: Fix use prometheus metrics service

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.5.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.31.1
+version: 2.31.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -20,3 +20,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Update to app version 1.5.1
+    - kind: fixed
+      description: Fix use prometheus metrics service

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -91,6 +91,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
 | controller.metricProviderPlugins | object | `{}` | Configures 3rd party metric providers for controller |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
+| controller.metrics.service.annotations | object | `{}` | Service annotations |
 | controller.metrics.service.port | int | `8090` | Metrics service port |
 | controller.metrics.service.portName | string | `"metrics"` | Metrics service port name |
 | controller.metrics.serviceMonitor.additionalAnnotations | object | `{}` | Annotations to be added to the ServiceMonitor |

--- a/charts/argo-rollouts/templates/controller/metrics-service.yaml
+++ b/charts/argo-rollouts/templates/controller/metrics-service.yaml
@@ -7,8 +7,11 @@ metadata:
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}
-  {{- with .Values.serviceAnnotations }}
   annotations:
+  {{- with .Values.serviceAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.controller.metrics.service.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -127,6 +127,8 @@ controller:
       portName: metrics
       # -- Metrics service port
       port: 8090
+      # -- Service annotations
+      annotations: {}
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false


### PR DESCRIPTION
https://argoproj.github.io/argo-rollouts/features/controller-metrics/
according to the current documentation annotations are assigned not only to the argo-rollouts-metrics service but to argo-rollouts-dashboard which is not correct.
```
serviceAnnotations:
  prometheus.io/scrape: "true"
  prometheus.io/path: /metrics
  prometheus.io/port: "8090"
```
result:
```
  # Source: argo-rollouts/templates/dashboard/service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: argo-rollouts-dashboard
    namespace: "argo-cd"
    labels:
      app.kubernetes.io/component: rollouts-dashboard
      helm.sh/chart: argo-rollouts-2.30.1
      app.kubernetes.io/name: argo-rollouts
      app.kubernetes.io/instance: argo-rollouts
      app.kubernetes.io/version: "v1.5.0"
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/part-of: argo-rollouts
    annotations:
+     prometheus.io/path: /metrics
+     prometheus.io/port: "8090"
+     prometheus.io/scrape: "true"
  spec:
    type: ClusterIP
    ports:
    - name: dashboard
      protocol: TCP
      port: 3100
      targetPort: 3100
    selector:
      app.kubernetes.io/component: rollouts-dashboard
      app.kubernetes.io/name: argo-rollouts
      app.kubernetes.io/instance: argo-rollouts
argo-cd, argo-rollouts-metrics, Service (v1) has changed:
  # Source: argo-rollouts/templates/controller/metrics-service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: argo-rollouts-metrics
    namespace: "argo-cd"
    labels:
      app.kubernetes.io/component: rollouts-controller
      helm.sh/chart: argo-rollouts-2.30.1
      app.kubernetes.io/name: argo-rollouts
      app.kubernetes.io/instance: argo-rollouts
      app.kubernetes.io/version: "v1.5.0"
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/part-of: argo-rollouts
+   annotations:
+     prometheus.io/path: /metrics
+     prometheus.io/port: "8090"
+     prometheus.io/scrape: "true"
  spec:
    ports:
    - name: metrics
      protocol: TCP
      port: 8090
      targetPort: metrics
    selector:
      app.kubernetes.io/component: rollouts-controller
      app.kubernetes.io/name: argo-rollouts
      app.kubernetes.io/instance: argo-rollouts
```
corrections are made:
values.yaml
```
controller:
...
  metrics:
    # -- Deploy metrics service
    enabled: false
    service:
      ...
      # -- Service annotations
      annotations: {}
```
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
