### PR TITLE
chore(argo-cd): Remove support for autoscaling/v1

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.44.0
+version: 5.45.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,6 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: removed
-      description: Support for cert-manager APIs prior K8s 1.22
+      description: Option apiVersionOverrides.autoscaling as v2 is now GA
+    - kind: removed
+      description: Codebase for autoscaling/v1 API

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -383,7 +383,6 @@ NAME: my-release
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| apiVersionOverrides.autoscaling | string | `""` | String to override apiVersion of autoscaling rendered by this helm chart |
 | apiVersionOverrides.cloudgoogle | string | `""` | String to override apiVersion of GKE resources rendered by this helm chart |
 | crds.additionalLabels | object | `{}` | Addtional labels to be added to all CRDs |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
@@ -572,7 +571,7 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | repoServer.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules to the deployment |
-| repoServer.autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. This is only available on HPA apiVersion `autoscaling/v2beta2` and newer |
+| repoServer.autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. |
 | repoServer.autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler ([HPA]) for the repo server |
 | repoServer.autoscaling.maxReplicas | int | `5` | Maximum number of replicas for the repo server [HPA] |
 | repoServer.autoscaling.metrics | list | `[]` | Configures custom HPA metrics for the Argo CD repo server Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/ |
@@ -670,7 +669,7 @@ NAME: my-release
 | server.GKEmanagedCertificate.domains | list | `["argocd.example.com"]` | Domains for the Google Managed Certificate |
 | server.GKEmanagedCertificate.enabled | bool | `false` | Enable ManagedCertificate custom resource for Google Kubernetes Engine. |
 | server.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules to the deployment |
-| server.autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. This is only available on HPA apiVersion `autoscaling/v2beta2` and newer |
+| server.autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. |
 | server.autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler ([HPA]) for the Argo CD server |
 | server.autoscaling.maxReplicas | int | `5` | Maximum number of replicas for the Argo CD server [HPA] |
 | server.autoscaling.metrics | list | `[]` | Configures custom HPA metrics for the Argo CD server Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/ |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -121,6 +121,9 @@ REMOVED option redis.containerPort - Use redis.containerPorts
 {{- if .Values.redis.metrics.containerPort }}
 REMOVED option redis.metrics.containerPort - Use redis.containerPorts
 {{- end }}
+{{- if .Values.apiVersionOverrides.autoscaling }}
+REMOVED option apiVersionOverrides.autoscaling - API autoscaling/v2 is GA from 1.23
+{{- end }}
 {{- if .Values.apiVersionOverrides.certmanager }}
 REMOVED option apiVersionOverrides.certmanager - API v1 is only possible option after K8s 1.22
 {{- end }}

--- a/charts/argo-cd/templates/_versions.tpl
+++ b/charts/argo-cd/templates/_versions.tpl
@@ -7,20 +7,6 @@ Return the target Kubernetes version
 {{- end }}
 
 {{/*
-Return the appropriate apiVersion for autoscaling
-*/}}
-{{- define "argo-cd.apiVersion.autoscaling" -}}
-{{- if .Values.apiVersionOverrides.autoscaling -}}
-{{- print .Values.apiVersionOverrides.autoscaling -}}
-{{- else if semverCompare "<1.23-0" (include "argo-cd.kubeVersion" .) -}}
-{{- print "autoscaling/v2beta1" -}}
-{{- else -}}
-{{- print "autoscaling/v2" -}}
-{{- end -}}
-{{- end -}}
-
-
-{{/*
 Return the appropriate apiVersion for GKE resources
 */}}
 {{- define "argo-cd.apiVersions.cloudgoogle" -}}

