### PR TITLE
chore(argo-rollouts): Update dependency argoproj/argo-rollouts to v1.6.3

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.6.2
+appVersion: v1.6.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.32.5
+version: 2.32.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade Argo Rollouts CRDs to match them mainstream from v1.6.2
+      description: Bump argo-rollouts to v1.6.3


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This was actually found by renovate during my testing of #2358, so I figured I should at least raise the PR.

Nothing breaking upstream that I could see: https://github.com/argoproj/argo-rollouts/compare/v1.6.2...v1.6.3

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
