### PR TITLE
feat(argo-cd): add authentication for builtin Redis

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.10.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.7.6
+version: 6.8.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: added
+      description: added authentication for builtin Redis
     - kind: fixed
       description: added missing crd change for 2.10.5

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1155,9 +1155,9 @@ NAME: my-release
 |-----|------|---------|-------------|
 | redis.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules to the deployment |
 | redis.auth.configAnnotations | object | `{}` | Annotations to be added to Redis config secret |
-| redis.auth.enabled | bool | `false` | enable authentication for Redis. Passwords are auto-generated and stored in argocd-redis |
+| redis.auth.enabled | bool | `false` | Enable authentication for Redis. Passwords are auto-generated and stored in the Secret `argocd-redis`. If you're managing ArgoCD via ArgoCD you need to ignore the auto-generated password fields in `ignoreDifferences` , e.g. with ``` ignoreDifferences: - kind: Secret   name: argocd-redis   jsonPointers:     - /data/redis-password     - /data/redis-password-admin     - /data/redis-password-default ``` |
 | redis.auth.secretAnnotations | object | `{}` | Annotations to be added to Redis secret |
-| redis.auth.username | string | `"argocd"` | username for connecting to Redis |
+| redis.auth.username | string | `"argocd"` | Username for connecting to Redis |
 | redis.containerPorts.metrics | int | `9121` | Metrics container port |
 | redis.containerPorts.redis | int | `6379` | Redis container port |
 | redis.containerSecurityContext | object | See [values.yaml] | Redis container-level security context |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1154,6 +1154,10 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | redis.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| redis.auth.configAnnotations | object | `{}` | Annotations to be added to Redis config secret |
+| redis.auth.enabled | bool | `false` | enable authentication for Redis. Passwords are auto-generated and stored in argocd-redis |
+| redis.auth.secretAnnotations | object | `{}` | Annotations to be added to Redis secret |
+| redis.auth.username | string | `"argocd"` | username for connecting to Redis |
 | redis.containerPorts.metrics | int | `9121` | Metrics container port |
 | redis.containerPorts.redis | int | `6379` | Redis container port |
 | redis.containerSecurityContext | object | See [values.yaml] | Redis container-level security context |
@@ -1183,6 +1187,7 @@ NAME: my-release
 | redis.exporter.readinessProbe.timeoutSeconds | int | `15` | Number of seconds after which the [probe] times out |
 | redis.exporter.resources | object | `{}` | Resource limits and requests for redis-exporter sidecar |
 | redis.extraArgs | list | `[]` | Additional command line arguments to pass to redis-server |
