### PR TITLE
fix(argo-rollouts): Add missing patch permissions for contour RBAC

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.4
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.34.1
+version: 2.34.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -20,3 +20,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added Gloo Platform provider RBAC rules
+    - kind: fixed
+      description: Fixed contour trafficrouter RBAC rules missing "patch" permission

--- a/charts/argo-rollouts/templates/controller/clusterrole.yaml
+++ b/charts/argo-rollouts/templates/controller/clusterrole.yaml
@@ -266,6 +266,7 @@ rules:
     - list
     - watch
     - update
+    - patch
 {{- end }}
 {{- if .Values.providerRBAC.providers.glooPlatform }}
   # Access needed when using the Gloo Platform provider


### PR DESCRIPTION
Since this PR argoproj-labs/rollouts-plugin-trafficrouter-contour#53 the contour trafficrouter plugin uses `patch` not `update`.

Add the `patch` permission so that the latest version of the trafficrouter plugin works

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
