### PR TITLE
chore(argo-cd): DRY cleanup of ServiceAccounts

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.9.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.52.0
+version: 5.52.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Use new Argo CD extension mechanism
+      description: DRY cleanup of ServiceAccounts

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -11,7 +11,7 @@ to 63 chars and it includes 10 chars of hash and a separating '-'.
 {{/*
 Create the name of the controller service account to use
 */}}
-{{- define "argo-cd.controllerServiceAccountName" -}}
+{{- define "argo-cd.controller.serviceAccountName" -}}
 {{- if .Values.controller.serviceAccount.create -}}
     {{ default (include "argo-cd.controller.fullname" .) .Values.controller.serviceAccount.name }}
 {{- else -}}
@@ -40,7 +40,7 @@ Create Dex server endpoint
 {{/*
 Create the name of the dex service account to use
 */}}
-{{- define "argo-cd.dexServiceAccountName" -}}
+{{- define "argo-cd.dex.serviceAccountName" -}}
 {{- if .Values.dex.serviceAccount.create -}}
     {{ default (include "argo-cd.dex.fullname" .) .Values.dex.serviceAccount.name }}
 {{- else -}}
@@ -78,7 +78,7 @@ Return Redis server endpoint
 {{/*
 Create the name of the redis service account to use
 */}}
-{{- define "argo-cd.redisServiceAccountName" -}}
+{{- define "argo-cd.redis.serviceAccountName" -}}
 {{- if .Values.redis.serviceAccount.create -}}
     {{ default (include "argo-cd.redis.fullname" .) .Values.redis.serviceAccount.name }}
 {{- else -}}
@@ -96,7 +96,7 @@ Create argocd server name and version as used by the chart label.
 {{/*
 Create the name of the Argo CD server service account to use
 */}}
-{{- define "argo-cd.serverServiceAccountName" -}}
+{{- define "argo-cd.server.serviceAccountName" -}}
 {{- if .Values.server.serviceAccount.create -}}
     {{ default (include "argo-cd.server.fullname" .) .Values.server.serviceAccount.name }}
 {{- else -}}
@@ -114,7 +114,7 @@ Create argocd repo-server name and version as used by the chart label.
 {{/*
 Create the name of the repo-server service account to use
 */}}
-{{- define "argo-cd.repoServerServiceAccountName" -}}
+{{- define "argo-cd.repoServer.serviceAccountName" -}}
 {{- if .Values.repoServer.serviceAccount.create -}}
     {{ default (include "argo-cd.repoServer.fullname" .) .Values.repoServer.serviceAccount.name }}
 {{- else -}}
@@ -132,7 +132,7 @@ Create argocd application set name and version as used by the chart label.
 {{/*
 Create the name of the application set service account to use
 */}}
-{{- define "argo-cd.applicationSetServiceAccountName" -}}
+{{- define "argo-cd.applicationSet.serviceAccountName" -}}
 {{- if .Values.applicationSet.serviceAccount.create -}}
     {{ default (include "argo-cd.applicationSet.fullname" .) .Values.applicationSet.serviceAccount.name }}
 {{- else -}}
@@ -150,7 +150,7 @@ Create argocd notifications name and version as used by the chart label.
 {{/*
 Create the name of the notifications service account to use
 */}}
-{{- define "argo-cd.notificationsServiceAccountName" -}}
+{{- define "argo-cd.notifications.serviceAccountName" -}}
 {{- if .Values.notifications.serviceAccount.create -}}
     {{ default (include "argo-cd.notifications.fullname" .) .Values.notifications.serviceAccount.name }}
 {{- else -}}

