### PR TITLE
chore(github): Add yu-croco to CODEOWNERS of argo-events and argo-rollouts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 
 /charts/argo-workflows/        @vladlosev @jmeridth @yu-croco @tico24
 /charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil @tico24
-/charts/argo-events/           @pdrastil @jmeridth @tico24
-/charts/argo-rollouts/         @jmeridth
+/charts/argo-events/           @pdrastil @jmeridth @tico24 @yu-croco
+/charts/argo-rollouts/         @jmeridth @yu-croco


### PR DESCRIPTION
Hello world.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
