### PR TITLE
fix(argo-cd): Fix fail to render `.Values.configs.secret.azureDevops`

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.9.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.53.4
+version: 5.53.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Support Azure DevOps webhook Secret
+    - kind: fixed
+      description: Fix fail to render `.Values.configs.secret.azureDevops`

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -34,7 +34,6 @@ data:
   {{- with .Values.configs.secret.gogsSecret }}
   webhook.gogs.secret: {{ . | b64enc }}
   {{- end }}
-  {{/* In some environment, `if` condition needed to render. */}}
   {{- if and (.Values.configs.secret.azureDevops.username .Values.configs.secret.azureDevops.password) }}
   webhook.azuredevops.username: {{ .Values.configs.secret.azureDevops.username }}
   webhook.azuredevops.password: {{ .Values.configs.secret.azureDevops.password | b64enc }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
   {{- end }}
 type: Opaque
-{{- if or .Values.configs.secret.githubSecret (or .Values.configs.secret.gitlabSecret .Values.configs.secret.bitbucketUUID .Values.configs.secret.bitbucketServerSecret .Values.configs.secret.gogsSecret .Values.configs.secret.argocdServerAdminPassword .Values.configs.secret.argocdServerTlsConfig .Values.configs.secret.extra) }}
+{{- if or .Values.configs.secret.githubSecret (or .Values.configs.secret.gitlabSecret .Values.configs.secret.bitbucketUUID .Values.configs.secret.bitbucketServerSecret .Values.configs.secret.gogsSecret (and .Values.configs.secret.azureDevops.username .Values.configs.secret.azureDevops.password) .Values.configs.secret.argocdServerAdminPassword .Values.configs.secret.argocdServerTlsConfig .Values.configs.secret.extra) }}
 # Setting a blank data again will wipe admin password/key/cert
 data:
   {{- with .Values.configs.secret.githubSecret }}
@@ -34,9 +34,10 @@ data:
   {{- with .Values.configs.secret.gogsSecret }}
   webhook.gogs.secret: {{ . | b64enc }}
   {{- end }}
-  {{- with .Values.configs.secret.azureDevops }}
-  webhook.azuredevops.username: {{ .username }}
-  webhook.azuredevops.password: {{ .password | b64enc }}
+  {{/* In some environment, `if` condition needed to render. */}}
+  {{- if and (.Values.configs.secret.azureDevops.username .Values.configs.secret.azureDevops.password) }}
+  webhook.azuredevops.username: {{ .Values.configs.secret.azureDevops.username }}
+  webhook.azuredevops.password: {{ .Values.configs.secret.azureDevops.password | b64enc }}
   {{- end }}
   {{- with .Values.configs.secret.argocdServerTlsConfig }}
   tls.key: {{ .key | b64enc }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -34,7 +34,7 @@ data:
   {{- with .Values.configs.secret.gogsSecret }}
   webhook.gogs.secret: {{ . | b64enc }}
   {{- end }}
-  {{- if and (.Values.configs.secret.azureDevops.username .Values.configs.secret.azureDevops.password) }}
+  {{- if and .Values.configs.secret.azureDevops.username .Values.configs.secret.azureDevops.password }}
   webhook.azuredevops.username: {{ .Values.configs.secret.azureDevops.username | b64enc }}
   webhook.azuredevops.password: {{ .Values.configs.secret.azureDevops.password | b64enc }}
   {{- end }}

--- a/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
@@ -35,7 +35,7 @@ data:
   webhook.gogs.secret: {{ . | b64enc }}
   {{- end }}
   {{- if and (.Values.configs.secret.azureDevops.username .Values.configs.secret.azureDevops.password) }}
-  webhook.azuredevops.username: {{ .Values.configs.secret.azureDevops.username }}
+  webhook.azuredevops.username: {{ .Values.configs.secret.azureDevops.username | b64enc }}
   webhook.azuredevops.password: {{ .Values.configs.secret.azureDevops.password | b64enc }}
   {{- end }}
   {{- with .Values.configs.secret.argocdServerTlsConfig }}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-helm/pull/2439#issuecomment-1903013533

We get the following error because of wrong `with` condition. 
> Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [unknown object type "nil" in Secret.data.webhook.azuredevops.password, unknown object type "nil" in Secret.data.webhook.azuredevops.username]

 
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
