### PR TITLE
feat(argo-cd): Add global domain configuration

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.1
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.14
+version: 6.1.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v2.10.1
+    - kind: added
+      description: Configuration option global.domain that is tied to all components

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -73,14 +73,15 @@ below corespond to their respective sections.
 The `tls: true` option will expect that the `argocd-server-tls` secret exists as Argo CD server loads TLS certificates from this place.
 
 ```yaml
+global:
+  domain: argocd.example.com
+
 certificate:
   enabled: true
-  domain: argocd.example.com
 
 server:
   ingress:
     enabled: true
-    hostname: argocd.example.com
     ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -91,6 +92,9 @@ server:
 ### SSL Termination at Ingress Controller
 
 ```yaml
+global:
+  domain: argocd.example.com
+
 configs:
   params:
     server.insecure: true
@@ -98,7 +102,6 @@ configs:
 server:
   ingress:
     enabled: true
-    hostname: argocd.example.com
     ingressClassName: nginx
     annotations:
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -118,6 +121,9 @@ server:
 Use `ingressGrpc` section if your ingress controller supports only a single protocol per Ingress resource (i.e.: Contour).
 
 ```yaml
+global:
+  domain: argocd.example.com
+
 configs:
   params:
     server.insecure: true
@@ -125,7 +131,6 @@ configs:
 server:
   ingress:
     enabled: true
-    hostname: argocd.example.com
     ingressClassName: contour-internal
     extraTls:
       - hosts:
@@ -134,7 +139,6 @@ server:
 
    ingressGrpc:
      enabled: true
-     hostname: grpc.argocd.example.com
      ingressClassName: contour-internal
      extraTls:
       - hosts:
@@ -145,10 +149,12 @@ server:
 ### Multiple ingress domains
 
 ```yaml
+global:
+  domain: argocd.example.com
+
 server:
   ingress:
     enabled: true
-    hostname: argocd.example.com
     ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: "<my-issuer>"
