### PR TITLE
fix(argo-cd): Fix ingressGrpc extraTls

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.1
+version: 6.0.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed rendering of ingress extraHosts sections
+      description: Fixed rendering of ingressGrpc extraTls sections

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -58,7 +58,7 @@ spec:
       - {{ $hostname }}
       secretName: {{ printf "%s-tls" $hostname }}
     {{- end }}
-    {{- with .Values.server.ingressGrpc.tls }}
+    {{- with .Values.server.ingressGrpc.extraTls }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Before:
```
$ helm template argo-cd . --set server.ingressGrpc.enabled=true --set server.ingressGrpc.tls=true > /dev/null; echo $?
Error: YAML parse error on argo-cd/templates/argocd-server/ingress-grpc.yaml: error converting YAML to JSON: yaml: line 31: could not find expected ':'

Use --debug flag to render out invalid YAML
1
```

After:
```
$ helm template argo-cd . --set server.ingressGrpc.enabled=true --set server.ingressGrpc.tls=true > /dev/null; echo $?
0
```
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
