### PR TITLE
chore(argo-workflows): Remove xip url from test to avoid confusion

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.39.2
+version: 0.39.3
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v3.5.1
+appVersion: v3.5.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Align version label
+    - kind: changed
+      description: Modify test host url to avoid user confusion

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v3.5.2
+appVersion: v3.5.1
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application

--- a/charts/argo-workflows/ci/enable-ingress-values.yaml
+++ b/charts/argo-workflows/ci/enable-ingress-values.yaml
@@ -5,4 +5,4 @@ server:
   ingress:
     enabled: true
     hosts:
-      - argo-workflows.myorg.biz
+      - argo-workflows.example.com

--- a/charts/argo-workflows/ci/enable-ingress-values.yaml
+++ b/charts/argo-workflows/ci/enable-ingress-values.yaml
@@ -5,4 +5,4 @@ server:
   ingress:
     enabled: true
     hosts:
-      - argo-workflows.127.0.0.1.xip.io
+      - argo-workflows.myorg.biz


### PR DESCRIPTION
The presence of a xip.io url was confusing to some inexperienced users who thought it a legitimate URL to use to set up Argo Workflows.

To compound matters, xip.io has been offline for a while, so it's evident that the tests don't actually make use of the URL anyway.

This PR changes the url to a placeholder to reduce the confusion.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
