### PR TITLE
Update _helpers.tpl to include pdb.apiversion

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.4
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.46.5
+version: 5.46.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -207,6 +207,14 @@ NOTE: Configuration keys must be stored as dict because YAML treats dot as separ
 {{- end -}}
 
 {{/*
+Use correct pdb version
+*/}}
+{{- define "argo-cd.podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "argo-cd.kubeVersion" $) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+
+{{/*
 Merge Argo Params Configuration with Preset Configuration
 */}}
 {{- define "argo-cd.config.params" -}}


### PR DESCRIPTION
refrenced in template but missing in helpers

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
