### PR TITLE
feat(argocd-image-updater): allow defining additional labels to service account

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.9.3
+version: 0.9.4
 appVersion: v0.12.2
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Support extra K8s manifests
+      description: Allow defining additional labels to Service Account

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -115,6 +115,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | securityContext | object | `{}` | Security context settings for the deployment |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.labels | object | `{}` | Labels to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Kubernetes toleration settings for the deployment |
 | updateStrategy | object | `{"type":"Recreate"}` | The deployment strategy to use to replace existing pods with new ones |

--- a/charts/argocd-image-updater/templates/serviceaccount.yaml
+++ b/charts/argocd-image-updater/templates/serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -178,6 +178,8 @@ serviceAccount:
   create: true
   # -- Annotations to add to the service account
   annotations: {}
+  # -- Labels to add to the service account
+  labels: {}
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""


### PR DESCRIPTION
Allow defining custom labels to the service account.
This is required when using Azure Workload Identity to authenticate with the Azure Container Registry.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
