### PR TITLE
chore(argo-rollouts): Change controller deployment strategy to rollingUpdate

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.34.3
+version: 2.34.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-rollouts to v1.6.6
+      description: Change controller deployment strategy to rollingUpdate

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       app.kubernetes.io/component: {{ .Values.controller.component }}
       {{- include "argo-rollouts.selectorLabels" . | nindent 6 }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:


### PR DESCRIPTION
Change controller deployment strategy to rollingUpdate due to chore: change controller's deploy strategy to RollingUpdate due to leader election #3334
https://github.com/argoproj/argo-rollouts/pull/3334/files

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
