### PR TITLE
fix(argo-cd): Fix secret name for applicationset webhook ingress

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.0
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.0.12
+version: 6.0.13
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: security
-      description: Argo CD repo-server cluster role is not deployed by default
+    - kind: fixed
+      description: Use argocd-applicationset-controller-tls secret for ApplicationSet certificate
+    - kind: fixed
+      description: Use argocd-applicationset-controller-tls secret for ApplicationSet webhook ingress

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1283,7 +1283,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | applicationSet.certificate.privateKey.rotationPolicy | string | `"Never"` | Rotation policy of private key when certificate is re-issued. Either: `Never` or `Always` |
 | applicationSet.certificate.privateKey.size | int | `2048` | Key bit size of the private key. If algorithm is set to `Ed25519`, size is ignored. |
 | applicationSet.certificate.renewBefore | string | `""` (defaults to 360h = 15d if not specified) | How long before the expiry a certificate should be renewed. |
-| applicationSet.certificate.secretName | string | `"argocd-application-controller-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
+| applicationSet.certificate.secretName | string | `"argocd-applicationset-controller-tls"` | The name of the Secret that will be automatically created and managed by this Certificate resource |
 | applicationSet.containerPorts.metrics | int | `8080` | Metrics container port |
 | applicationSet.containerPorts.probe | int | `8081` | Probe container port |
 | applicationSet.containerPorts.webhook | int | `7000` | Webhook container port |

--- a/charts/argo-cd/templates/argocd-applicationset/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/ingress.yaml
@@ -55,7 +55,7 @@ spec:
     {{- if .Values.applicationSet.ingress.tls }}
     - hosts:
       - {{ .Values.applicationSet.ingress.hostname }}
-      secretName: argocd-application-controller-tls
+      secretName: argocd-applicationset-controller-tls
     {{- end }}
     {{- with .Values.applicationSet.ingress.extraTls }}
       {{- toYaml . | nindent 4 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2790,7 +2790,7 @@ applicationSet:
     # -- Deploy a Certificate resource (requires cert-manager)
     enabled: false
     # -- The name of the Secret that will be automatically created and managed by this Certificate resource
-    secretName: argocd-application-controller-tls
+    secretName: argocd-applicationset-controller-tls
     # -- Certificate primary domain (commonName)
     domain: argocd.example.com
     # -- Certificate Subject Alternate Names (SANs)
@@ -2849,7 +2849,7 @@ applicationSet:
     pathType: Prefix
 
     # -- Enable TLS configuration for the hostname defined at `applicationSet.webhook.ingress.hostname`
-    ## TLS certificate will be retrieved from a TLS secret with name:`argocd-application-controller-tls`
+    ## TLS certificate will be retrieved from a TLS secret with name:`argocd-applicationset-controller-tls`
     tls: false
 
     # -- The list of additional hostnames to be covered by ingress record


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
