### PR TITLE
feat(argocd-image-updater): Add ability to set .Values.namespaceOverride

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.9.4
+version: 0.9.5
 appVersion: v0.12.2
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Allow defining additional labels to Service Account
+      description: Allow overriding of .Release.Namespace with .Values.namespaceOverride

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -105,6 +105,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
 | metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | nameOverride | string | `""` | Global name (argocd-image-updater.name in _helpers.tpl) override |
+| namespaceOverride | string | `""` | Global namespace (argocd-image-updater.namespace in _helpers.tpl) override |
 | nodeSelector | object | `{}` | Kubernetes nodeSelector settings for the deployment |
 | podAnnotations | object | `{}` | Pod Annotations for the deployment |
 | podLabels | object | `{}` | Pod Labels for the deployment |

--- a/charts/argocd-image-updater/templates/_helpers.tpl
+++ b/charts/argocd-image-updater/templates/_helpers.tpl
@@ -25,6 +25,13 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Override .Release.Namespace 
+*/}}
+{{- define "argocd-image-updater.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "argocd-image-updater.chart" -}}

--- a/charts/argocd-image-updater/templates/configmap-authscripts.yaml
+++ b/charts/argocd-image-updater/templates/configmap-authscripts.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
   name: argocd-image-updater-authscripts
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 data:
   {{- toYaml .Values.authScripts.scripts | nindent 2}}
 {{- end }}

--- a/charts/argocd-image-updater/templates/configmap-sshconfig.yaml
+++ b/charts/argocd-image-updater/templates/configmap-sshconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
   name: argocd-image-updater-ssh-config
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 data:
   {{- with .Values.config.sshConfig }}
   {{- toYaml . | nindent 2 }}

--- a/charts/argocd-image-updater/templates/configmap.yaml
+++ b/charts/argocd-image-updater/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
   name: argocd-image-updater-config
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 data:
   {{- with .Values.config.applicationsAPIKind }}
   applications_api: {{ . }}

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "argocd-image-updater.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
 spec:

--- a/charts/argocd-image-updater/templates/metrics-service.yaml
+++ b/charts/argocd-image-updater/templates/metrics-service.yaml
@@ -14,7 +14,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "argocd-image-updater.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 spec:
   ports:
     - name: metrics

--- a/charts/argocd-image-updater/templates/rbac.yaml
+++ b/charts/argocd-image-updater/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{ include "argocd-image-updater.labels" . | nindent 4 }}
   name: {{ include "argocd-image-updater.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 rules:
   - apiGroups:
       - ''
@@ -39,6 +39,7 @@ metadata:
   labels:
     {{ include "argocd-image-updater.labels" . | nindent 4 }}
   name: {{ include "argocd-image-updater.fullname" . }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -46,5 +47,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "argocd-image-updater.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 {{- end }}

--- a/charts/argocd-image-updater/templates/secret.yaml
+++ b/charts/argocd-image-updater/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-image-updater-secret
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/argocd-image-updater/templates/serviceaccount.yaml
+++ b/charts/argocd-image-updater/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "argocd-image-updater.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "argocd-image-updater.namespace" . | quote }}
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.labels }}

--- a/charts/argocd-image-updater/templates/servicemonitor.yaml
+++ b/charts/argocd-image-updater/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd-image-updater.fullname" . }}-metrics
-  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "argocd-image-updater.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "argocd-image-updater.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.selector }}
@@ -29,7 +29,7 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "argocd-image-updater.namespace" . | quote }}
   selector:
     matchLabels:
       {{- include "argocd-image-updater.selectorLabels" . | nindent 6 }}

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -17,6 +17,8 @@ imagePullSecrets: []
 nameOverride: ""
 # -- Global fullname (argocd-image-updater.fullname in _helpers.tpl) override
 fullnameOverride: ""
+# -- Global namespace (argocd-image-updater.namespace in _helpers.tpl) override
+namespaceOverride: ""
 
 # -- Extra arguments for argocd-image-updater not defined in `config.argocd`.
 # If a flag contains both key and value, they need to be split to a new entry


### PR DESCRIPTION
I use this chart as a dependency but the .Release.Namespace is `bootstrap`, but I need to install argocd-image-updater chart into `argo` namespace.  This allows that and makes everything fall into place for me.

---
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->