### PR TITLE
chore(argo-cd): Disable argocd-repo-server cluster role by default

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.11
+version: 6.0.12
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Use `with` instead of `range` on reposerver serviceaccount
+    - kind: security
+      description: Argo CD repo-server cluster role is not deployed by default

--- a/charts/argo-cd/templates/argocd-repo-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.createClusterRoles }}
+{{- if and .Values.createClusterRoles .Values.repoServer.clusterRoleRules.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
 rules:
-  {{- if .Values.repoServer.clusterRoleRules.enabled }}
-    {{- toYaml .Values.repoServer.clusterRoleRules.rules | nindent 2 }}
+  {{- with .Values.repoServer.clusterRoleRules.rules }}
+    {{- toYaml . | nindent 2 }}
   {{- else }}
   - apiGroups:
     - '*'

--- a/charts/argo-cd/templates/argocd-repo-server/clusterrolebinding.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.createClusterRoles }}
+{{- if and .Values.createClusterRoles .Values.repoServer.clusterRoleRules.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Resolves: https://github.com/argoproj/argo-helm/discussions/2420

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
