### PR TITLE
feat(argo-cd): Add `existingVolumes` setting for remaining deployments with emptyDir volumes

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.9.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 5.53.12
+version: 5.54.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: security
-      description: updated dex image version to fix cves
+    - kind: added
+      description: Add `existingVolumes` setting to remaining deployments with emptyDir volumes.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -525,6 +525,7 @@ NAME: my-release
 | controller.dnsPolicy | string | `"ClusterFirst"` | Alternative DNS policy for application controller pods |
 | controller.env | list | `[]` | Environment variables to pass to application controller |
 | controller.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to application controller |
+| controller.existingVolumes | object | `{}` | Volumes to be used in replacement of emptydir on default volumes |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to application controller |
 | controller.extraContainers | list | `[]` | Additional containers to be added to the application controller pod |
 | controller.hostNetwork | bool | `false` | Host Network for application controller pods |
@@ -729,6 +730,7 @@ NAME: my-release
 | server.dnsPolicy | string | `"ClusterFirst"` | Alternative DNS policy for Server pods |
 | server.env | list | `[]` | Environment variables to pass to Argo CD server |
 | server.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to Argo CD server |
+| server.existingVolumes | object | `{}` | Volumes to be used in replacement of emptydir on default volumes |
 | server.extensions.containerSecurityContext | object | See [values.yaml] | Server UI extensions container-level security context |
 | server.extensions.enabled | bool | `false` | Enable support for Argo CD extensions |
 | server.extensions.extensionList | list | `[]` (See [values.yaml]) | Extensions for Argo CD |
@@ -881,6 +883,7 @@ server:
 | dex.enabled | bool | `true` | Enable dex |
 | dex.env | list | `[]` | Environment variables to pass to the Dex server |
 | dex.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the Dex server |
+| dex.existingVolumes | object | `{}` | Volumes to be used in replacement of emptydir on default volumes |
 | dex.extraArgs | list | `[]` | Additional command line arguments to pass to the Dex server |
 | dex.extraContainers | list | `[]` | Additional containers to be added to the dex pod |
 | dex.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Dex imagePullPolicy |
@@ -1101,6 +1104,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.dnsConfig | object | `{}` | [DNS configuration] |
 | applicationSet.dnsPolicy | string | `"ClusterFirst"` | Alternative DNS policy for ApplicationSet controller pods |
 | applicationSet.enabled | bool | `true` | Enable ApplicationSet controller |
