### PR TITLE
Make the configmap and sshconfigmap names configurable

### DIFF
--- a/charts/argocd-image-updater/templates/configmap-sshconfig.yaml
+++ b/charts/argocd-image-updater/templates/configmap-sshconfig.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
-  name: argocd-image-updater-ssh-config
+  name: {{ .Values.sshConfigName }}
   namespace: {{ .Release.Namespace | quote }}
 data:
   {{- with .Values.config.sshConfig }}

--- a/charts/argocd-image-updater/templates/configmap.yaml
+++ b/charts/argocd-image-updater/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
-  name: argocd-image-updater-config
+  name: {{ .Values.configName }}
   namespace: {{ .Release.Namespace | quote }}
 data:
   {{- with .Values.config.applicationsAPIKind }}

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -45,31 +45,31 @@ spec:
             valueFrom:
               configMapKeyRef:
                 key: applications_api
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: ARGOCD_GRPC_WEB
             valueFrom:
               configMapKeyRef:
                 key: argocd.grpc_web
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: ARGOCD_SERVER
             valueFrom:
               configMapKeyRef:
                 key: argocd.server_addr
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: ARGOCD_INSECURE
             valueFrom:
               configMapKeyRef:
                 key: argocd.insecure
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: ARGOCD_PLAINTEXT
             valueFrom:
               configMapKeyRef:
                 key: argocd.plaintext
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: ARGOCD_TOKEN
             valueFrom:
@@ -81,25 +81,25 @@ spec:
             valueFrom:
               configMapKeyRef:
                 key: log.level
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: GIT_COMMIT_USER
             valueFrom:
               configMapKeyRef:
                 key: git.user
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: GIT_COMMIT_EMAIL
             valueFrom:
               configMapKeyRef:
                 key: git.email
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           - name: IMAGE_UPDATER_KUBE_EVENTS
             valueFrom:
               configMapKeyRef:
                 key: kube.events
-                name: argocd-image-updater-config
+                name: {{ .Values.configName }}
                 optional: true
           {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 10 }}
@@ -152,7 +152,7 @@ spec:
             path: registries.conf
           - key: git.commit-message-template
             path: commit.template
-          name: argocd-image-updater-config
+          name: {{ .Values.configName }}
           optional: true
         name: image-updater-conf
       {{- if .Values.authScripts.enabled }}
@@ -168,7 +168,7 @@ spec:
           optional: true
         name: ssh-known-hosts
       - configMap:
-          name: argocd-image-updater-ssh-config
+          name: {{ .Values.sshConfigName }}
           optional: true
         name: ssh-config
       {{- with .Values.volumes }}

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -18,6 +18,9 @@ nameOverride: ""
 # -- Global fullname (argocd-image-updater.fullname in _helpers.tpl) override
 fullnameOverride: ""
 
+configName: argocd-image-updater-config
+sshConfigName: argocd-image-updater-ssh-config
+
 # -- Extra arguments for argocd-image-updater not defined in `config.argocd`.
 # If a flag contains both key and value, they need to be split to a new entry
 extraArgs: []


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
