### PR TITLE
fix(github): update chart testing action due to failure

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Setup Chart Linting
         id: lint
-        uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # v2.6.0
         with:
           # Note: Also update in scripts/lint.sh
-          version: v3.7.1
+          version: v3.10.0
 
       - name: List changed charts
         id: list-changed

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,7 +9,7 @@ echo -e "\n-- Linting all Helm Charts --\n"
 docker run \
      -v "$SRCROOT:/workdir" \
      --entrypoint /bin/sh \
-     quay.io/helmpack/chart-testing:v3.7.1 \
+     quay.io/helmpack/chart-testing:v3.10.0 \
      -c cd /workdir \
      ct lint \
      --config .github/configs/ct-lint.yaml \


### PR DESCRIPTION
Getting failure when running chart testing action pulling v2.0.0 from sigstore

Updating action to see if this helps

Error [here](https://github.com/argoproj/argo-helm/actions/runs/6709281657/job/18232558679)

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
