### PR TITLE
fix(extra-manifests): fix helm lint error when extraObjecrts is defined

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.5.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.31.2
+version: 2.31.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix use prometheus metrics service
+      description: Fix helm lint error when `extraObjects` is defined

--- a/charts/argo-rollouts/templates/extra-manifests.yaml
+++ b/charts/argo-rollouts/templates/extra-manifests.yaml
@@ -1,6 +1,6 @@
 {{ range .Values.extraObjects }}
 ---
-{{- if typeIs "string" . }}
+{{ if typeIs "string" . }}
     {{- tpl . $ }}
 {{- else }}
     {{- tpl (toYaml .) $ }}


### PR DESCRIPTION
`helm lint` fails when `extraObjects` is defined

Same fix as one done for `argo-cd` #2116

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
