### PR TITLE
fix(argo-cd): Add missing `global.domain` default values

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.1
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.2.0
+version: 6.2.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: bumped redis chart and redis exporter
+    - kind: fixed
+      description: Add missing `global.domain` default values

--- a/charts/argo-cd/templates/argocd-applicationset/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/ingress.yaml
@@ -52,7 +52,7 @@ spec:
   tls:
     {{- if .Values.applicationSet.ingress.tls }}
     - hosts:
-      - {{ .Values.applicationSet.ingress.hostname }}
+      - {{ .Values.applicationSet.ingress.hostname | default .Values.global.domain }}
       secretName: argocd-applicationset-controller-tls
     {{- end }}
     {{- with .Values.applicationSet.ingress.extraTls }}

--- a/charts/argo-cd/templates/argocd-server/aws/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/ingress.yaml
@@ -22,7 +22,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    - host: {{ .Values.server.ingress.hostname }}
+    - host: {{ .Values.server.ingress.hostname | default .Values.global.domain }}
       http:
         paths:
           {{- with .Values.server.ingress.extraPaths }}
@@ -61,7 +61,7 @@ spec:
   tls:
     {{- if .Values.server.ingress.tls }}
     - hosts:
-      - {{ .Values.server.ingress.hostname }}
+      - {{ .Values.server.ingress.hostname | default .Values.global.domain }}
       secretName: argocd-server-tls
     {{- end }}
     {{- with .Values.server.ingress.extraTls }}

--- a/charts/argo-cd/templates/argocd-server/gke/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/gke/ingress.yaml
@@ -27,7 +27,7 @@ spec:
   ingressClassName: {{ . }}
   {{- end }}
   rules:
-    - host: {{ .Values.server.ingress.hostname }}
+    - host: {{ .Values.server.ingress.hostname | default .Values.global.domain }}
       http:
         paths:
           {{- with .Values.server.ingress.extraPaths }}
@@ -59,7 +59,7 @@ spec:
   tls:
     {{- if .Values.server.ingress.tls }}
     - hosts:
-      - {{ .Values.server.ingress.hostname }}
+      - {{ .Values.server.ingress.hostname | default .Values.global.domain }}
       secretName: argocd-server-tls
     {{- end }}
     {{- with .Values.server.ingress.extraTls }}

--- a/charts/argo-cd/templates/argocd-server/gke/managedcertificate.yaml
+++ b/charts/argo-cd/templates/argocd-server/gke/managedcertificate.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
   domains:
-    - {{ .Values.server.ingress.hostname }}
+    - {{ .Values.server.ingress.hostname | default .Values.global.domain }}
     {{- with .Values.server.ingress.gke.managedCertificate.extraDomains }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/argo-cd/templates/argocd-server/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress.yaml
@@ -54,7 +54,7 @@ spec:
   tls:
     {{- if .Values.server.ingress.tls }}
     - hosts:
-      - {{ .Values.server.ingress.hostname }}
+      - {{ .Values.server.ingress.hostname | default .Values.global.domain }}
       {{- range .Values.server.ingress.extraHosts }}
         {{- if .name }}
       -  {{ .name }}

--- a/charts/argo-cd/templates/argocd-server/openshift/route.yaml
+++ b/charts/argo-cd/templates/argocd-server/openshift/route.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 {{- end }}
 spec:
-  host: {{ .Values.server.route.hostname | quote }}
+  host: {{ .Values.server.route.hostname | default .Values.global.domain | quote }}
   to:
     kind: Service
     name: {{ template "argo-cd.server.fullname" . }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
