### PR TITLE
fix(argo-cd): Fix ports and TLS for dedicated gRPC ingress

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.5
+version: 6.0.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Dedicated gRPC ingress should route to HTTPS port even when running with insecure server
     - kind: changed
-      description: Improved documentation for various ingress setups
+      description: Dedicated gRPC ingress TLS secret changed to argocd-server-grpc-tls based on feedback

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -948,9 +948,8 @@ NAME: my-release
 | server.ingressGrpc.extraPaths | list | `[]` (See [values.yaml]) | Additional ingress paths for dedicated [gRPC-ingress] |
 | server.ingressGrpc.extraRules | list | `[]` (See [values.yaml]) | Additional ingress rules |
 | server.ingressGrpc.extraTls | list | `[]` (See [values.yaml]) | Additional TLS configuration for dedicated [gRPC-ingress] |
-| server.ingressGrpc.hostname | string | `""` | Argo CD server hostname for dedicated [gRPC-ingress] |
+| server.ingressGrpc.hostname | string | `""` (defaults to grpc.`server.ingress.hostname`) | Argo CD server hostname for dedicated [gRPC-ingress] |
 | server.ingressGrpc.ingressClassName | string | `""` | Defines which ingress controller will implement the resource [gRPC-ingress] |
-| server.ingressGrpc.isAWSALB | bool | `false` | Setup up gRPC ingress to work with an AWS ALB |
 | server.ingressGrpc.labels | object | `{}` | Additional ingress labels for dedicated [gRPC-ingress] |
 | server.ingressGrpc.path | string | `"/"` | Argo CD server ingress path for dedicated [gRPC-ingress] |
 | server.ingressGrpc.pathType | string | `"Prefix"` | Ingress path type for dedicated [gRPC-ingress]. One of `Exact`, `Prefix` or `ImplementationSpecific` |

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -1,7 +1,5 @@
 {{- if and .Values.server.ingressGrpc.enabled (eq .Values.server.ingress.controller "generic") -}}
 {{- $hostname := .Values.server.ingressGrpc.hostname | default (printf "grpc.%s" .Values.server.ingress.hostname) -}}
-{{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
-{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,7 +33,7 @@ spec:
               service:
                 name: {{ include "argo-cd.server.fullname" . }}
                 port:
-                  number: {{ $servicePort }}
+                  number: {{ .Values.server.service.servicePortHttps }}
     {{- range .Values.server.ingressGrpc.extraHosts }}
     - host: {{ .name | quote }}
       http:
@@ -46,7 +44,7 @@ spec:
               service:
                 name: {{ include "argo-cd.server.fullname" $ }}
                 port:
-                  number: {{ $servicePort }}
+                  number: {{ $.Values.server.service.servicePortHttps }}
     {{- end }}
     {{- with .Values.server.ingressGrpc.extraRules }}
       {{- toYaml . | nindent 4 }}
@@ -56,7 +54,7 @@ spec:
     {{- if .Values.server.ingressGrpc.tls }}
     - hosts:
       - {{ $hostname }}
-      secretName: {{ printf "%s-tls" $hostname }}
+      secretName: argocd-server-grpc-tls
     {{- end }}
     {{- with .Values.server.ingressGrpc.extraTls }}
       {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -236,6 +236,7 @@ configs:
 
     ## Server properties
     # -- Run server without TLS
+    ## NOTE: This value should be set when you generate params by other means as it changes ports used by ingress template.
     server.insecure: false
     # -- Value for base href in index.html. Used if Argo CD is running behind reverse proxy under subpath different from /
     server.basehref: /
@@ -2078,8 +2079,6 @@ server:
   ingressGrpc:
     # -- Enable an ingress resource for the Argo CD server for dedicated [gRPC-ingress]
     enabled: false
-    # -- Setup up gRPC ingress to work with an AWS ALB
-    isAWSALB: false
     # -- Additional ingress annotations for dedicated [gRPC-ingress]
     annotations: {}
     # -- Additional ingress labels for dedicated [gRPC-ingress]
@@ -2088,6 +2087,7 @@ server:
     ingressClassName: ""
 
     # -- Argo CD server hostname for dedicated [gRPC-ingress]
+    # @default -- `""` (defaults to grpc.`server.ingress.hostname`)
     hostname: ""
 
     # -- Argo CD server ingress path for dedicated [gRPC-ingress]
@@ -2097,7 +2097,7 @@ server:
     pathType: Prefix
 
     # -- Enable TLS configuration for the hostname defined at `server.ingressGrpc.hostname`
-    ## TLS certificate will be retrieved from a TLS secret with name: `<hostname>-tls`
+    ## TLS certificate will be retrieved from a TLS secret with name: `argocd-server-grpc-tls`
     tls: false
 
     # -- The list of additional hostnames to be covered by ingress record


### PR DESCRIPTION
Resolves:
- https://github.com/argoproj/argo-helm/issues/2496
- Based on feedback https://github.com/argoproj/argo-helm/pull/2481 changes TLS secret to argocd-server-grpc-tls

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
