### PR TITLE
fix(argo-cd): Fix Repo server `serviceaccount` label template

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.9.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.53.8
+version: 5.53.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Updated documented default value for application.instanceLabelKey.
+    - kind: fixed
+      description: Fixed labels template for ArgoCD server service account.

--- a/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
+++ b/charts/argo-cd/templates/argocd-server/serviceaccount.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
-    {{- range $key, $value := .Values.server.serviceAccount.labels }}
+    {{- with .Values.server.serviceAccount.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->


The template for [argocd-server/serviceaccount](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-server/serviceaccount.yaml#L16) is currently broken and the chart installation is failing when labels are passed via `server.serviceAccount.labels`.

- Error can be reproduced by just passing label values to `server.serviceAccount.labels`

```bash
$ cat labels.yaml ;echo "" ;  helm upgrade --install argocd argo/argo-cd --namespace argocd --create-namespace --values labels.yaml --kube-context  argocd-cluster-aks                  
server:
  serviceAccount:
    labels:
      azure.workload.identity/use: "true"
Error: UPGRADE FAILED: YAML parse error on argo-cd/templates/argocd-server/serviceaccount.yaml: error converting YAML to JSON: yaml: line 16: could not find expected ':'
```


