### PR TITLE
fix(argo-cd): make ServiceMonitor annotations in ArgoCD server conditional

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Align redis-ha's affinity type to upstream due to warnings
+      description: fixed issue with argocd-server servicemonitor annotation attribute being added even when no annotations where defined

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.4
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.46.4
+version: 5.46.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -12,10 +12,10 @@ metadata:
     {{- with .Values.server.metrics.serviceMonitor.additionalLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.server.metrics.serviceMonitor.annotations }}
   annotations:
-    {{- range $key, $value := .Values.server.metrics.serviceMonitor.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - port: {{ .Values.server.metrics.service.portName }}


### PR DESCRIPTION
Currently, if no annotations are specified, ArgoCD will want to sync a resource with annotations: null in there, which is automatically removed by the API server. The rest of the services from ArgoCD do not have this issue, since the annotations attribute itself is conditional to annotations being there.

This applies the same change to ArgoCD server.

Prevents this:

<img width="1468" alt="image" src="https://github.com/argoproj/argo-helm/assets/60099717/d1ae9343-3544-4a02-98c2-d63d12aa9c6f">


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
