### PR TITLE
fix(argo-cd): Template configuration keys as a string instead of map

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.7.10
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.42.1
+version: 5.42.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo CD to v2.7.10
+    - kind: fixed
+      description: Templates for global presets properly renders keys as a string instead of map

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -162,9 +162,11 @@ Create the name of the notifications service account to use
 Argo Configuration Preset Values (Incluenced by Values configuration)
 */}}
 {{- define "argo-cd.config.cm.presets" -}}
+{{- $presets := dict -}}
 {{- if .Values.configs.styles -}}
-ui.cssurl: "./custom/custom.styles.css"
+{{- $_ := set $presets "ui.cssurl" "./custom/custom.styles.css" -}}
 {{- end -}}
+{{- toYaml $presets }}
 {{- end -}}
 
 {{/*
@@ -183,24 +185,25 @@ Merge Argo Configuration with Preset Configuration
 
 {{/*
 Argo Params Default Configuration Presets
+NOTE: Configuration keys must be stored as dict because YAML treats dot as separator
 */}}
 {{- define "argo-cd.config.params.presets" -}}
-repo.server: "{{ include "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}"
-server.repo.server.strict.tls: {{ .Values.repoServer.certificateSecret.enabled | toString }}
-{{- with include "argo-cd.redis.server" . }}
-redis.server: {{ . | quote }}
-{{- end }}
-{{- if .Values.dex.enabled }}
-server.dex.server: {{ include "argo-cd.dex.server" . | quote }}
-server.dex.server.strict.tls: {{ .Values.dex.certificateSecret.enabled | toString }}
-{{- end }}
-{{- range $component := tuple "applicationsetcontroller" "controller" "server" "reposerver" }}
-{{ $component }}.log.format: {{ $.Values.global.logging.format | quote }}
-{{ $component }}.log.level: {{ $.Values.global.logging.level | quote }}
-{{- end }}
-{{- if .Values.applicationSet.enabled }}
-applicationsetcontroller.enable.leader.election: {{ gt (.Values.applicationSet.replicaCount | int64) 1 }}
-{{- end }}
+{{- $presets := dict -}}
+{{- $_ := set $presets "repo.server" (printf "%s:%s" (include "argo-cd.repoServer.fullname" .) (.Values.repoServer.service.port | toString)) -}}
+{{- $_ := set $presets "server.repo.server.strict.tls" (.Values.repoServer.certificateSecret.enabled | toString ) -}}
+{{- $_ := set $presets "redis.server" (include "argo-cd.redis.server" .) -}}
+{{- if .Values.dex.enabled -}}
+{{- $_ := set $presets "server.dex.server" (include "argo-cd.dex.server" .) -}}
+{{- $_ := set $presets "server.dex.server.strict.tls" .Values.dex.certificateSecret.enabled -}}
+{{- end -}}
+{{- range $component := tuple "applicationsetcontroller" "controller" "server" "reposerver" -}}
+{{- $_ := set $presets (printf "%s.log.format" $component) $.Values.global.logging.format -}}
+{{- $_ := set $presets (printf "%s.log.format" $component) $.Values.global.logging.format -}}
+{{- end -}}
+{{- if .Values.applicationSet.enabled -}}
+{{- $_ := set $presets "applicationsetcontroller.enable.leader.election" (gt (.Values.applicationSet.replicaCount | int64) 1) -}}
+{{- end -}}
+{{- toYaml $presets }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Resolves:

https://github.com/argoproj/argo-helm/issues/2202

Explanation:

Helm treats text value of `repoServer.log.level` and similar keys as a map that will return a false for simple test `{{ hasKey  $presets "repoServer.log.level" }}`. To force correct behaviour items must be stored in the dict before serialization.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
