### PR TITLE
feat(github): Use renovate to create PRs when upstream releases

### DIFF
--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -8,6 +8,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: write
+
 jobs:
   helm-bumper:
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'renovate')) }}

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -16,12 +16,12 @@ jobs:
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'renovate')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v40
+        uses: tj-actions/changed-files@https://github.com/tj-actions/changed-files/commit/1c938490c880156b746568a518594309cfb3f66b # v40.2.1
         with:
           files: charts/{argo-workflows,argo-cd,argo-events,argo-rollouts,argocd-image-updater}/Chart.yaml
       - name: "Bump Version and Changelog"
@@ -48,6 +48,6 @@ jobs:
           echo "      description: Bump ${chartName} to ${appVersion}" >> ${parentDir}/Chart.yaml
           cat ${parentDir}/Chart.yaml
       - name: "Commit and push changes"
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
         with:
           commit_options: '--signoff'

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -38,7 +38,7 @@ jobs:
           minor=$(echo $version | cut -d. -f2)
           patch=$(echo $version | cut -d. -f3)
           patch=$(expr $patch + 1)
-          sed -i "s/^version:.*/version: v${major}.${minor}.${patch}/g" ${parentDir}/Chart.yaml
+          sed -i "s/^version:.*/version: ${major}.${minor}.${patch}/g" ${parentDir}/Chart.yaml
 
           # Add a changelog entry
           appVersion=$(grep '^appVersion:' ${parentDir}/Chart.yaml | awk '{print $2}')

--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -1,0 +1,50 @@
+## Used on Renovate PRs to bump the chart version and add a changelog entry
+## Reference: https://github.com/stefanzweifel/git-auto-commit-action
+## Reference: https://github.com/marketplace/actions/changed-files
+name: 'Chart Version Bump and Changelog'
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  helm-bumper:
+    if: ${{ (contains(github.event.pull_request.labels.*.name, 'renovate')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+        with:
+          files: charts/{argo-workflows,argo-cd,argo-events,argo-rollouts,argocd-image-updater}/Chart.yaml
+      - name: "Bump Version and Changelog"
+        run: |
+          chartName="$(echo \"${{ steps.changed-files.outputs.all_changed_files }}\" | cut -d '/' -f2)"
+          echo "Changed chart name is: $chartName"
+          echo "----------------------------------------"
+
+          parentDir="charts/${chartName}"
+
+          # Bump the chart version by one patch version
+          version=$(grep '^version:' ${parentDir}/Chart.yaml | awk '{print $2}')
+          major=$(echo $version | cut -d. -f1)
+          minor=$(echo $version | cut -d. -f2)
+          patch=$(echo $version | cut -d. -f3)
+          patch=$(expr $patch + 1)
+          sed -i "s/^version:.*/version: v${major}.${minor}.${patch}/g" ${parentDir}/Chart.yaml
+
+          # Add a changelog entry
+          appVersion=$(grep '^appVersion:' ${parentDir}/Chart.yaml | awk '{print $2}')
+          sed -i -e '/^  artifacthub.io\/changes: |/,$d' ${parentDir}/Chart.yaml
+          echo "  artifacthub.io/changes: |" >> ${parentDir}/Chart.yaml
+          echo "    - kind: changed" >> ${parentDir}/Chart.yaml
+          echo "      description: Bump ${chartName} to ${appVersion}" >> ${parentDir}/Chart.yaml
+          cat ${parentDir}/Chart.yaml
+      - name: "Commit and push changes"
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_options: '--signoff'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "kubernetes": {
+    "fileMatch": ["\\.yaml$", "\\.yml$"]
+  },
+  "extends": [
+    "config:base",
+    "docker:enableMajor"
+  ],
+  "labels": ["renovate"],
+  "includePaths": [
+    "**/charts/argo-workflows/Chart.yaml",
+    "**/charts/argo-cd/Chart.yaml",
+    "**/charts/argo-events/Chart.yaml",
+    "**/charts/argo-rollouts/Chart.yaml",
+    "**/charts/argocd-image-updater/Chart.yaml"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["charts/argo-workflows/Chart.yaml$"],
+      "matchStrings": [
+        "\\sappVersion: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "depNameTemplate": "argoproj/argo-workflows",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["charts/argo-cd/Chart.yaml$"],
+      "matchStrings": [
+        "\\sappVersion: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "depNameTemplate": "argoproj/argo-cd",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["charts/argo-events/Chart.yaml$"],
+      "matchStrings": [
+        "\\sappVersion: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "depNameTemplate": "argoproj/argo-events",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["charts/argo-rollouts/Chart.yaml$"],
+      "matchStrings": [
+        "\\sappVersion: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "depNameTemplate": "argoproj/argo-rollouts",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["charts/argocd-image-updater/Chart.yaml$"],
+      "matchStrings": [
+        "\\sappVersion: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "depNameTemplate": "argoproj-labs/argocd-image-updater",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["argoproj/argo-workflows"],
+      "commitMessagePrefix": "chore(argo-workflows):"
+    },
+    {
+      "matchPackagePatterns": ["argoproj/argo-cd"],
+      "commitMessagePrefix": "chore(argo-cd):"
+    },
+    {
+      "matchPackagePatterns": ["argoproj/argo-events"],
+      "commitMessagePrefix": "chore(argo-events):"
+    },
+    {
+      "matchPackagePatterns": ["argoproj/argo-rollouts"],
+      "commitMessagePrefix": "chore(argo-rollouts):"
+    },
+    {
+      "matchPackagePatterns": ["argoproj-labs/argocd-image-updater"],
+      "commitMessagePrefix": "chore(argocd-image-updater):"
+    },
+    {
+      "matchPackagePatterns": ["redis-ha"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

oh boy..

So bad news first. this won't "just work". Someone with repo permissions will need to set up renovate, and probably polish off the final step of the github action (the one that pushes the changes back to the PR).z

Renovate should be available as an app for the repo, it was enabled for all argoproj projects to my knowedge.

## What's all this then?

When set up, renovate will
- create a PR whenever an upstream project releases something.
- create the PR title in a format friendly to our linter
- bump the chart version by +1 patch version
- update the release notes

it won't:
- Hunt for any changes in the upstream release (eg crd changes). You'll have to check out the branch and add to it.
- automerge the pr into main
- bump the chart version more than once (unless you add and remove labels from the PR, but you're not gonna do that.. right?)

Renovate is only set to look at the Chart.yaml files. Here's all the dependencies it sees:
![image](https://github.com/argoproj/argo-helm/assets/45351296/1e52a9f5-8b04-4f56-a9d1-37252ccf0ba5)

(You can see in the above screenshot that it wants to bump workflows up a version.. I was using that for testing).


`redis-ha` is disabled to prevent PRs appearing that will bump it above upstream.

Once this is in, I'd strongly suggest enabling renovate on the `.github` directory. Some actions are out of date.


Here's a screenshot of a test PR. All of this was automated:

![image](https://github.com/argoproj/argo-helm/assets/45351296/19e34890-6627-4880-bd58-ae244e6724a5)



Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
