### PR TITLE
docs(argo-workflows): fix wrong `artifactRepository` identations on values.yaml

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.40.6
+version: 0.40.7
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v3.5.4
+    - kind: fixed
+      description: Wrong identation in artifactRepository block

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -769,41 +769,41 @@ artifactRepository:
     # roleARN:
     # useSDKCreds: true
     # encryptionOptions:
-    #    enableEncryption: true
+    #   enableEncryption: true
   # -- Store artifact in a GCS object store
   # @default -- `{}` (See [values.yaml])
   gcs: {}
-  # bucket: <project>-argo
-  # keyFormat: "{{ \"{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}\" }}"
-  # serviceAccountKeySecret is a secret selector.
-  # It references the k8s secret named 'my-gcs-credentials'.
-  # This secret is expected to have have the key 'serviceAccountKey',
-  # containing the base64 encoded credentials
-  # to the bucket.
-  #
-  # If it's running on GKE and Workload Identity is used,
-  # serviceAccountKeySecret is not needed.
-  # serviceAccountKeySecret:
-  # name: my-gcs-credentials
-  # key: serviceAccountKey
+    # bucket: <project>-argo
+    # keyFormat: "{{ \"{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}\" }}"
+    # # serviceAccountKeySecret is a secret selector.
+    # # It references the k8s secret named 'my-gcs-credentials'.
+    # # This secret is expected to have have the key 'serviceAccountKey',
+    # # containing the base64 encoded credentials
+    # # to the bucket.
+    # #
+    # # If it's running on GKE and Workload Identity is used,
+    # # serviceAccountKeySecret is not needed.
+    # serviceAccountKeySecret:
+    #   name: my-gcs-credentials
+    #   key: serviceAccountKey
   # -- Store artifact in Azure Blob Storage
   # @default -- `{}` (See [values.yaml])
   azure: {}
-  # endpoint: https://mystorageaccountname.blob.core.windows.net
-  # container: my-container-name
-  # blobNameFormat: path/in/container
-  ## accountKeySecret is a secret selector.
-  ## It references the k8s secret named 'my-azure-storage-credentials'.
-  ## This secret is expected to have have the key 'account-access-key',
-  ## containing the base64 encoded credentials to the storage account.
-  ## If a managed identity has been assigned to the machines running the
-  ## workflow (e.g., https://docs.microsoft.com/en-us/azure/aks/use-managed-identity)
-  ## then accountKeySecret is not needed, and useSDKCreds should be
-  ## set to true instead:
-  # useSDKCreds: true
-  # accountKeySecret:
-  #  name: my-azure-storage-credentials
-  #  key: account-access-key
+    # endpoint: https://mystorageaccountname.blob.core.windows.net
+    # container: my-container-name
+    # blobNameFormat: path/in/container
+    # # accountKeySecret is a secret selector.
+    # # It references the k8s secret named 'my-azure-storage-credentials'.
+    # # This secret is expected to have have the key 'account-access-key',
+    # # containing the base64 encoded credentials to the storage account.
+    # # If a managed identity has been assigned to the machines running the
+    # # workflow (e.g., https://docs.microsoft.com/en-us/azure/aks/use-managed-identity)
+    # # then accountKeySecret is not needed, and useSDKCreds should be
+    # # set to true instead:
+    # useSDKCreds: true
+    # accountKeySecret:
+    #   name: my-azure-storage-credentials
+    #   key: account-access-key
 
 # -- The section of custom artifact repository.
 # Utilize a custom artifact repository that is not one of the current base ones (s3, gcs, azure)


### PR DESCRIPTION
On `artifactRepository.gcs` the following 3 keys were in the same level:
- `.serviceAccountKeySecret`
- `.name`
- `.key`

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
