### PR TITLE
chore(github): Update renovate image only monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -98,6 +98,10 @@
     {
       "matchPackagePatterns": ["redis-ha"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["ghcr.io/renovatebot/renovate"],
+      "extends": ["schedule:monthly"]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

Today we received 3 PRs for renovate updating renovate 😆 :
- https://github.com/argoproj/argo-helm/pull/2560
- https://github.com/argoproj/argo-helm/pull/2563
- https://github.com/argoproj/argo-helm/pull/2567

I think it is enough if we set the schedule to monthly for this exact package.

It is 1:1 copy paste from here:
https://docs.renovatebot.com/configuration-options/#schedule

> To restrict aws-sdk to only monthly updates, you could add this package rule:
> ```json
> {
>   "packageRules": [
>     {
>       "matchPackageNames": ["aws-sdk"],
>       "extends": ["schedule:monthly"]
>     }
>   ]
> }
> ```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
---
Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
