### PR TITLE
fix(argo-cd): Fix path order in AWS Ingress declaration

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Add missing `global.domain` default values
+      description: AWS gRPC Ingress rule ordering

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.1
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.2.1
+version: 6.2.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/templates/argocd-server/aws/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/ingress.yaml
@@ -29,17 +29,17 @@ spec:
             {{- toYaml . | nindent 10 }}
           {{- end }}
           - path: {{ .Values.server.ingress.path }}
-            pathType: {{ $.Values.server.ingress.pathType }}
-            backend:
-              service:
-                name: {{ include "argo-cd.server.fullname" . }}
-                port:
-                  number: {{ $servicePort }}
-          - path: {{ .Values.server.ingress.path }}
             pathType: {{ $.Values.server.ingressGrpc.pathType }}
             backend:
               service:
                 name: {{ include "argo-cd.server.fullname" $ }}-grpc
+                port:
+                  number: {{ $servicePort }}
+          - path: {{ .Values.server.ingress.path }}
+            pathType: {{ $.Values.server.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "argo-cd.server.fullname" . }}
                 port:
                   number: {{ $servicePort }}
     {{- range .Values.server.ingress.extraHosts }}


### PR DESCRIPTION
Fix path order to evaluate GRPc endpoint first

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
