### PR TITLE
fix(github): Copy-pasta error on Action digest

### DIFF
--- a/.github/workflows/chart-version-bump.yml
+++ b/.github/workflows/chart-version-bump.yml
@@ -19,11 +19,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@https://github.com/tj-actions/changed-files/commit/1c938490c880156b746568a518594309cfb3f66b # v40.2.1
+        uses: tj-actions/changed-files@1c938490c880156b746568a518594309cfb3f66b # v40.2.1
         with:
           files: charts/{argo-workflows,argo-cd,argo-events,argo-rollouts,argocd-image-updater}/Chart.yaml
+
       - name: "Bump Version and Changelog"
         run: |
           chartName="$(echo \"${{ steps.changed-files.outputs.all_changed_files }}\" | cut -d '/' -f2)"
@@ -47,6 +49,7 @@ jobs:
           echo "    - kind: changed" >> ${parentDir}/Chart.yaml
           echo "      description: Bump ${chartName} to ${appVersion}" >> ${parentDir}/Chart.yaml
           cat ${parentDir}/Chart.yaml
+
       - name: "Commit and push changes"
         uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # v5.0.0
         with:


### PR DESCRIPTION
@tico24 my digest proposal in PR #2358 was wrong :/

> ![my bad proof](https://github.com/argoproj/argo-helm/assets/7290987/2b7f59b1-1b25-48b7-86db-d464eced4cf2)


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
