### PR TITLE
fix(argo-cd): Make the PathType configurable when using single ingress resource in AWS

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.45.1
+version: 5.45.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: fixed example for configs.styles to be sidebar instead of nav-bar
+      description: do not hardcode the pathtype of the grpc ingress rule when using a single ingress resource in aws alb

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -39,7 +39,7 @@ spec:
           {{- range $p := $paths }}
           {{- if and $.Values.server.ingressGrpc.isAWSALB $.Values.server.ingressGrpc.enabled }}
           - path: {{ $p }}
-            pathType: Prefix
+            pathType: {{ .Values.server.ingressGrpc.pathType }}
             backend:
               service:
                 name: {{ template "argo-cd.server.fullname" $ }}-grpc

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -39,7 +39,7 @@ spec:
           {{- range $p := $paths }}
           {{- if and $.Values.server.ingressGrpc.isAWSALB $.Values.server.ingressGrpc.enabled }}
           - path: {{ $p }}
-            pathType: {{ .Values.server.ingressGrpc.pathType }}
+            pathType: {{ $.Values.server.ingressGrpc.pathType }}
             backend:
               service:
                 name: {{ template "argo-cd.server.fullname" $ }}-grpc


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
