### PR TITLE
fix(argo-workflows): fix helm lint error when extraObjects is defined

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.39.8
+version: 0.39.9
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Add support for sso filterGroupsRegex according to https://argoproj.github.io/argo-workflows/argo-server-sso/#filtering-groups
+      description: fix(argo-workflows): fix helm lint error when extraObjects is defined and same fix as one done for argo-cd #2116

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: fix(argo-workflows): fix helm lint error when extraObjects is defined and same fix as one done for argo-cd #2116
+      description: "fix(argo-workflows): fix helm lint error when extraObjects is defined and same fix as one done for argo-cd #2116"

--- a/charts/argo-workflows/templates/extra-manifests.yaml
+++ b/charts/argo-workflows/templates/extra-manifests.yaml
@@ -1,6 +1,6 @@
 {{ range .Values.extraObjects }}
 ---
-{{- if typeIs "string" . }}
+{{ if typeIs "string" . }}
     {{- tpl . $ }}
 {{- else }}
     {{- tpl (toYaml .) $ }}


### PR DESCRIPTION
Signed-off-by: workwithprashant <60788667+workwithprashant@users.noreply.github.com>

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
