### PR TITLE
chore(github): Add yu-cruco to * in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,6 @@
-# All
-*                              @mkilchhofer @jmeridth
+* @mkilchhofer @jmeridth @yu-croco
 
-# Argo Workflows
 /charts/argo-workflows/        @vladlosev @jmeridth @yu-croco @tico24
-
-# Argo CD
 /charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil @tico24
-
-# Argo Events
 /charts/argo-events/           @pdrastil @jmeridth @tico24
-
-# Argo Rollouts
 /charts/argo-rollouts/         @jmeridth


### PR DESCRIPTION
yu-cruco is now a maintainer and will be notified on all PRs

- [x] moved CODEOWNERS into .github folder where it belongs IMO
- [x] simplify CODEOWNERS (folder names == projects)

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
