### PR TITLE
fix(argo-workflows): Remove duplication in aggregated admin ClusterRole

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.40.0
+version: 0.40.1
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: "feat(argo-workflows): add hostAliases to server"
+    - kind: fixed
+      description: "Remove duplication in aggregated admin ClusterRole"

--- a/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-aggregate-roles.yaml
@@ -83,8 +83,6 @@ rules:
   - workflows/finalizers
   - workfloweventbindings
   - workfloweventbindings/finalizers
-  - workflowtasksets
-  - workflowtasksets/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows


### PR DESCRIPTION
The `workflowtasksets` and `workflowtasksets/finalizers` resources are duplicated in the aggregated admin ClusterRole. This PR simply removes the duplication.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