--- a/charts/argo-cd/templates/argocd-repo-server/hpa.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/hpa.yaml
@@ -1,46 +1,38 @@
 {{- if .Values.repoServer.autoscaling.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.autoscaling" . }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  labels:
-    {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" (printf "%s-hpa" .Values.repoServer.name)) | nindent 4 }}
-  name: {{ template "argo-cd.repoServer.fullname" . }}-hpa
+  name: {{ include "argo-cd.repoServer.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "argo-cd.repoServer.fullname" . }}
+    name: {{ include "argo-cd.repoServer.fullname" . }}
   minReplicas: {{ .Values.repoServer.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.repoServer.autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.repoServer.autoscaling.metrics }}
-    {{- toYaml .Values.repoServer.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.repoServer.autoscaling.metrics }}
+    {{- toYaml . | nindent 4 }}
   {{- else }}
-  {{- with .Values.repoServer.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- with .Values.repoServer.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        {{- if eq (include "argo-cd.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
-        targetAverageUtilization: {{ . }}
-        {{- else }}
         target:
-          averageUtilization: {{ . }}
           type: Utilization
-        {{- end }}
-  {{- end }}
-  {{- with .Values.repoServer.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.repoServer.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if eq (include "argo-cd.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
-        targetAverageUtilization: {{ . }}
-        {{- else }}
         target:
-          averageUtilization: {{ . }}
           type: Utilization
-        {{- end }}
-  {{- end }}
+          averageUtilization: {{ . }}
+    {{- end }}
   {{- end }}
   {{- with .Values.repoServer.autoscaling.behavior }}
   behavior:

--- a/charts/argo-cd/templates/argocd-server/hpa.yaml
+++ b/charts/argo-cd/templates/argocd-server/hpa.yaml
@@ -1,47 +1,39 @@
 {{- if .Values.server.autoscaling.enabled }}
-apiVersion: {{ include "argo-cd.apiVersion.autoscaling" . }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  labels:
-    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" (printf "%s-hpa" .Values.server.name)) | nindent 4 }}
-  name: {{ template "argo-cd.server.fullname" . }}-hpa
+  name: {{ include "argo-cd.server.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "argo-cd.server.fullname" . }}
+    name: {{ include "argo-cd.server.fullname" . }}
   minReplicas: {{ .Values.server.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.server.autoscaling.metrics }}
-    {{ toYaml .Values.server.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.server.autoscaling.metrics }}
+    {{- toYaml . | nindent 4 }}
   {{- else }}
-  {{- with .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- with .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        {{- if eq (include "argo-cd.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
-        targetAverageUtilization: {{ . }}
-        {{- else }}
         target:
-          averageUtilization: {{ . }}
           type: Utilization
-        {{- end }}
-  {{- end }}
-  {{- with .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.server.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if eq (include "argo-cd.apiVersion.autoscaling" $) "autoscaling/v2beta1" }}
-        targetAverageUtilization: {{ . }}
-        {{- else }}
         target:
-          averageUtilization: {{ . }}
           type: Utilization
-        {{- end }}
+          averageUtilization: {{ . }}
+    {{- end }}
   {{- end }}
-  {{- end}}
   {{- with .Values.server.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -14,8 +14,6 @@ kubeVersionOverride: ""
 apiVersionOverrides:
   # -- String to override apiVersion of GKE resources rendered by this helm chart
   cloudgoogle: "" # cloud.google.com/v1
-  # -- String to override apiVersion of autoscaling rendered by this helm chart
-  autoscaling: "" # autoscaling/v2
 
 # -- Create aggregated roles that extend existing cluster roles to interact with argo-cd resources
 ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
@@ -1460,7 +1458,6 @@ server:
     # -- Average memory utilization percentage for the Argo CD server [HPA]
     targetMemoryUtilizationPercentage: 50
     # -- Configures the scaling behavior of the target in both Up and Down directions.
-    # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
     behavior: {}
       # scaleDown:
       #  stabilizationWindowSeconds: 300
@@ -2030,7 +2027,6 @@ repoServer:
     # -- Average memory utilization percentage for the repo server [HPA]
     targetMemoryUtilizationPercentage: 50
     # -- Configures the scaling behavior of the target in both Up and Down directions.
-    # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
     behavior: {}
       # scaleDown:
       #  stabilizationWindowSeconds: 300


### PR DESCRIPTION
API version autoscaling/v2 is GA since 1.23 which is now minimum K8s version. We can safely remove this backward compatibility feature as no longer needed.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
