### PR TITLE
feat(argo-workflows): add configurable liveness+readiness probes to server

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v3.4.9
+appVersion: v3.4.10
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
@@ -16,5 +16,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: added
+      description: Add support for overriding server livenessProbe, readinessProbe
     - kind: added
       description: Add support for executor args

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -277,6 +277,7 @@ Fields to note:
 | server.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | server.ingress.paths | list | `["/"]` | List of ingress paths |
 | server.ingress.tls | list | `[]` | Ingress TLS configuration |
+| server.livenessProbe | object | httpGet on 2746 | Configure liveness [probe] for the server |
 | server.loadBalancerIP | string | `""` | Static IP address to assign to loadBalancer service type `LoadBalancer` |
 | server.loadBalancerSourceRanges | list | `[]` | Source ranges to allow access to service from. Only applies to service type `LoadBalancer` |
 | server.logging.format | string | `"text"` | Set the logging format (one of: `text`, `json`) |
@@ -290,6 +291,7 @@ Fields to note:
 | server.podSecurityContext | object | `{}` | SecurityContext to set on the server pods |
 | server.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages |
 | server.rbac.create | bool | `true` | Adds Role and RoleBinding for the server. |
+| server.readinessProbe | object | httpGet on 2746 | Configure readiness [probe] for the server |
 | server.replicas | int | `1` | The number of server pods to run |
 | server.resources | object | `{}` | Resource limits and requests for the server |
 | server.secure | bool | `false` | Run the argo server in "secure" mode. Configure this value instead of `--secure` in extraArgs. |

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -65,6 +65,23 @@ spec:
           ports:
           - name: web
             containerPort: 2746
+          {{- with .Values.server.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
+          livenessProbe:
+            httpGet:
+              port: 2746
+              path: /healthz
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          {{- end }}
+          {{- with .Values.server.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /
@@ -76,6 +93,7 @@ spec:
               {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 20
+          {{- end }}
           env:
             - name: IN_CLUSTER
               value: "true"

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -406,6 +406,12 @@ server:
     tag: ""
   # -- optional map of annotations to be applied to the ui Deployment
   deploymentAnnotations: {}
+  # -- Configure liveness [probe] for the server
+  # @default -- httpGet on 2746
+  livenessProbe: {}
+  # -- Configure readiness [probe] for the server
+  # @default -- httpGet on 2746
+  readinessProbe: {}
   # -- optional map of annotations to be applied to the ui Pods
   podAnnotations: {}
   # -- Optional labels to add to the UI pods


### PR DESCRIPTION
Adds a sane default `livenessProbe` for `server`, and allows both `livenessProbe` and `readinessProbe` to be overridden from `values.yaml`.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