--- a/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/clusterrolebinding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: {{ include "argo-cd.controller.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.controllerServiceAccountName" . }}
+  name: {{ include "argo-cd.controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "argo-cd.controller.fullname" . }}
+  name: {{ include "argo-cd.controller.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "argo-cd.controller.fullname" . }}
+  name: {{ include "argo-cd.controller.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.controllerServiceAccountName" . }}
+  name: {{ include "argo-cd.controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/serviceaccount.yaml
@@ -3,17 +3,17 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.controllerServiceAccountName" . }}
+  name: {{ include "argo-cd.controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.controller.serviceAccount.annotations }}
+  {{- with .Values.controller.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.controller.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
-  {{- range $key, $value := .Values.controller.serviceAccount.labels }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- with .Values.controller.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       {{- if .Values.controller.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "argo-cd.controllerServiceAccountName" . }}
+      serviceAccountName: {{ include "argo-cd.controller.serviceAccountName" . }}
       containers:
       - args:
         - /usr/local/bin/argocd-application-controller

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- if .Values.applicationSet.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.applicationSet.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "argo-cd.applicationSetServiceAccountName" . }}
+      serviceAccountName: {{ include "argo-cd.applicationSet.serviceAccountName" . }}
       containers:
         - name: {{ .Values.applicationSet.name }}
           image: {{ default .Values.global.image.repository .Values.applicationSet.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.applicationSet.image.tag }}

--- a/charts/argo-cd/templates/argocd-applicationset/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/rolebinding.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "argo-cd.applicationSet.fullname" . }}
+  name: {{ include "argo-cd.applicationSet.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "argo-cd.applicationSet.fullname" . }}
+  name: {{ include "argo-cd.applicationSet.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "argo-cd.applicationSetServiceAccountName" . }}
+    name: {{ include "argo-cd.applicationSet.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/serviceaccount.yaml
@@ -3,17 +3,17 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.applicationSet.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.applicationSetServiceAccountName" . }}
+  name: {{ include "argo-cd.applicationSet.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.applicationSet.serviceAccount.annotations }}
+  {{- with .Values.applicationSet.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.applicationSet.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
-  {{- range $key, $value := .Values.applicationSet.serviceAccount.labels }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- with .Values.applicationSet.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/clusterrolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ include "argo-cd.notifications.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.notificationsServiceAccountName" . }}
+  name: {{ include "argo-cd.notifications.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- if .Values.notifications.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.notifications.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "argo-cd.notificationsServiceAccountName" . }}
+      serviceAccountName: {{ include "argo-cd.notifications.serviceAccountName" . }}
       containers:
         - name: {{ .Values.notifications.name }}
           image: {{ default .Values.global.image.repository .Values.notifications.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.notifications.image.tag }}

--- a/charts/argo-cd/templates/argocd-notifications/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/rolebinding.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "argo-cd.notifications.fullname" . }}
+  name: {{ include "argo-cd.notifications.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "argo-cd.notifications.fullname" . }}
+  name: {{ include "argo-cd.notifications.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "argo-cd.notificationsServiceAccountName" . }}
+    name: {{ include "argo-cd.notifications.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/serviceaccount.yaml
@@ -3,17 +3,17 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.notifications.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.notificationsServiceAccountName" . }}
+  name: {{ include "argo-cd.notifications.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.notifications.serviceAccount.annotations }}
+  {{- with .Values.notifications.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.notifications.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
-  {{- range $key, $value := .Values.notifications.serviceAccount.labels }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- with .Values.notifications.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/clusterrolebinding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: {{ include "argo-cd.repoServer.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.repoServerServiceAccountName" . }}
+  name: {{ include "argo-cd.repoServer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       {{- if .Values.repoServer.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.repoServer.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "argo-cd.repoServerServiceAccountName" . }}
+      serviceAccountName: {{ include "argo-cd.repoServer.serviceAccountName" . }}
       containers:
       - name: {{ .Values.repoServer.name }}
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}

--- a/charts/argo-cd/templates/argocd-repo-server/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/rolebinding.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "argo-cd.repoServer.fullname" . }}
+  name: {{ include "argo-cd.repoServer.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "argo-cd.repoServer.fullname" . }}
+  name: {{ include "argo-cd.repoServer.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.repoServerServiceAccountName" . }}
+  name: {{ include "argo-cd.repoServer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/serviceaccount.yaml
@@ -3,17 +3,17 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.repoServer.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.repoServerServiceAccountName" . }}
+  name: {{ include "argo-cd.repoServer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.repoServer.serviceAccount.annotations }}
+  {{- with .Values.repoServer.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.repoServer.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
-  {{- range $key, $value := .Values.repoServer.serviceAccount.labels }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- range $key, $value := .Values.repoServer.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrolebinding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: {{ include "argo-cd.server.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "argo-cd.serverServiceAccountName" . }}
+  name: {{ include "argo-cd.server.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if .Values.server.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "argo-cd.serverServiceAccountName" . }}
+      serviceAccountName: {{ include "argo-cd.server.serviceAccountName" . }}
       containers:
       - name: {{ .Values.server.name }}
         image: {{ default .Values.global.image.repository .Values.server.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.server.image.tag }}

--- a/charts/argo-cd/templates/argocd-server/rolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-server/rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "argo-cd.server.fullname" . }}
+  name: {{ include "argo-cd.server.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
@@ -11,5 +11,5 @@ roleRef:
   name: {{ template "argo-cd.server.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.serverServiceAccountName" . }}
+  name: {{ include "argo-cd.server.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
@@ -3,17 +3,17 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.server.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.serverServiceAccountName" . }}
+  name: {{ include "argo-cd.server.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.server.serviceAccount.annotations }}
+  {{- with .Values.server.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.server.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-  {{- range $key, $value := .Values.server.serviceAccount.labels }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- range $key, $value := .Values.server.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -58,7 +58,7 @@ spec:
       {{- if .Values.dex.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.dex.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ template "argo-cd.dexServiceAccountName" . }}
+      serviceAccountName: {{ template "argo-cd.dex.serviceAccountName" . }}
       containers:
       - name: {{ .Values.dex.name }}
         image: {{ .Values.dex.image.repository }}:{{ .Values.dex.image.tag }}

--- a/charts/argo-cd/templates/dex/rolebinding.yaml
+++ b/charts/argo-cd/templates/dex/rolebinding.yaml
@@ -2,16 +2,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "argo-cd.dex.fullname" . }}
+  name: {{ include "argo-cd.dex.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "argo-cd.dex.fullname" . }}
+  name: {{ include "argo-cd.dex.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "argo-cd.dexServiceAccountName" . }}
+  name: {{ include "argo-cd.dex.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/argo-cd/templates/dex/serviceaccount.yaml
+++ b/charts/argo-cd/templates/dex/serviceaccount.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.dex.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.dexServiceAccountName" . }}
+  name: {{ include "argo-cd.dex.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.dex.serviceAccount.annotations }}
+  {{- with .Values.dex.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.dex.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 4 }}
 {{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       {{- if .Values.redis.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.redis.terminationGracePeriodSeconds }}
       {{- end }}
-      serviceAccountName: {{ include "argo-cd.redisServiceAccountName" . }}
+      serviceAccountName: {{ include "argo-cd.redis.serviceAccountName" . }}
       containers:
       - name: {{ .Values.redis.name }}
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}

--- a/charts/argo-cd/templates/redis/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis/serviceaccount.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redis.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ template "argo-cd.redisServiceAccountName" . }}
+  name: {{ include "argo-cd.redis.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if .Values.redis.serviceAccount.annotations }}
+  {{- with .Values.redis.serviceAccount.annotations }}
   annotations:
-  {{- range $key, $value := .Values.redis.serviceAccount.annotations }}
+    {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- end }}
-{{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Non-functional cleanup of helper templates and if -> with for ServiceAccounts.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
