### PR TITLE
chore(argo-cd): Remove wildcard catch all ingress rule

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: removed
       description: Wildcard catch all ingress rule
+    - kind: added
+      description: Ingress extra rules to allow explicit configuration of catch all rule

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.9.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.52.1
+version: 5.53.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: DRY cleanup of ServiceAccounts
+    - kind: removed
+      description: Wildcard catch all ingress rule

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -738,6 +738,7 @@ NAME: my-release
 | server.ingress.annotations | object | `{}` | Additional ingress annotations |
 | server.ingress.enabled | bool | `false` | Enable an ingress resource for the Argo CD server |
 | server.ingress.extraPaths | list | `[]` | Additional ingress paths |
+| server.ingress.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
 | server.ingress.hosts | list | `[]` | List of ingress hosts |
 | server.ingress.https | bool | `false` | Uses `server.service.servicePortHttps` instead `server.service.servicePortHttp` |
 | server.ingress.ingressClassName | string | `""` | Defines which ingress controller will implement the resource |
@@ -750,6 +751,7 @@ NAME: my-release
 | server.ingressGrpc.awsALB.serviceType | string | `"NodePort"` | Service type for the AWS ALB gRPC service |
 | server.ingressGrpc.enabled | bool | `false` | Enable an ingress resource for the Argo CD server for dedicated [gRPC-ingress] |
 | server.ingressGrpc.extraPaths | list | `[]` | Additional ingress paths for dedicated [gRPC-ingress] |
+| server.ingressGrpc.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
 | server.ingressGrpc.hosts | list | `[]` | List of ingress hosts for dedicated [gRPC-ingress] |
 | server.ingressGrpc.https | bool | `false` | Uses `server.service.servicePortHttps` instead `server.service.servicePortHttp` |
 | server.ingressGrpc.ingressClassName | string | `""` | Defines which ingress controller will implement the resource [gRPC-ingress] |
@@ -1161,6 +1163,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.webhook.ingress.annotations | object | `{}` | Additional ingress annotations |
 | applicationSet.webhook.ingress.enabled | bool | `false` | Enable an ingress resource for Webhooks |
 | applicationSet.webhook.ingress.extraPaths | list | `[]` | Additional ingress paths |
+| applicationSet.webhook.ingress.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
 | applicationSet.webhook.ingress.hosts | list | `[]` | List of ingress hosts |
 | applicationSet.webhook.ingress.ingressClassName | string | `""` | Defines which ingress ApplicationSet controller will implement the resource |
 | applicationSet.webhook.ingress.labels | object | `{}` | Additional ingress labels |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -737,7 +737,7 @@ NAME: my-release
 | server.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | server.ingress.annotations | object | `{}` | Additional ingress annotations |
 | server.ingress.enabled | bool | `false` | Enable an ingress resource for the Argo CD server |
-| server.ingress.extraPaths | list | `[]` | Additional ingress paths |
+| server.ingress.extraPaths | list | `[]` (See [values.yaml]) | Additional ingress paths |
 | server.ingress.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
 | server.ingress.hosts | list | `[]` | List of ingress hosts |
 | server.ingress.https | bool | `false` | Uses `server.service.servicePortHttps` instead `server.service.servicePortHttp` |
@@ -750,8 +750,8 @@ NAME: my-release
 | server.ingressGrpc.awsALB.backendProtocolVersion | string | `"HTTP2"` | Backend protocol version for the AWS ALB gRPC service |
 | server.ingressGrpc.awsALB.serviceType | string | `"NodePort"` | Service type for the AWS ALB gRPC service |
 | server.ingressGrpc.enabled | bool | `false` | Enable an ingress resource for the Argo CD server for dedicated [gRPC-ingress] |
-| server.ingressGrpc.extraPaths | list | `[]` | Additional ingress paths for dedicated [gRPC-ingress] |
-| server.ingressGrpc.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
+| server.ingressGrpc.extraPaths | list | `[]` (See [values.yaml]) | Additional ingress paths for dedicated [gRPC-ingress] |
+| server.ingressGrpc.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules for dedicated [gRPC-ingress] |
 | server.ingressGrpc.hosts | list | `[]` | List of ingress hosts for dedicated [gRPC-ingress] |
 | server.ingressGrpc.https | bool | `false` | Uses `server.service.servicePortHttps` instead `server.service.servicePortHttp` |
 | server.ingressGrpc.ingressClassName | string | `""` | Defines which ingress controller will implement the resource [gRPC-ingress] |
@@ -1162,7 +1162,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the ApplicationSet controller |
 | applicationSet.webhook.ingress.annotations | object | `{}` | Additional ingress annotations |
 | applicationSet.webhook.ingress.enabled | bool | `false` | Enable an ingress resource for Webhooks |
