### PR TITLE
fix(argo-workflows): Fix trailing whitespace in controller ConfigMap

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.40.7
+version: 0.40.8
 icon: https://argoproj.github.io/argo-workflows/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Wrong identation in artifactRepository block
+      description: Remove trailing whitespace from `.resourceRateLimit` when value is set and `.sso.redirectUrl` when value is an empty string.

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -19,7 +19,7 @@ data:
     parallelism: {{ .Values.controller.parallelism }}
     {{- end }}
     {{- if .Values.controller.resourceRateLimit }}
-    resourceRateLimit: {{ toYaml .Values.controller.resourceRateLimit | nindent 6 }}
+    resourceRateLimit: {{- toYaml .Values.controller.resourceRateLimit | nindent 6 }}
     {{- end }}
     {{- with .Values.controller.namespaceParallelism }}
     namespaceParallelism: {{ . }}
@@ -141,7 +141,7 @@ data:
       clientSecret:
         name: {{ .Values.server.sso.clientSecret.name }}
         key: {{ .Values.server.sso.clientSecret.key }}
-      redirectUrl: {{ .Values.server.sso.redirectUrl }}
+      redirectUrl: {{ .Values.server.sso.redirectUrl | quote }}
       rbac:
         enabled: {{ .Values.server.sso.rbac.enabled }}
       {{- with .Values.server.sso.scopes }}


### PR DESCRIPTION
This commit addresses two places where trailing whitespace may be generated in the workflow-controller ConfigMap.

When the value `.resourceRateLimit` is not null, a trailing whitespace is added after "resourceRateLimit:". This commit trims that whitespace.

When the value `.sso.redirectUrl` is left as the default of empty string, a trailing whitespace is left after "redirectUrl:" as this value is not quoted. This commit pipes this value through `quote` to ensure this whitespace is no longer trailing and instead followed by `"` pair.

The main motivation of this commit is to generate a workflow-controller ConfigMap that is properly pretty-printed, which trailing whitespace prevents.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
