### PR TITLE
fix(argo-rollouts): Update all rollout CRDs to match upstream

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.32.4
+version: 2.32.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade Argo Rollouts to v1.6.2
+      description: Upgrade Argo Rollouts CRDs to match them mainstream from v1.6.2

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -185,13 +185,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2805,6 +2814,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2853,6 +2875,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -185,13 +185,22 @@ spec:
                         datadog:
                           properties:
                             apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
                               type: string
                             interval:
+                              default: 5m
                               type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
                             query:
                               type: string
-                          required:
-                          - query
                           type: object
                         graphite:
                           properties:
@@ -2805,6 +2814,19 @@ spec:
                               type: string
                             authentication:
                               properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
                                 sigv4:
                                   properties:
                                     profile:
@@ -2853,6 +2875,31 @@ spec:
                           type: object
                         web:
                           properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
                             body:
                               type: string
                             headers:


### PR DESCRIPTION
Apparently this PR https://github.com/argoproj/argo-helm/pull/2320/files fixed only `AnalysisRun` spec, but we have more changes in the mainstream.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