@@ -168,6 +174,9 @@ The provided example assumes you are using TLS off-loading via AWS ACM service.
 > Using `controller: aws` creates additional service for gRPC traffic and it's no longer need to use `ingressGrpc` configuration section.
 
 ```yaml
+global:
+  domain: argocd.example.com
+
 configs:
   params:
     server.insecure: true
@@ -175,7 +184,6 @@ configs:
 server:
   ingress:
     enabled: true
-    hostname: argocd.example.com
     controller: aws
     ingressClassName: alb
     annotations:
@@ -183,7 +191,7 @@ server:
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/backend-protocol: HTTP
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":80}, {"HTTPS":443}]'
-      alb.ingress.kubernetes.io/ssl-redirect" '443'
+      alb.ingress.kubernetes.io/ssl-redirect: '443'
     aws:
       serviceType: ClusterIP # <- Used with target-type: ip
       backendProtocolVersion: GRPC
@@ -195,6 +203,9 @@ The implementation will populate `ingressClassName`, `networking.gke.io/managed-
 automatically if you provide configuration for GKE resources.
 
 ```yaml
+global:
+  domain: argocd.example.com
+
 configs:
   params:
     server.insecure: true
@@ -207,7 +218,6 @@ server:
 
   ingress:
     enabled: true
-    hostname: argocd.example.com
     controller: gke
     gke:
       backendConfig:
@@ -267,6 +277,10 @@ kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=v2.4.9"
 For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
+
+### 6.1.0
+
+Added support for global domain used by all components.
 
 ### 6.0.0
 

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -163,6 +163,7 @@ Argo Configuration Preset Values (Incluenced by Values configuration)
 */}}
 {{- define "argo-cd.config.cm.presets" -}}
 {{- $presets := dict -}}
+{{- $_ := set $presets "url" (printf "https://%s" .Values.global.domain) -}}
 {{- if .Values.configs.styles -}}
 {{- $_ := set $presets "ui.cssurl" "./custom/custom.styles.css" -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-applicationset/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/certificate.yaml
@@ -14,9 +14,9 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
 spec:
   secretName: {{ .Values.applicationSet.certificate.secretName }}
-  commonName: {{ .Values.applicationSet.certificate.domain | quote }}
+  commonName: {{ .Values.applicationSet.certificate.domain | default .Values.global.domain }}
   dnsNames:
-    - {{ .Values.applicationSet.certificate.domain | quote }}
+    - {{ .Values.applicationSet.certificate.domain | default .Values.global.domain }}
     {{- range .Values.applicationSet.certificate.additionalHosts }}
     - {{ . | quote }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/ingress.yaml
@@ -20,8 +20,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    {{- if .Values.applicationSet.ingress.hostname }}
-    - host: {{ .Values.applicationSet.ingress.hostname }}
+    - host: {{ .Values.applicationSet.ingress.hostname | default .Values.global.domain }}
       http:
         paths:
           {{- with .Values.applicationSet.ingress.extraPaths }}
@@ -34,7 +33,6 @@ spec:
                 name: {{ include "argo-cd.applicationSet.fullname" . }}
                 port:
                   number: {{ .Values.applicationSet.service.port }}
-    {{- end }}
     {{- range .Values.applicationSet.ingress.extraHosts }}
     - host: {{ .name | quote }}
       http:

--- a/charts/argo-cd/templates/argocd-configs/argocd-notifications-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-notifications-cm.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
 data:
   context: |
-    argocdUrl: {{ .Values.notifications.argocdUrl | quote }}
+    argocdUrl: {{ .Values.notifications.argocdUrl | default (printf "https://%s" .Values.global.domain) }}
     {{- with .Values.notifications.context }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-server/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-server/certificate.yaml
@@ -14,9 +14,9 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
   secretName: {{ .Values.server.certificate.secretName }}
-  commonName: {{ .Values.server.certificate.domain | quote }}
+  commonName: {{ .Values.server.certificate.domain | default .Values.global.domain }}
   dnsNames:
-    - {{ .Values.server.certificate.domain | quote }}
+    - {{ .Values.server.certificate.domain | default .Values.global.domain }}
     {{- range .Values.server.certificate.additionalHosts }}
     - {{ . | quote }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.server.ingressGrpc.enabled (eq .Values.server.ingress.controller "generic") -}}
-{{- $hostname := .Values.server.ingressGrpc.hostname | default (printf "grpc.%s" .Values.server.ingress.hostname) -}}
+{{- $hostname := printf "grpc.%s" (.Values.server.ingress.hostname | default .Values.global.domain) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -21,7 +21,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    - host: {{ $hostname }}
+    - host: {{ .Values.server.ingressGrpc.hostname | default $hostname }}
       http:
         paths:
           {{- with .Values.server.ingressGrpc.extraPaths }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -22,7 +22,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    - host: {{ .Values.server.ingress.hostname }}
+    - host: {{ .Values.server.ingress.hostname | default .Values.global.domain }}
       http:
         paths:
           {{- with .Values.server.ingress.extraPaths }}
@@ -57,7 +57,7 @@ spec:
       - {{ .Values.server.ingress.hostname }}
       {{- range .Values.server.ingress.extraHosts }}
         {{- if .name }}
-      -  {{ .name }} 
+      -  {{ .name }}
         {{- end }}
       {{- end }}
       secretName: argocd-server-tls

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -37,6 +37,10 @@ crds:
 
 ## Globally shared configuration
 global:
+  # -- Default domain used by all components
+  ## Used for ingresses, certificates, SSO, notifications, etc.
+  domain: argocd.example.com
+
   # -- Common labels for the all resources
   additionalLabels: {}
     # app: argo-cd
@@ -154,9 +158,6 @@ configs:
 
     # -- Annotations to be added to argocd-cm configmap
     annotations: {}
-
-    # -- Argo CD's externally facing base URL (optional). Required when configuring SSO
-    url: ""
 
     # -- The name of tracking label used by Argo CD for resource pruning
     application.instanceLabelKey: argocd.argoproj.io/instance
@@ -1828,7 +1829,8 @@ server:
     # -- The name of the Secret that will be automatically created and managed by this Certificate resource
     secretName: argocd-server-tls
     # -- Certificate primary domain (commonName)
-    domain: argocd.example.com
+    # @default -- `""` (defaults to global.domain)
+    domain: ""
     # -- Certificate Subject Alternate Names (SANs)
     additionalHosts: []
     # -- The requested 'duration' (i.e. lifetime) of the certificate.
@@ -1985,8 +1987,8 @@ server:
     ingressClassName: ""
 
     # -- Argo CD server hostname
-    ## NOTE: Hostname must be provided if Ingress is enabled
-    hostname: argocd.example.com
+    # @default -- `""` (defaults to global.domain)
+    hostname: ""
 
     # -- The path to Argo CD server
     path: /
@@ -2792,7 +2794,8 @@ applicationSet:
     # -- The name of the Secret that will be automatically created and managed by this Certificate resource
     secretName: argocd-applicationset-controller-tls
     # -- Certificate primary domain (commonName)
-    domain: argocd.example.com
+    # @default -- `""` (defaults to global.domain)
+    domain: ""
     # -- Certificate Subject Alternate Names (SANs)
     additionalHosts: []
     # -- The requested 'duration' (i.e. lifetime) of the certificate.
@@ -2839,8 +2842,8 @@ applicationSet:
     ingressClassName: ""
 
     # -- Argo CD ApplicationSet hostname
-    ## NOTE: Hostname must be provided if Ingress is enabled
-    hostname: argocd.example.com
+    # @default -- `""` (defaults to global.domain)
+    hostname: ""
 
     # -- List of ingress paths
     path: /api/webhook
@@ -2897,7 +2900,8 @@ notifications:
   name: notifications-controller
 
   # -- Argo CD dashboard url; used in place of {{.context.argocdUrl}} in templates
-  argocdUrl:
+  # @default -- `""` (defaults to https://`global.domain`)
+  argocdUrl: ""
 
   ## Notifications controller Pod Disruption Budget
   ## Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/


### PR DESCRIPTION
Adds global configuration to provide single domain used by all components

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
