### PR TITLE
fix(argo-workflows): Prevent extra whitespace in controller ConfigMap

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.40.1
+version: 0.40.2
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Remove duplication in aggregated admin ClusterRole"
+      description: "Prevent extra whitespace in controller ConfigMap"

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -145,7 +145,7 @@ data:
       rbac:
         enabled: {{ .Values.server.sso.rbac.enabled }}
       {{- with .Values.server.sso.scopes }}
-      scopes: {{ toYaml . | nindent 8 }}
+      scopes: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.server.sso.issuerAlias }}
       issuerAlias: {{ toYaml . }}
@@ -163,7 +163,7 @@ data:
       insecureSkipVerify: {{ toYaml . }}
       {{- end }}
       {{- with .Values.server.sso.filterGroupsRegex }}
-      filterGroupsRegex: {{ toYaml . | nindent 8 }}
+      filterGroupsRegex: {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
     {{- with .Values.controller.workflowRestrictions }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR addresses a formatting issue in the Argo Workflows Helm chart, specifically targeting extra whitespace after the `filterGroupsRegex` and `scopes` fields in the generated controller ConfigMap. By adding hyphens (`-`) to the template directives, this change effectively eliminates unwanted extra spaces, enhancing the clarity and consistency of the YAML output.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
