### PR TITLE
feat(argo-cd): add notification cluster role

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.8.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.48.1
+version: 5.49.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update Bitbucket.org SSH key
+    - kind: added
+      description: Add notification cluster role support

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1160,7 +1160,6 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 |-----|------|---------|-------------|
 | notifications.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules |
 | notifications.argocdUrl | string | `nil` | Argo CD dashboard url; used in place of {{.context.argocdUrl}} in templates |
-| notifications.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the notifications controller's ClusterRole resource |
 | notifications.clusterRoleRules.rules | list | `[]` | List of custom rules for the notifications controller's ClusterRole resource |
 | notifications.cm.create | bool | `true` | Whether helm chart creates notifications controller config map |
 | notifications.containerPorts.metrics | int | `9001` | Metrics container port |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1160,6 +1160,8 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 |-----|------|---------|-------------|
 | notifications.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules |
 | notifications.argocdUrl | string | `nil` | Argo CD dashboard url; used in place of {{.context.argocdUrl}} in templates |
+| notifications.clusterRoleRules.enabled | bool | `false` | Enable custom rules for the notifications controller's ClusterRole resource |
+| notifications.clusterRoleRules.rules | list | `[]` | List of custom rules for the notifications controller's ClusterRole resource |
 | notifications.cm.create | bool | `true` | Whether helm chart creates notifications controller config map |
 | notifications.containerPorts.metrics | int | `9001` | Metrics container port |
 | notifications.containerSecurityContext | object | See [values.yaml] | Notification controller container-level security Context |

--- a/charts/argo-cd/templates/argocd-notifications/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
   {{- with .Values.notifications.clusterRoleRules.rules }}
     {{- toYaml . | nindent 2 }}
-  {{- else }}
+  {{- end }}
   - apiGroups:
     - "argoproj.io"
     resources:
@@ -19,5 +19,4 @@ rules:
     - watch
     - update
     - patch
-  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.createClusterRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "argo-cd.notifications.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
+rules:
+  {{- with .Values.notifications.clusterRoleRules.rules }}
+    {{- toYaml . | nindent 2 }}
+  {{- else }}
+  - apiGroups:
+    - "argoproj.io"
+    resources:
+    - "applications"
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- $config := .Values.notifications.clusterAdminAccess | default dict -}}
-{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
+{{- if .Values.createClusterRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/argo-cd/templates/argocd-notifications/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- $config := .Values.notifications.clusterAdminAccess | default dict -}}
+{{- if hasKey $config "enabled" | ternary $config.enabled .Values.createClusterRoles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "argo-cd.notifications.fullname" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "argo-cd.notifications.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "argo-cd.notificationsServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2997,6 +2997,12 @@ notifications:
     # -- Whether helm chart creates notifications controller config map
     create: true
 
+  ## Enable this and set the rules: to whatever custom rules you want for the Cluster Role resource.
+  ## Defaults to off
+  clusterRoleRules:
+    # -- List of custom rules for the notifications controller's ClusterRole resource
+    rules: []
+
   # -- Contains centrally managed global application subscriptions
   ## For more information: https://argocd-notifications.readthedocs.io/en/stable/subscriptions/
   subscriptions: []


### PR DESCRIPTION
Closes #2319
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->


Based on this commit from upstream https://github.com/argoproj/argo-cd/compare/v2.8.4...v2.8.5#diff-9b67c714fa7e685352f63e4cd04d71a150f195f1363d5311de1a2c30dff40c14. after upgrading to 2.8.5, notif controller started to error with:

```
message:E1029 16:48:32.856047 7 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.2/tools/cache/reflector.go:167: Failed to watch *unstructured.Unstructured: failed to list *unstructured.Unstructured: failed to list applications: applications.argoproj.io is forbidden: User "system:serviceaccount:argocd-prod:argocd-notifications-controller" cannot list resource "applications" in API group "argoproj.io" at the cluster scope
```