### PR TITLE
chore(github): Disable some GH actions on forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'argoproj/argo-helm'
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release
       packages: write  # to push OCI chart package to GitHub Registry

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   renovate:
+    if: github.repository == 'argoproj/argo-helm'
     runs-on: ubuntu-latest
     steps:
       - name: Get token


### PR DESCRIPTION
Some of the GH actions fail on forks. They should probably just not run.

This is how the argo-workflows repo seems to operate, and I've not heard complaints.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