+| applicationSet.existingVolumes | object | `{}` | Volumes to be used in replacement of emptydir on default volumes |
 | applicationSet.extraArgs | list | `[]` | List of extra cli args to add |
 | applicationSet.extraContainers | list | `[]` | Additional containers to be added to the ApplicationSet controller pod |
 | applicationSet.extraEnv | list | `[]` | Environment variables to pass to the ApplicationSet controller |

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -321,7 +321,11 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: argocd-home
+        {{- with .Values.controller.existingVolumes.argocdHome }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       - name: argocd-repo-server-tls
         secret:
           secretName: argocd-repo-server-tls

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -310,9 +310,17 @@ spec:
           configMap:
             name: argocd-gpg-keys-cm
         - name: gpg-keyring
+          {{- with .Values.applicationSet.existingVolumes.gpgKeyring }}
+          {{- toYaml . | nindent 10 }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: tmp
+          {{- with .Values.applicationSet.existingVolumes.tmp }}
+          {{- toYaml . | nindent 10 }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: argocd-repo-server-tls
           secret:
             secretName: argocd-repo-server-tls

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -373,27 +373,27 @@ spec:
       {{- end }}
       {{- if .Values.repoServer.useEphemeralHelmWorkingDir }}
       - name: helm-working-dir
-        {{- if .Values.repoServer.existingVolumes.helmWorkingDir -}}
-        {{ toYaml .Values.repoServer.existingVolumes.helmWorkingDir | nindent 8  }}
+        {{- with .Values.repoServer.existingVolumes.helmWorkingDir }}
+        {{- toYaml . | nindent 8 }}
         {{- else }}
         emptyDir: {}
         {{- end }}
       {{- end }}
       - name: plugins
-        {{- if .Values.repoServer.existingVolumes.plugins -}}
-        {{ toYaml .Values.repoServer.existingVolumes.plugins | nindent 8  }}
+        {{- with .Values.repoServer.existingVolumes.plugins }}
+        {{- toYaml . | nindent 8 }}
         {{- else }}
         emptyDir: {}
         {{- end }}
       - name: var-files
-        {{- if .Values.repoServer.existingVolumes.varFiles -}}
-        {{ toYaml .Values.repoServer.existingVolumes.varFiles | nindent 8  }}
+        {{- with .Values.repoServer.existingVolumes.varFiles }}
+        {{- toYaml . | nindent 8 }}
         {{- else }}
         emptyDir: {}
         {{- end }}
       - name: tmp
-        {{- if .Values.repoServer.existingVolumes.tmp -}}
-        {{ toYaml .Values.repoServer.existingVolumes.tmp | nindent 8  }}
+        {{- with .Values.repoServer.existingVolumes.tmp }}
+        {{- toYaml . | nindent 8 }}
         {{- else }}
         emptyDir: {}
         {{- end }}
@@ -407,8 +407,8 @@ spec:
         configMap:
           name: argocd-gpg-keys-cm
       - name: gpg-keyring
-        {{- if .Values.repoServer.existingVolumes.gpgKeyring -}}
-        {{ toYaml .Values.repoServer.existingVolumes.gpgKeyring | nindent 8  }}
+        {{- with .Values.repoServer.existingVolumes.gpgKeyring }}
+        {{- toYaml . | nindent 8 }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -418,12 +418,24 @@ spec:
       {{- end }}
       {{- if .Values.server.extensions.enabled }}
       - name: extensions
+        {{- with .Values.server.existingVolumes.extensions }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       {{- end }}
       - name: plugins-home
+        {{- with .Values.server.existingVolumes.pluginsHome }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       - name: tmp
+        {{- with .Values.server.existingVolumes.tmp }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       - name: ssh-known-hosts
         configMap:
           name: argocd-ssh-known-hosts-cm

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -185,9 +185,17 @@ spec:
       {{- end }}
       volumes:
       - name: static-files
+        {{- with .Values.dex.existingVolumes.staticFiles }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       - name: dexconfig
+        {{- with .Values.dex.existingVolumes.dexconfig }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       - name: argocd-dex-server-tls
         secret:
           secretName: argocd-dex-server-tls

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -688,6 +688,12 @@ controller:
   #  - name: custom-tools
   #    emptyDir: {}
 
+  # -- Volumes to be used in replacement of emptydir on default volumes
+  existingVolumes: {}
+  #  argocdHome:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-application-controller-home
+
   # -- Annotations for the application controller StatefulSet
   statefulsetAnnotations: {}
 
@@ -998,6 +1004,15 @@ dex:
 
   # -- Additional volumes to the dex pod
   volumes: []
+
+  # -- Volumes to be used in replacement of emptydir on default volumes
+  existingVolumes: {}
+  #  staticFiles:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-dex-server-static-files
+  #  dexconfig:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-dex-server-dexconfig
 
   # TLS certificate configuration via Secret
   ## Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/tls/#configuring-tls-to-argocd-dex-server
@@ -1683,6 +1698,18 @@ server:
   volumes: []
   #  - name: custom-tools
   #    emptyDir: {}
+
+  # -- Volumes to be used in replacement of emptydir on default volumes
+  existingVolumes: {}
+  #  extensions:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-server-extensions
+  #  pluginsHome:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-server-plugins-home
+  #  tmp:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-server-tmp
 
   # -- Annotations to be added to server Deployment
   deploymentAnnotations: {}
@@ -2538,6 +2565,15 @@ applicationSet:
 
   # -- List of extra volumes to add
   extraVolumes: []
+
+  # -- Volumes to be used in replacement of emptydir on default volumes
+  existingVolumes: {}
+  #  gpgKeyring:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-applicationset-controller-keyring
+  #  tmp:
+  #    persistentVolumeClaim:
+  #      claimName: pvc-argocd-applicationset-controller-tmp
 
   ## Metrics service configuration
   metrics:


### PR DESCRIPTION
#2410 added the `existingVolumes` setting for the repo-server component. This PR adds an equivalent setting to the other Argo CD components that have `emptyDir` volumes in their deployment so you can either use a PVC or further tune the `emptyDir` volume with `sizeLimit` parameters, etc. (which is what I do).

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
