### PR TITLE
chore(argo-cd): Remove support for legacy cert-manager APIs

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.43.9
+version: 5.44.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.43.8
+version: 5.43.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade redis-exporter to 1.53.0
+    - kind: removed
+      description: Support for cert-manager APIs prior K8s 1.22

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -384,7 +384,6 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiVersionOverrides.autoscaling | string | `""` | String to override apiVersion of autoscaling rendered by this helm chart |
-| apiVersionOverrides.certmanager | string | `""` | String to override apiVersion of cert-manager resources rendered by this helm chart |
 | apiVersionOverrides.cloudgoogle | string | `""` | String to override apiVersion of GKE resources rendered by this helm chart |
 | crds.additionalLabels | object | `{}` | Addtional labels to be added to all CRDs |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -121,6 +121,9 @@ REMOVED option redis.containerPort - Use redis.containerPorts
 {{- if .Values.redis.metrics.containerPort }}
 REMOVED option redis.metrics.containerPort - Use redis.containerPorts
 {{- end }}
+{{- if .Values.apiVersionOverrides.certmanager }}
+REMOVED option apiVersionOverrides.certmanager - API v1 is only possible option after K8s 1.22
+{{- end }}
 
 In order to access the server UI you have the following options:
 

--- a/charts/argo-cd/templates/_versions.tpl
+++ b/charts/argo-cd/templates/_versions.tpl
@@ -19,24 +19,6 @@ Return the appropriate apiVersion for autoscaling
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for cert-manager
-*/}}
-{{- define "argo-cd.apiVersion.cert-manager" -}}
-{{- if .Values.apiVersionOverrides.certmanager -}}
-{{- print .Values.apiVersionOverrides.certmanager -}}
-{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1" -}}
-{{- print "cert-manager.io/v1" -}}
-{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1beta1" -}}
-{{- print "cert-manager.io/v1beta1" -}}
-{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha3" -}}
-{{- print "cert-manager.io/v1alpha3" -}}
-{{- else if .Capabilities.APIVersions.Has "cert-manager.io/v1alpha2" -}}
-{{- print "cert-manager.io/v1alpha2" -}}
-{{- else -}}
-{{- print "certmanager.k8s.io/v1alpha1" -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Return the appropriate apiVersion for GKE resources

--- a/charts/argo-cd/templates/argocd-applicationset/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.applicationSet.certificate.enabled -}}
-apiVersion: {{ include "argo-cd.apiVersion.cert-manager" . }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   {{- with (mergeOverwrite (deepCopy .Values.global.certificateAnnotations) .Values.applicationSet.certificate.annotations) }}

--- a/charts/argo-cd/templates/argocd-server/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-server/certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.certificate.enabled -}}
-apiVersion: {{ include "argo-cd.apiVersion.cert-manager" . }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   {{- with (mergeOverwrite (deepCopy .Values.global.certificateAnnotations) .Values.server.certificate.annotations) }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -12,8 +12,6 @@ kubeVersionOverride: ""
 # If you want to template helm charts but cannot access k8s API server
 # you can set api versions here
 apiVersionOverrides:
-  # -- String to override apiVersion of cert-manager resources rendered by this helm chart
-  certmanager: "" # cert-manager.io/v1
   # -- String to override apiVersion of GKE resources rendered by this helm chart
   cloudgoogle: "" # cloud.google.com/v1
   # -- String to override apiVersion of autoscaling rendered by this helm chart


### PR DESCRIPTION
It's no longer possible to install older cert-manager as beta version of CRD were removed in K8s 1.22

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
