### PR TITLE
feat(argo-cd): Allow modification of path and port for dex liveness and readiness probes

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.1
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.2.4
+version: 6.3.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Format redis health check confimap mode in decimal.
+    - kind: changed
+      description: Allow modification of path and port for dex liveness and readiness probes

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1077,6 +1077,8 @@ NAME: my-release
 | dex.initImage.tag | string | `""` (defaults to global.image.tag) | Argo CD init image tag |
 | dex.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for Dex >= 2.28.0 |
 | dex.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| dex.livenessProbe.httpPath | string | `"/healthz/live"` | Http path to use for the liveness probe |
+| dex.livenessProbe.httpPort | string | `"metrics"` | Http port to use for the liveness probe |
 | dex.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | dex.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | dex.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
@@ -1109,6 +1111,8 @@ NAME: my-release
 | dex.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the dex pods |
 | dex.readinessProbe.enabled | bool | `false` | Enable Kubernetes readiness probe for Dex >= 2.28.0 |
 | dex.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| dex.readinessProbe.httpPath | string | `"/healthz/ready"` | Http path to use for the readiness probe |
+| dex.readinessProbe.httpPort | string | `"metrics"` | Http port to use for the readiness probe |
 | dex.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | dex.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | dex.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -99,8 +99,8 @@ spec:
         {{- if .Values.dex.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /healthz/live
-            port: metrics
+            path: {{ .Values.dex.livenessProbe.httpPort }}
+            port: {{ .Values.dex.livenessProbe.httpPath }}
           initialDelaySeconds: {{ .Values.dex.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.dex.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.dex.livenessProbe.timeoutSeconds }}
@@ -110,8 +110,8 @@ spec:
         {{- if .Values.dex.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /healthz/ready
-            port: metrics
+            path: {{ .Values.dex.readinessProbe.httpPort }}
+            port: {{ .Values.dex.readinessProbe.httpPath }}
           initialDelaySeconds: {{ .Values.dex.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.dex.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.dex.readinessProbe.timeoutSeconds }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1039,6 +1039,10 @@ dex:
   livenessProbe:
     # -- Enable Kubernetes liveness probe for Dex >= 2.28.0
     enabled: false
+    # -- Http path to use for the liveness probe
+    httpPath: /healthz/live
+    # -- Http port to use for the liveness probe
+    httpPort: metrics
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
     # -- Number of seconds after the container has started before [probe] is initiated
@@ -1053,6 +1057,10 @@ dex:
   readinessProbe:
     # -- Enable Kubernetes readiness probe for Dex >= 2.28.0
     enabled: false
+    # -- Http path to use for the readiness probe
+    httpPath: /healthz/ready
+    # -- Http port to use for the readiness probe
+    httpPort: metrics
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
     # -- Number of seconds after the container has started before [probe] is initiated


### PR DESCRIPTION
Allow to change the default http path and port for Dex server.

Fixes: https://github.com/argoproj/argo-cd/issues/9091

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
