### PR TITLE
fix(argo-workflows): Server only needs `get` Secrets

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.9
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.32.1
+version: 0.32.2
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for executor args
+    - kind: fixed
+      description: Removed Secrets list and watch from Server RBAC

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -47,7 +47,6 @@ rules:
   - sso
   verbs:
   - get
-  - update
 - apiGroups:
   - ""
   resources:
@@ -71,8 +70,6 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch
 {{- if and .Values.server.sso.enabled .Values.server.sso.rbac.enabled }}
   {{- with .Values.server.sso.rbac.secretWhitelist }}
   resourceNames: {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary

As part of my root cause analysis in https://github.com/argoproj/argo-helm/issues/2159#issuecomment-1646988596, discovered that the Server had some no longer needed RBAC for Secrets

## Details

- as of https://github.com/argoproj/argo-workflows/pull/8555, the Server no longer needs `list` or `watch` and only uses `get`
  - this was released as part of [v3.4.0](https://github.com/argoproj/argo-workflows/blob/master/CHANGELOG.md#v340-rc1-2022-08-09), and the current version of the chart uses [v3.4.9](https://github.com/argoproj/argo-helm/blob/3e35b0c7f7d758d553b17f369cc5940484ef5d89/charts/argo-workflows/Chart.yaml#L2)

- `update` is not needed either for SSO secret
  - [manifests RBAC](https://github.com/argoproj/argo-workflows/blob/a68ea0feabc87c09d5e13d12e6f0d1a61adc5b16/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml#L18)
  - SSO source code only uses [`create`](https://github.com/argoproj/argo-workflows/blob/20d0923611f1df6b7147c3547aeeff6b6bfecf18/server/auth/sso/sso.go#L140) and [`get`](https://github.com/argoproj/argo-workflows/blob/20d0923611f1df6b7147c3547aeeff6b6bfecf18/server/auth/sso/sso.go#L151)
    - (also some `get`s above that for [`clientID`](https://github.com/argoproj/argo-workflows/blob/20d0923611f1df6b7147c3547aeeff6b6bfecf18/server/auth/sso/sso.go#L127) and [`clientSecret`](https://github.com/argoproj/argo-workflows/blob/20d0923611f1df6b7147c3547aeeff6b6bfecf18/server/auth/sso/sso.go#L106) as well)

## Future Work

I'm pretty sure the Secrets RBAC can be further reduced, based on my reading of the code, but that's a bit more risky of a change, so I will split that into follow-ups:

1. `create` can be moved up into the `sso` `resourceNames` `verbs` block. Afaict, it is [only used for the `sso` secret](https://github.com/argoproj/argo-workflows/blob/20d0923611f1df6b7147c3547aeeff6b6bfecf18/server/auth/sso/sso.go#L140)
1. `get` is only needed when SSO is enabled, afaict. Right now it seems to be unconditonal. So can shift the conditionals a bit around.
1. `get` is needed for the SSO `clientSecret`, `clientID`, and `sso` (pending what is used), so the `rbac.secretWhitelist` could unintentionally break that. So should probably split that into a separate block

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [n/a] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [n/a] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
