### PR TITLE
fix(argo-cd): Fix applicationset network policy when webhook is enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.2
+version: 6.0.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed rendering of ingressGrpc extraTls sections
+      description: Fixed rendering of network policy when applicationset webhook is enabled

--- a/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.applicationSet.enabled .Values.global.networkPolicy.create (or .Values.applicationSet.metrics.enabled .Values.applicationSet.webhook.ingress.enabled) }}
+{{- if and .Values.applicationSet.enabled .Values.global.networkPolicy.create (or .Values.applicationSet.metrics.enabled .Values.applicationSet.ingress.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -8,7 +8,7 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
 spec:
   ingress:
-  {{- if .Values.applicationSet.webhook.ingress.enabled }}
+  {{- if .Values.applicationSet.ingress.enabled }}
   - ports:
     - port: webhook
   {{- end }}


### PR DESCRIPTION
Resolves: https://github.com/argoproj/argo-helm/issues/2482

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
