### PR TITLE
chore(argo-cd): Upgrade Argo CD to v2.8.5

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v2.8.4
+appVersion: v2.8.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.47.0
+version: 5.48.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: add terminationGracePeriodSeconds
+    - kind: changed
+      description: Upgrade Argo CD to v2.8.5

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -78,11 +78,17 @@ spec:
                 configMapKeyRef:
                   key: notificationscontroller.log.level
                   name: argocd-cmd-params-cm
-                  optional: true              
+                  optional: true
             - name: ARGOCD_NOTIFICATIONS_CONTROLLER_LOGFORMAT
               valueFrom:
                 configMapKeyRef:
                   key: notificationscontroller.log.format
+                  name: argocd-cmd-params-cm
+                  optional: true
+            - name: ARGOCD_APPLICATION_NAMESPACES
+              valueFrom:
+                configMapKeyRef:
+                  key: application.namespaces
                   name: argocd-cmd-params-cm
                   optional: true
           {{- with .Values.notifications.extraEnvFrom }}


### PR DESCRIPTION
release not: https://github.com/argoproj/argo-cd/releases/tag/v2.8.5
diff: https://github.com/argoproj/argo-cd/compare/v2.8.4...v2.8.5

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
