### PR TITLE
fix(argo-cd): Add default value for the applicationSet webhook ingress boolean

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.2
+version: 6.0.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed rendering of ingressGrpc extraTls sections
+      description: Added missing default value for applicationSet.webhook.ingress.enabled

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1273,6 +1273,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | applicationSet.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | applicationSet.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the ApplicationSet controller |
+| applicationSet.webhook.ingress.enabled | bool | `true` | Create ApplicationSet webhook ingress |
 
 ## Notifications
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2555,6 +2555,12 @@ applicationSet:
     ## Has higher precedence over `applicationSet.pdb.minAvailable`
     maxUnavailable: ""
 
+  ## -- ApplicationSet webhook configuration
+  webhook:
+    # -- Ingress configuration for the webhook
+    ingress:
+      # -- Enable ApplicationSet webhook ingress
+      enabled: false
   ## ApplicationSet controller image
   image:
     # -- Repository to use for the ApplicationSet controller


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

Resolves #2482 