### PR TITLE
feat(argo-rollouts): Restrict write access to rollout status in the aggregated roles

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.6.4
+appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.34.0
+version: 2.35.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Allow setting log config for rollouts dashboard
+      description: Restrict rollout status write access in the aggregated roles

--- a/charts/argo-rollouts/templates/aggregate-roles.yaml
+++ b/charts/argo-rollouts/templates/aggregate-roles.yaml
@@ -37,7 +37,6 @@ rules:
   resources:
   - rollouts
   - rollouts/scale
-  - rollouts/status
   - experiments
   - analysistemplates
   - clusteranalysistemplates


### PR DESCRIPTION
The status subresource is typically managed automatically by the controller managing the resource, in this case, the Argo Rollouts controller. Allowing users to directly manipulate the status subresource could lead to inconsistencies and unintended behavior, as the controller might overwrite or ignore manually set status updates.

Therefore, it's generally a good practice to restrict permissions to modify the status subresource to the controller or system components responsible for managing the resource, rather than granting such permissions to users directly. This helps ensure the integrity and consistency of the resource's state.
After this change, users will be still able to view the rollout status. 

Current setup: argo-rollouts:edit
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
