### PR TITLE
fix(argo-cd): Update values.yaml - update custom css styles side bar example

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,7 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: removed
-      description: Option apiVersionOverrides.autoscaling as v2 is now GA
-    - kind: removed
-      description: Codebase for autoscaling/v1 API
+    - kind: fixed
+      description: fixed example for configs.styles to be sidebar instead of nav-bar

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.45.0
+version: 5.45.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -539,7 +539,7 @@ configs:
   ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/custom-styles/
   styles: ""
   # styles: |
-  #  .nav-bar {
+  #  .sidebar {
   #    background: linear-gradient(to bottom, #999, #777, #333, #222, #111);
   #  }
 


### PR DESCRIPTION
.nav-bar is no longer the css class name. Found used the inspect tool in firefox:
<img width="1287" alt="Screenshot 2023-09-01 at 00 22 25" src="https://github.com/argoproj/argo-helm/assets/2389292/44cd18bd-324d-48e3-9f43-cb4ec78ec529">

Last tested in Argo CD v2.8.2+dbdfc71

Update: realized it's already updated in the docs here: https://argo-cd.readthedocs.io/en/stable/operator-manual/custom-styles/

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