+| redis.extraConfig | string | `""` | Redis extra configuration settings (https://redis.io/docs/management/config-file/) |
 | redis.extraContainers | list | `[]` | Additional containers to be added to the redis pod |
 | redis.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Redis image pull policy |
 | redis.image.repository | string | `"public.ecr.aws/docker/library/redis"` | Redis repository |

--- a/charts/argo-cd/templates/redis/configmap.yaml
+++ b/charts/argo-cd/templates/redis/configmap.yaml
@@ -1,0 +1,25 @@
+{{- $redisHa := index .Values "redis-ha" -}}
+{{- if and .Values.redis.enabled (or .Values.redis.auth.enabled .Values.redis.extraConfig) (not $redisHa.enabled) -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "argo-cd.redis.fullname" . }}-config"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
+  {{- with .Values.redis.auth.secretAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+data:
+  {{- if or .Values.redis.auth.enabled .Values.redis.extraConfig }}
+  redis.conf: |
+    {{- if .Values.redis.auth.enabled }}
+    aclfile /etc/redis/users.acl
+    {{- end }}
+    {{- .Values.redis.extraConfig | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -26,8 +26,9 @@ spec:
         {{- with (mergeOverwrite (deepCopy .Values.global.podLabels) .Values.redis.podLabels) }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.redis.podAnnotations) }}
       annotations:
+        checksum/redis-config: {{ include (print $.Template.BasePath "/redis/secret.yaml") . | sha256sum }}
+      {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.redis.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
@@ -59,6 +60,9 @@ spec:
         args:
         {{- with .Values.redis.extraArgs }}
           {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if or .Values.redis.auth.enabled .Values.redis.extraConfig }}
+        - /etc/redis/redis.conf
         {{- end }}
         - --save
         - ""
@@ -111,6 +115,11 @@ spec:
         volumeMounts:
           - mountPath: /health
             name: health
+        {{- if or .Values.redis.auth.enabled .Values.redis.extraConfig }}
+          - mountPath: /etc/redis
+            name: config
+            readOnly: true
+        {{- end }}
         {{- with .Values.redis.volumeMounts }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -194,6 +203,17 @@ spec:
           configMap:
             name: {{ include "argo-cd.redis.fullname" . }}-health-configmap
             defaultMode: 493
+        {{- if or .Values.redis.auth.enabled .Values.redis.extraConfig }}
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: "{{ include "argo-cd.redis.fullname" . }}-config"
+              {{- if .Values.redis.auth.enabled }}
+              - secret:
+                  name: "{{ include "argo-cd.redis.fullname" . }}-users"
+              {{- end }}
+        {{- end }}
       {{- with .Values.redis.volumes }}
         {{- toYaml . | nindent 8}}
       {{- end }}

--- a/charts/argo-cd/templates/redis/secret.yaml
+++ b/charts/argo-cd/templates/redis/secret.yaml
@@ -1,4 +1,22 @@
-# lookup existing secret
+# lookup existing secret with Helm's `lookup` function.
+# At first, it might seem strange to use this function in the ArgoCD ecosystem.
+# However, the purpose of this Helm Chart is to bootstrap ArgoCD. For this use-case
+# you don't have necessarily ArgoCD available, yet.
+#
+# Basically, ArgoCD can be installed with two approaches:
+# 1. Via Helm -> Helm's `lookup` function works as expected
+# 2. Via ArgoCD -> `lookup` will always return an empty value because ArgoCD
+#    calls `helm template` internally. In this case, you need to ignore the password
+#    fields of the secret in `ignoreDifferences`:
+#    ```yaml
+#    ignoreDifferences:
+#    - kind: Secret
+#      name: argocd-redis
+#      jsonPointers:
+#        - /data/redis-password
+#        - /data/redis-password-admin
+#        - /data/redis-password-default
+#    ```
 {{- $secretName :=  include "argo-cd.redis.fullname" . -}}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secretName) | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}

--- a/charts/argo-cd/templates/redis/secret.yaml
+++ b/charts/argo-cd/templates/redis/secret.yaml
@@ -1,0 +1,60 @@
+# lookup existing secret
+{{- $secretName :=  include "argo-cd.redis.fullname" . -}}
+{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secretName) | default dict }}
+{{- $secretData := (get $secretObj "data") | default dict }}
+# generate random password if secret doesn't exist
+{{- $defaultUserPassword := (get $secretData "redis-password-default") | default (randAlphaNum 48 | b64enc) }}
+{{- $adminUserPassword := (get $secretData "redis-password-admin") | default (randAlphaNum 48 | b64enc) }}
+{{- $argoUserPassword := (get $secretData "redis-password") | default (randAlphaNum 48 | b64enc) }}
+{{- if .Values.redis.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
+  {{- with .Values.redis.auth.secretAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+type: Opaque
+immutable: true
+data:
+  redis-username-default: {{ "default" | b64enc }}
+  redis-password-default: {{ $defaultUserPassword | quote }}
+
+  redis-username-admin: {{ "admin" | b64enc }}
+  redis-password-admin: {{ $adminUserPassword | quote }}
+
+  {{- with .Values.redis.auth.username }}
+  redis-username: {{ . | b64enc }}
+  {{- end }}
+  redis-password: {{ $argoUserPassword | quote }}
+{{- end }}
+
+{{- $redisHa := index .Values "redis-ha" -}}
+{{- if and .Values.redis.enabled .Values.redis.auth.enabled (not $redisHa.enabled) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "argo-cd.redis.fullname" . }}-users"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
+  {{- with .Values.redis.auth.secretAnnotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+stringData:
+  users.acl: |
+    user default on +@all -@admin -@dangerous ~* &* >{{ $defaultUserPassword | b64dec }}
+    user admin on +@all -@admin -@dangerous ~* &* >{{ $adminUserPassword | b64dec }}
+    user {{ .Values.redis.auth.username }} on +@all ~* &* >{{ $argoUserPassword | b64dec }}
+
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1163,6 +1163,20 @@ redis:
   # -- Redis name
   name: redis
 
+  # -- Redis extra configuration settings (https://redis.io/docs/management/config-file/)
+  extraConfig: ""
+
+  ## Redis authentication
+  auth:
+    # -- enable authentication for Redis. Passwords are auto-generated and stored in argocd-redis
+    enabled: false
+    # -- username for connecting to Redis
+    username: argocd
+    # -- Annotations to be added to Redis secret
+    secretAnnotations: {}
+    # -- Annotations to be added to Redis config secret
+    configAnnotations: {}
+
   ## Redis Pod Disruption Budget
   ## Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   pdb:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1168,9 +1168,20 @@ redis:
 
   ## Redis authentication
   auth:
-    # -- enable authentication for Redis. Passwords are auto-generated and stored in argocd-redis
+    # -- Enable authentication for Redis. Passwords are auto-generated and stored in the Secret `argocd-redis`.
+    # If you're managing ArgoCD via ArgoCD you need to ignore the auto-generated password fields in `ignoreDifferences`
+    # , e.g. with
+    # ```
+    # ignoreDifferences:
+    # - kind: Secret
+    #   name: argocd-redis
+    #   jsonPointers:
+    #     - /data/redis-password
+    #     - /data/redis-password-admin
+    #     - /data/redis-password-default
+    # ```
     enabled: false
-    # -- username for connecting to Redis
+    # -- Username for connecting to Redis
     username: argocd
     # -- Annotations to be added to Redis secret
     secretAnnotations: {}


### PR DESCRIPTION
This PR introduces authentication for the builtin Redis. It can be enabled by setting `redis.auth.enabled=true`. The secrets are auto-generated and stored in a secret.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
