### PR TITLE
fix(argo-cd): Add applicationsets resource to argocd-server cluster role

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.45.3
+version: 5.45.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade Argo CD to v2.8.3
+    - kind: fixed
+      description: argocd-server ClusterRole also grants applicationsets permissions

--- a/charts/argo-cd/templates/argocd-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrole.yaml
@@ -40,6 +40,9 @@ rules:
       - argoproj.io
     resources:
       - applications
+      {{- if .Values.applicationSet.enabled }}
+      - applicationsets
+      {{- end }}
     verbs:
       - get
       - list


### PR DESCRIPTION
argocd-server tries to list applicationsets accross all the cluster in v2.8:
```
argocd appset list
WARN[0000] Failed to invoke grpc call. Use flag --grpc-web in grpc calls. To avoid this warning message, use flag --grpc-web.
FATA[0000] rpc error: code = PermissionDenied desc = error listing ApplicationSets with selectors: applicationsets.argoproj.io is forbidden: User "system:serviceaccount:argocd:argocd-server" cannot list resource "applicationsets" in API group "argoproj.io" at the cluster scope
```

That permission is granted within the argo namespace but is missing in the cluster role. This PR adds it to the cluster role

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
