### PR TITLE
docs(argo-workflows): update documentation links to readthedocs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ helm install charts/argo-workflows -n argo
 argo version
 ```
 
-Follow [these](https://argoproj.github.io/argo-workflows/quick-start/#submitting-an-example-workflow) instructions for running a hello world workflow.
+Follow [these](https://argo-workflows.readthedocs.io/en/stable/quick-start/#submitting-an-example-workflow) instructions for running a hello world workflow.
 
 ### Testing Argo CD Changes
 

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,8 +3,8 @@ appVersion: v3.5.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.40.9
-icon: https://argoproj.github.io/argo-workflows/assets/logo.png
+version: 0.40.10
+icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
   - https://github.com/argoproj/argo-workflows
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Add MySQL persistence support explicitly on README
+    - kind: fixed
+      description: Update argo-workflows documentation links to readthedocs

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -78,7 +78,7 @@ For full list of changes, please check ArtifactHub [changelog].
 ### High Availability
 
 This chart installs the non-HA version of Argo Workflows by default. If you want to run in HA mode, you can use [these example values](ci/ha-values.yaml) as a starting point.
-Please see the upstream [Operator Manual's High Availability page](https://argoproj.github.io/argo-workflows/high-availability/) to understand how to scale Argo Workflows in depth.
+Please see the upstream [Operator Manual's High Availability page](https://argo-workflows.readthedocs.io/en/stable/high-availability/) to understand how to scale Argo Workflows in depth.
 
 ### Workflow controller
 
@@ -354,7 +354,7 @@ Fields to note:
 | artifactRepository.azure | object | `{}` (See [values.yaml]) | Store artifact in Azure Blob Storage |
 | artifactRepository.gcs | object | `{}` (See [values.yaml]) | Store artifact in a GCS object store |
 | artifactRepository.s3 | object | See [values.yaml] | Store artifact in a S3-compliant object store |
-| artifactRepositoryRef | object | `{}` (See [values.yaml]) | The section of [artifact repository ref](https://argoproj.github.io/argo-workflows/artifact-repository-ref/). Each map key is the name of configmap |
+| artifactRepositoryRef | object | `{}` (See [values.yaml]) | The section of [artifact repository ref](https://argo-workflows.readthedocs.io/en/stable/artifact-repository-ref/). Each map key is the name of configmap |
 | customArtifactRepository | object | `{}` | The section of custom artifact repository. Utilize a custom artifact repository that is not one of the current base ones (s3, gcs, azure) |
 | useStaticCredentials | bool | `true` | Use static credentials for S3 (eg. when not using AWS IRSA) |
 
@@ -381,7 +381,7 @@ Fields to note:
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 [BackendConfigSpec]: https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig#backendconfigspec_v1beta1_cloudgooglecom
 [FrontendConfigSpec]: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#configuring_ingress_features_through_frontendconfig_parameters
-[links]: https://argoproj.github.io/argo-workflows/links/
+[links]: https://argo-workflows.readthedocs.io/en/stable/links/
 [columns]: https://github.com/argoproj/argo-workflows/pull/10693
 [Node selector]: https://kubernetes.io/docs/user-guide/node-selection/
 [Pod Disruption Budget]: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -390,5 +390,5 @@ Fields to note:
 [TopologySpreadConstraints]: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 [values.yaml]: values.yaml
 [changelog]: https://artifacthub.io/packages/helm/argo/argo-workflows?modal=changelog
-[SSO RBAC]: https://argo-workflows.readthedocs.io/en/latest/argo-server-sso/
-[Argo Server Auth Mode]: https://argo-workflows.readthedocs.io/en/latest/argo-server-auth-mode/
+[SSO RBAC]: https://argo-workflows.readthedocs.io/en/stable/argo-server-sso/
+[Argo Server Auth Mode]: https://argo-workflows.readthedocs.io/en/stable/argo-server-auth-mode/

--- a/charts/argo-workflows/README.md.gotmpl
+++ b/charts/argo-workflows/README.md.gotmpl
@@ -78,7 +78,7 @@ For full list of changes, please check ArtifactHub [changelog].
 ### High Availability
 
 This chart installs the non-HA version of Argo Workflows by default. If you want to run in HA mode, you can use [these example values](ci/ha-values.yaml) as a starting point.
-Please see the upstream [Operator Manual's High Availability page](https://argoproj.github.io/argo-workflows/high-availability/) to understand how to scale Argo Workflows in depth.
+Please see the upstream [Operator Manual's High Availability page](https://argo-workflows.readthedocs.io/en/stable/high-availability/) to understand how to scale Argo Workflows in depth.
 
 ### Workflow controller
 
@@ -199,7 +199,7 @@ Fields to note:
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 [BackendConfigSpec]: https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig#backendconfigspec_v1beta1_cloudgooglecom
 [FrontendConfigSpec]: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#configuring_ingress_features_through_frontendconfig_parameters
-[links]: https://argoproj.github.io/argo-workflows/links/
+[links]: https://argo-workflows.readthedocs.io/en/stable/links/
 [columns]: https://github.com/argoproj/argo-workflows/pull/10693
 [Node selector]: https://kubernetes.io/docs/user-guide/node-selection/
 [Pod Disruption Budget]: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -208,5 +208,5 @@ Fields to note:
 [TopologySpreadConstraints]: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 [values.yaml]: values.yaml
 [changelog]: https://artifacthub.io/packages/helm/argo/argo-workflows?modal=changelog
-[SSO RBAC]: https://argo-workflows.readthedocs.io/en/latest/argo-server-sso/
-[Argo Server Auth Mode]: https://argo-workflows.readthedocs.io/en/latest/argo-server-auth-mode/ 
+[SSO RBAC]: https://argo-workflows.readthedocs.io/en/stable/argo-server-sso/
+[Argo Server Auth Mode]: https://argo-workflows.readthedocs.io/en/stable/argo-server-auth-mode/ 

--- a/charts/argo-workflows/ci/ha-values.yaml
+++ b/charts/argo-workflows/ci/ha-values.yaml
@@ -1,7 +1,7 @@
-# Sample values for High Availability configuration, following https://argoproj.github.io/argo-workflows/high-availability/
+# Sample values for High Availability configuration, following https://argo-workflows.readthedocs.io/en/stable/high-availability/
 
 controller:
-  # in v3.0+, a second controller can be ran as a hot-standby: https://argoproj.github.io/argo-workflows/high-availability/#workflow-controller
+  # in v3.0+, a second controller can be ran as a hot-standby: https://argo-workflows.readthedocs.io/en/stable/high-availability/#workflow-controller
   replicas: 2 # should be strictly greater than PDB minAvailable
   # enable PDB with at least one Pod
   pdb:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -147,7 +147,7 @@ controller:
       drop:
         - ALL
   # -- enable Workflow Archive to store the status of workflows. Postgres and MySQL (>= 5.7.8) are available.
-  ## Ref: https://argo-workflows.readthedocs.io/en/latest/workflow-archive/
+  ## Ref: https://argo-workflows.readthedocs.io/en/stable/workflow-archive/
   persistence: {}
   # connectionPool:
   #   maxIdleConns: 100
@@ -186,12 +186,12 @@ controller:
 
   # -- Default values that will apply to all Workflows from this controller, unless overridden on the Workflow-level.
   # Only valid for 2.7+
-  ## See more: https://argoproj.github.io/argo-workflows/default-workflow-specs/
+  ## See more: https://argo-workflows.readthedocs.io/en/stable/default-workflow-specs/
   workflowDefaults: {}
   #   spec:
   #     ttlStrategy:
   #       secondsAfterCompletion: 84600
-  #     # Ref: https://argoproj.github.io/argo-workflows/artifact-repository-ref/
+  #     # Ref: https://argo-workflows.readthedocs.io/en/stable/artifact-repository-ref/
   #     artifactRepositoryRef:
   #       configMap: my-artifact-repository # default is "artifact-repositories"
   #       key: v2-s3-artifact-repository # default can be set by the `workflows.argoproj.io/default-artifact-repository` annotation in config map.
@@ -343,7 +343,7 @@ controller:
   priorityClassName: ""
 
   # -- Configure Argo Server to show custom [links]
-  ## Ref: https://argoproj.github.io/argo-workflows/links/
+  ## Ref: https://argo-workflows.readthedocs.io/en/stable/links/
   links: []
   # -- Configure Argo Server to show custom [columns]
   ## Ref: https://github.com/argoproj/argo-workflows/pull/10693
@@ -556,7 +556,7 @@ server:
 
   # -- Run the argo server in "secure" mode. Configure this value instead of `--secure` in extraArgs.
   ## See the following documentation for more details on secure mode:
-  ## https://argoproj.github.io/argo-workflows/tls/
+  ## https://argo-workflows.readthedocs.io/en/stable/tls/
   secure: false
 
   # -- Extra environment variables to provide to the argo-server container
@@ -568,11 +568,11 @@ server:
   authMode: ""
 
   # -- A list of supported authentication modes. Available values are `server`, `client`, or `sso`. If you provide sso, please configure `.Values.server.sso` as well.
-  ## Ref: https://argoproj.github.io/argo-workflows/argo-server-auth-mode/
+  ## Ref: https://argo-workflows.readthedocs.io/en/stable/argo-server-auth-mode/
   authModes: []
 
   # -- Extra arguments to provide to the Argo server binary.
-  ## Ref: https://argoproj.github.io/argo-workflows/argo-server/#options
+  ## Ref: https://argo-workflows.readthedocs.io/en/stable/argo-server/#options
   extraArgs: []
 
   logging:
@@ -829,7 +829,7 @@ customArtifactRepository: {}
 #     name: artifactory-creds
 #     key: password
 
-# -- The section of [artifact repository ref](https://argoproj.github.io/argo-workflows/artifact-repository-ref/).
+# -- The section of [artifact repository ref](https://argo-workflows.readthedocs.io/en/stable/artifact-repository-ref/).
 # Each map key is the name of configmap
 # @default -- `{}` (See [values.yaml])
 artifactRepositoryRef: {}
@@ -884,7 +884,7 @@ artifactRepositoryRef: {}
 
 emissary:
   # -- The command/args for each image on workflow, needed when the command is not specified and the emissary executor is used.
-  ## See more: https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
+  ## See more: https://argo-workflows.readthedocs.io/en/stable/workflow-executors/#emissary-emissary
   images: []
   #  argoproj/argosay:v2:
   #    cmd: [/argosay]


### PR DESCRIPTION
argo-workflows docs moved from github pages to readthedocs

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