-| applicationSet.webhook.ingress.extraPaths | list | `[]` | Additional ingress paths |
+| applicationSet.webhook.ingress.extraPaths | list | `[]` (See [values.yaml]) | Additional ingress paths |
 | applicationSet.webhook.ingress.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
 | applicationSet.webhook.ingress.hosts | list | `[]` | List of ingress hosts |
 | applicationSet.webhook.ingress.ingressClassName | string | `""` | Defines which ingress ApplicationSet controller will implement the resource |

--- a/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.applicationSet.enabled .Values.applicationSet.webhook.ingress.enabled -}}
+{{- if and .Values.applicationSet.enabled (and .Values.applicationSet.webhook.ingress.enabled .Values.applicationSet.webhook.ingress.hosts) -}}
 {{- $servicePort := .Values.applicationSet.service.portName -}}
 {{- $paths := .Values.applicationSet.webhook.ingress.paths -}}
 {{- $extraPaths := .Values.applicationSet.webhook.ingress.extraPaths -}}
@@ -24,13 +24,12 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-  {{- if .Values.applicationSet.webhook.ingress.hosts }}
-    {{- range $host := .Values.applicationSet.webhook.ingress.hosts }}
-    - host: {{ $host }}
+    {{- range .Values.applicationSet.webhook.ingress.hosts }}
+    - host: {{ . }}
       http:
         paths:
           {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
@@ -44,28 +43,8 @@ spec:
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-          {{- end -}}
-    {{- end -}}
-  {{- else }}
-    - http:
-        paths:
-          {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range $p := $paths }}
-          - path: {{ $p }}
-            pathType: {{ $pathType }}
-            backend:
-              service:
-                name: {{ include "argo-cd.applicationSet.fullname" $ }}
-                port:
-                  {{- if kindIs "float64" $servicePort }}
-                  number: {{ $servicePort }}
-                  {{- else }}
-                  name: {{ $servicePort }}
-                  {{- end }}
-          {{- end -}}
-  {{- end -}}
+    {{- end }}
   {{- with .Values.applicationSet.webhook.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
@@ -1,8 +1,5 @@
 {{- if and .Values.applicationSet.enabled (and .Values.applicationSet.webhook.ingress.enabled .Values.applicationSet.webhook.ingress.hosts) -}}
 {{- $servicePort := .Values.applicationSet.service.portName -}}
-{{- $paths := .Values.applicationSet.webhook.ingress.paths -}}
-{{- $extraPaths := .Values.applicationSet.webhook.ingress.extraPaths -}}
-{{- $pathType := .Values.applicationSet.webhook.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,12 +25,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          {{- with $extraPaths }}
+          {{- with $.Values.applicationSet.webhook.ingress.extraPaths }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range $p := $paths }}
-          - path: {{ $p }}
-            pathType: {{ $pathType }}
+          {{- range $.Values.applicationSet.webhook.ingress.paths }}
+          - path: {{ . }}
+            pathType: {{ $.Values.applicationSet.webhook.ingress.pathType }}
             backend:
               service:
                 name: {{ include "argo-cd.applicationSet.fullname" $ }}

--- a/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/webhook-ingress.yaml
@@ -45,6 +45,9 @@ spec:
                   {{- end }}
           {{- end }}
     {{- end }}
+    {{- with .Values.applicationSet.webhook.ingress.extraRules }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.applicationSet.webhook.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.server.ingressGrpc.enabled (not .Values.server.ingressGrpc.isAWSALB) -}}
+{{- if and (and .Values.server.ingressGrpc.enabled .Values.server.ingressGrpc.hosts) (not .Values.server.ingressGrpc.isAWSALB) -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingressGrpc.https -}}
 {{- $paths := .Values.server.ingressGrpc.paths -}}
 {{- $extraPaths := .Values.server.ingressGrpc.extraPaths -}}
@@ -24,13 +24,12 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-  {{- if .Values.server.ingressGrpc.hosts }}
-    {{- range $host := .Values.server.ingressGrpc.hosts }}
-    - host: {{ $host }}
+    {{- range .Values.server.ingressGrpc.hosts }}
+    - host: {{ . }}
       http:
         paths:
           {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
@@ -44,30 +43,10 @@ spec:
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-          {{- end -}}
-    {{- end -}}
-  {{- else }}
-    - http:
-        paths:
-          {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range $p := $paths }}
-          - path: {{ $p }}
-            pathType: {{ $pathType }}
-            backend:
-              service:
-                name: {{ include "argo-cd.server.fullname" $ }}
-                port:
-                  {{- if kindIs "float64" $servicePort }}
-                  number: {{ $servicePort }}
-                  {{- else }}
-                  name: {{ $servicePort }}
-                  {{- end }}
-          {{- end -}}
-  {{- end -}}
+    {{- end }}
   {{- with .Values.server.ingressGrpc.tls }}
   tls:
     {{- toYaml . | nindent 4 }}
-  {{- end -}}
-{{- end -}}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -1,8 +1,5 @@
 {{- if and (and .Values.server.ingressGrpc.enabled .Values.server.ingressGrpc.hosts) (not .Values.server.ingressGrpc.isAWSALB) -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingressGrpc.https -}}
-{{- $paths := .Values.server.ingressGrpc.paths -}}
-{{- $extraPaths := .Values.server.ingressGrpc.extraPaths -}}
-{{- $pathType := .Values.server.ingressGrpc.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,12 +25,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          {{- with $extraPaths }}
+          {{- with $.Values.server.ingressGrpc.extraPaths }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range $p := $paths }}
-          - path: {{ $p }}
-            pathType: {{ $pathType }}
+          {{- range $.Values.server.ingressGrpc.paths }}
+          - path: {{ . }}
+            pathType: {{ $.Values.server.ingressGrpc.pathType }}
             backend:
               service:
                 name: {{ include "argo-cd.server.fullname" $ }}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -45,6 +45,9 @@ spec:
                   {{- end }}
           {{- end }}
     {{- end }}
+    {{- with .Values.server.ingressGrpc.extraRules }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.server.ingressGrpc.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -1,8 +1,5 @@
 {{- if and .Values.server.ingress.enabled .Values.server.ingress.hosts -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingress.https -}}
-{{- $paths := .Values.server.ingress.paths -}}
-{{- $extraPaths := .Values.server.ingress.extraPaths -}}
-{{- $pathType := .Values.server.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -32,12 +29,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          {{- with $extraPaths }}
+          {{- with $.Values.server.ingress.extraPaths }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range $p := $paths }}
+          {{- range $.Values.server.ingress.paths }}
           {{- if and $.Values.server.ingressGrpc.isAWSALB $.Values.server.ingressGrpc.enabled }}
-          - path: {{ $p }}
+          - path: {{ . }}
             pathType: {{ $.Values.server.ingressGrpc.pathType }}
             backend:
               service:
@@ -49,8 +46,8 @@ spec:
                   name: {{ $servicePort }}
                   {{- end }}
           {{- end }}
-          - path: {{ $p }}
-            pathType: {{ $pathType }}
+          - path: {{ . }}
+            pathType: {{ $.Values.server.ingress.pathType }}
             backend:
               service:
                 name: {{ include "argo-cd.server.fullname" $ }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -62,6 +62,9 @@ spec:
                   {{- end }}
           {{- end }}
     {{- end }}
+    {{- with .Values.server.ingress.extraRules }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.server.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.ingress.enabled -}}
+{{- if and .Values.server.ingress.enabled .Values.server.ingress.hosts -}}
 {{- $servicePort := ternary .Values.server.service.servicePortHttps .Values.server.service.servicePortHttp .Values.server.ingress.https -}}
 {{- $paths := .Values.server.ingress.paths -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
@@ -28,13 +28,12 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-  {{- if .Values.server.ingress.hosts }}
-    {{- range $host := .Values.server.ingress.hosts }}
-    - host: {{ $host | quote }}
+    {{- range .Values.server.ingress.hosts }}
+    - host: {{ . }}
       http:
         paths:
           {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- range $p := $paths }}
           {{- if and $.Values.server.ingressGrpc.isAWSALB $.Values.server.ingressGrpc.enabled }}
@@ -42,34 +41,14 @@ spec:
             pathType: {{ $.Values.server.ingressGrpc.pathType }}
             backend:
               service:
-                name: {{ template "argo-cd.server.fullname" $ }}-grpc
+                name: {{ include "argo-cd.server.fullname" $ }}-grpc
                 port:
                   {{- if kindIs "float64" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-            {{- end }}
-          - path: {{ $p }}
-            pathType: {{ $pathType }}
-            backend:
-              service:
-                name: {{ include "argo-cd.server.fullname" $ }}
-                port:
-                  {{- if kindIs "float64" $servicePort }}
-                  number: {{ $servicePort }}
-                  {{- else }}
-                  name: {{ $servicePort }}
-                  {{- end }}
-          {{- end -}}
-    {{- end -}}
-  {{- else }}
-    - http:
-        paths:
-          {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- range $p := $paths }}
           - path: {{ $p }}
             pathType: {{ $pathType }}
             backend:
@@ -81,10 +60,10 @@ spec:
                   {{- else }}
                   name: {{ $servicePort }}
                   {{- end }}
-          {{- end -}}
-  {{- end -}}
+          {{- end }}
+    {{- end }}
   {{- with .Values.server.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}
-  {{- end -}}
-{{- end -}}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1946,6 +1946,7 @@ server:
       - /
     # -- Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`
     pathType: Prefix
+
     # -- Additional ingress paths
     extraPaths: []
       # - path: /*
@@ -1955,6 +1956,18 @@ server:
       #       name: ssl-redirect
       #       port:
       #         name: use-annotation
+
+    # -- Additional ingress rules
+    # @default -- `[]` (See [values.yaml])
+    extraRules: []
+      # - host: example.server.local
+      #   http:
+      #       path: /
+      #       backend:
+      #         service:
+      #           name: example-svc
+      #           port:
+      #             name: http
 
     # -- Ingress TLS configuration
     tls: []
@@ -2013,6 +2026,18 @@ server:
       #       name: ssl-redirect
       #       port:
       #         name: use-annotation
+
+    # -- Additional ingress rules
+    # @default -- `[]` (See [values.yaml])
+    extraRules: []
+      # - host: example.server.local
+      #   http:
+      #       path: /
+      #       backend:
+      #         service:
+      #           name: example-svc
+      #           port:
+      #             name: http
 
     # -- Ingress TLS configuration for dedicated [gRPC-ingress]
     tls: []
@@ -2713,17 +2738,24 @@ applicationSet:
       # -- Additional ingress paths
       extraPaths: []
         # - path: /*
-        #   backend:
-        #     serviceName: ssl-redirect
-        #     servicePort: use-annotation
-        ## for Kubernetes >=1.19 (when "networking.k8s.io/v1" is used)
-        # - path: /*
         #   pathType: Prefix
         #   backend:
         #     service:
         #       name: ssl-redirect
         #       port:
         #         name: use-annotation
+
+      # -- Additional ingress rules
+      # @default -- `[]` (See [values.yaml])
+      extraRules: []
+        # - host: example.server.local
+        #   http:
+        #       path: /
+        #       backend:
+        #         service:
+        #           name: example-svc
+        #           port:
+        #             name: http
 
       # -- Ingress TLS configuration
       tls: []

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1931,6 +1931,7 @@ server:
     annotations: {}
     # -- Additional ingress labels
     labels: {}
+
     # -- Defines which ingress controller will implement the resource
     ingressClassName: ""
 
@@ -1948,6 +1949,7 @@ server:
     pathType: Prefix
 
     # -- Additional ingress paths
+    # @default -- `[]` (See [values.yaml])
     extraPaths: []
       # - path: /*
       #   pathType: Prefix
@@ -2015,9 +2017,12 @@ server:
     # -- List of ingress paths for dedicated [gRPC-ingress]
     paths:
       - /
+
     # -- Ingress path type for dedicated [gRPC-ingress]. One of `Exact`, `Prefix` or `ImplementationSpecific`
     pathType: Prefix
+
     # -- Additional ingress paths for dedicated [gRPC-ingress]
+    # @default -- `[]` (See [values.yaml])
     extraPaths: []
       # - path: /*
       #   pathType: Prefix
@@ -2027,7 +2032,7 @@ server:
       #       port:
       #         name: use-annotation
 
-    # -- Additional ingress rules
+    # -- Additional ingress rules for dedicated [gRPC-ingress]
     # @default -- `[]` (See [values.yaml])
     extraRules: []
       # - host: example.server.local
@@ -2721,6 +2726,7 @@ applicationSet:
       annotations: {}
       # -- Additional ingress labels
       labels: {}
+
       # -- Defines which ingress ApplicationSet controller will implement the resource
       ingressClassName: ""
 
@@ -2733,9 +2739,12 @@ applicationSet:
       # -- List of ingress paths
       paths:
         - /api/webhook
+
       # -- Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`
       pathType: Prefix
+
       # -- Additional ingress paths
+      # @default -- `[]` (See [values.yaml])
       extraPaths: []
         # - path: /*
         #   pathType: Prefix


### PR DESCRIPTION
There will be multiple PRs for Ingress to decouple implementations for various controllers in attempt to make this piece more maintainable.

This PR removes ingress rule without specified hostname that acts as a global catch-all rule. It's usually not a good practice to have this in a cluster in first place as it can intercept traffic from another misconfigured application that is behind same Load balancer / IP. If we want to support this we can consider `defaultBackend` section if no hosts are provided, however from security perspective it's better to get 404 or 503 if administrator haven't configured default backend for any non-matching traffic.

Ref:
- https://kubernetes.io/docs/concepts/services-networking/ingress/#default-backend
- https://kubernetes.io/docs/concepts/services-networking/ingress/#single-service-ingress

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
