### PR TITLE
fix(argo-rollouts): Add required ingress permission

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.5.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.31.3
+version: 2.31.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix helm lint error when `extraObjects` is defined
+      description: Add required ingress permission

--- a/charts/argo-rollouts/templates/controller/clusterrole.yaml
+++ b/charts/argo-rollouts/templates/controller/clusterrole.yaml
@@ -135,6 +135,7 @@ rules:
   - get
   - list
   - watch
+  - update
   - patch
 # job access needed for analysis template job metrics
 - apiGroups:

--- a/charts/argo-rollouts/templates/controller/role.yaml
+++ b/charts/argo-rollouts/templates/controller/role.yaml
@@ -136,6 +136,7 @@ rules:
   - get
   - list
   - watch
+  - update
   - patch
 # job access needed for analysis template job metrics
 - apiGroups:


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/2101 🙋 
Following upstream https://github.com/argoproj/argo-rollouts/pull/2933 . 

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
