### PR TITLE
fix(argo-cd): Fixed default tls hosts for grpc ingress endpoint

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Support ApplicationSet in any namespace.
+      description: Fixed a bug for TLS host value in GRPC ingress endpoint

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.6.0
+version: 6.6.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -278,10 +278,6 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
-### 6.6.1
-
-Fixed a bug were TLS host for GRPC ingress endpoint does not match the Ingress hosts value
-
 ### 6.4.0
 
 Added support for application controller dynamic cluster distribution.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -278,6 +278,10 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 6.6.1
+
+Fixed a bug were TLS host for GRPC ingress endpoint does not match the Ingress hosts value
+
 ### 6.4.0
 
 Added support for application controller dynamic cluster distribution.

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -53,7 +53,7 @@ spec:
   tls:
     {{- if .Values.server.ingressGrpc.tls }}
     - hosts:
-      - {{ $hostname }}
+      - {{ .Values.server.ingressGrpc.hostname | default $hostname }}
       secretName: argocd-server-grpc-tls
     {{- end }}
     {{- with .Values.server.ingressGrpc.extraTls }}


### PR DESCRIPTION
The default tls hosts entry for ingress must match the default ingress rules host - which can be .Values.server.ingressGrpc.hostname or  $hostname  when nothing else was specified.

Example to reproduce this bug:

Create a server with 2 ingresses (for argocd ui and grpc):
```
global:
  domain: "argocd.k8s.local"

server:
  ingress:
    enabled: true

    annotations:
      cert-manager.io/cluster-issuer: blablabla

    tls: true
    hostname: "argocd.k8s.local"

  ingressGrpc:
    enabled: true
    annotations:
      cert-manager.io/cluster-issuer: blablabla
      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"

    tls: true
    hostname: "argocd-grpc.k8s.local"
```
The Argo CD UI ingress endpoint is correct.

The GRPC ingress endpoint will be rendered with wrong tls hosts path (grpc.argocd.k8s.local
 instead of argocd-grpc.k8s.local).

The PR will fix this problem.

---
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->