### PR TITLE
feat(argo-cd): adds toggle for helm-working-dir

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.45.5
+version: 5.46.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Documented scheduling parameters for redis-ha
+      description: added a toggle for the shared Helm working directory

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -655,6 +655,7 @@ NAME: my-release
 | repoServer.serviceAccount.name | string | `""` | Repo server service account name |
 | repoServer.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | repoServer.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the repo server |
+| repoServer.useEphemeralHelmWorkingDir | bool | `true` | Toggle the usage of a ephemeral Helm working directory |
 | repoServer.volumeMounts | list | `[]` | Additional volumeMounts to the repo server main container |
 | repoServer.volumes | list | `[]` | Additional volumes to the repo server pod |
 

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -231,12 +231,14 @@ spec:
                 key: reposerver.enable.git.submodule
                 name: argocd-cmd-params-cm
                 optional: true
+          {{- if .Values.repoServer.useEphemeralHelmWorkingDir }}
           - name: HELM_CACHE_HOME
             value: /helm-working-dir
           - name: HELM_CONFIG_HOME
             value: /helm-working-dir
           - name: HELM_DATA_HOME
             value: /helm-working-dir
+          {{- end }}
         {{- with .Values.repoServer.envFrom }}
         envFrom:
           {{- toYaml . | nindent 10 }}
@@ -255,8 +257,10 @@ spec:
           name: gpg-keyring
         - mountPath: /app/config/reposerver/tls
           name: argocd-repo-server-tls
+        {{- if .Values.repoServer.useEphemeralHelmWorkingDir }}
         - mountPath: /helm-working-dir
           name: helm-working-dir
+        {{- end }}
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
         - mountPath: /tmp
@@ -349,8 +353,10 @@ spec:
       {{- with .Values.repoServer.volumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.repoServer.useEphemeralHelmWorkingDir }}
       - name: helm-working-dir
         emptyDir: {}
+      {{- end }}
       - name: plugins
         emptyDir: {}
       - name: var-files

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2177,6 +2177,9 @@ repoServer:
   #  - name: cmp-tmp
   #    emptyDir: {}
 
+  # -- Toggle the usage of a ephemeral Helm working directory
+  useEphemeralHelmWorkingDir: true
+
   # -- Annotations to be added to repo server Deployment
   deploymentAnnotations: {}
 


### PR DESCRIPTION
- Adds a toggle to be able to turn off the helm-working-dir for the repo server deployment. Using a shared helm repo storage directory can cause issues when multiple helm commands are being run in parallel. The repo server also has the ability to rebuild the repos and do updates in the normal flow for checking the status of an application so it won't cause issues if it's disabled.

We've been having issues with collisions happening in the shared helm-working-dir and with the index.yaml file being empty when read by one of the processes. The repo server code is setup to rebuild the repo and do a chart build for each templating run for us so it makes more sense to allow it to utilize the temporary space. I didn't want to remove it for everyone so I made the default to enabled with the option to disable it. Since testing this change in one of our environments we've had no issues with services consistently entering the Unknown state.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
