### PR TITLE
fix(argo-cd): Add cluster role to allow a namespaced applicationset to be handled by a controller

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Add a cluster role to make namespaced application set controller work.  
+      description: clusterAdminAccess now creates a cluster role for thhe applicationset controller to support multiple namespaces 

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.43.4
+version: 5.43.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Rename comment of repositoryCredentials to credentialTemplates
+      description: Add a cluster role to make namespaced application set controller work.  

--- a/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
-{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
+{{- if .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/argo-cd/templates/argocd-applicationset/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
-{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
+{{- if .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/argo-cd/templates/argocd-applicationset/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "argo-cd.applicationSet.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
+rules:
+  - apiGroups:
+    - argoproj.io
+    resources:
+    - applications
+    - applicationsets
+    verbs:
+    - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "argo-cd.applicationSet.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "argo-cd.applicationSet.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "argo-cd.applicationSetServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- $config := .Values.controller.clusterAdminAccess | default dict -}}
+{{- $config := .Values.applicationSet.clusterRole | default dict -}}
 {{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I recently enabled the name spacing feature of the application controller and ran into the the issue that the application controller couldn't create/read the applications in the required namespace.

Its probably best to add a cluster role for this case?

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
