### PR TITLE
feat(argo-rollouts): Add configurable deployment strategy for Argo Rollouts controller

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.6.4
+appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.34.0
+version: 2.35.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Allow setting log config for rollouts dashboard
+    - kind: added
+      description: Allow configuring deployment strategy for the Argo Rollouts controller

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -80,6 +80,9 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.containerPorts.healthz | int | `8080` | Healthz container port |
 | controller.containerPorts.metrics | int | `8090` | Metrics container port |
 | controller.createClusterRole | bool | `true` | flag to enable creation of cluster controller role (requires cluster RBAC) |
+| controller.deploymentStrategy.type | string | `""` | Deployment strategy type. Options: "Recreate" or "RollingUpdate". If not specified, defaults to "RollingUpdate". |
+| controller.deploymentStrategy.rollingUpdate.maxSurge | int or string | `0` | Maximum number or percentage of additional pods that can be created during an update. |
+| controller.deploymentStrategy.rollingUpdate.maxUnavailable | int or string | `0` | Maximum number or percentage of pods that can be unavailable during an update. |
 | controller.deploymentAnnotations | object | `{}` | Annotations to be added to the controller deployment |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-controller.  A list of flags. |
 | controller.extraContainers | list | `[]` | Literal yaml for extra containers to be added to controller deployment. |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -17,8 +17,13 @@ spec:
     matchLabels:
       app.kubernetes.io/component: {{ .Values.controller.component }}
       {{- include "argo-rollouts.selectorLabels" . | nindent 6 }}
+  {{- if .Values.controller.deploymentStrategy }}
   strategy:
-    type: Recreate
+    {{- toYaml .Values.controller.deploymentStrategy | nindent 4 }}
+  {{- else }}
+  strategy:
+    type: RollingUpdate
+  {{- end }}
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -45,6 +45,14 @@ global:
 controller:
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-controller
+
+  # -- Configuration for the deployment strategy defaults to RollingUpdate
+  deploymentStrategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 25%
+    #   maxUnavailable: 25%
+
   # -- Annotations to be added to the controller deployment
   deploymentAnnotations: {}
   # -- Annotations to be added to application controller pods


### PR DESCRIPTION
Added configurable deployment strategy for the Argo Rollouts controller. Users can now specify either "Recreate" or "RollingUpdate" as the deployment strategy in the values.yaml file. This enhancement provides users with flexibility in choosing the deployment strategy that best suits their needs.

Checklist:

 - [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
- [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
- [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
- [x] Any new values are backwards compatible and/or have sensible default.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
- [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
