### PR TITLE
feat(argo-workflows): Add the ability to use headless service for workflow controller

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.41.0
+version: 0.41.1
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Check Prometheus CRDs are available before creating Service Monitor resource(s)
+      description: Add the ability to use a headless service for the workflow controller

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -155,6 +155,7 @@ Fields to note:
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
 | controller.extraInitContainers | list | `[]` | Enables init containers to be added to the controller deployment |
+| controller.headlessService | bool | `false` | Whether to use a headless service or not. |
 | controller.image.registry | string | `"quay.io"` | Registry to use for the controller |
 | controller.image.repository | string | `"argoproj/workflow-controller"` | Registry to use for the controller |
 | controller.image.tag | string | `""` | Image tag for the workflow controller. Defaults to `.Values.images.tag`. |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -155,7 +155,6 @@ Fields to note:
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
 | controller.extraInitContainers | list | `[]` | Enables init containers to be added to the controller deployment |
-| controller.headlessService | bool | `false` | Whether to use a headless service or not. |
 | controller.image.registry | string | `"quay.io"` | Registry to use for the controller |
 | controller.image.repository | string | `"argoproj/workflow-controller"` | Registry to use for the controller |
 | controller.image.tag | string | `""` | Image tag for the workflow controller. Defaults to `.Values.images.tag`. |
@@ -171,6 +170,7 @@ Fields to note:
 | controller.logging.globallevel | string | `"0"` | Set the glog logging level |
 | controller.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
 | controller.metricsConfig.enabled | bool | `false` | Enables prometheus metrics server |
+| controller.metricsConfig.headlessService | bool | `false` | Flag to enable headless service |
 | controller.metricsConfig.ignoreErrors | bool | `false` | Flag that instructs prometheus to ignore metric emission errors. |
 | controller.metricsConfig.metricRelabelings | list | `[]` | ServiceMonitor metric relabel configs to apply to samples before ingestion |
 | controller.metricsConfig.metricsTTL | string | `""` | How often custom metrics are cleared from memory |

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -32,7 +32,7 @@ spec:
     {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 4 }}
   sessionAffinity: None
   type: {{ .Values.controller.serviceType }}
-  {{- if and (eq .Values.controller.serviceType "ClusterIP") .Values.controller.headlessService }}
+  {{- if and (eq .Values.controller.serviceType "ClusterIP") .Values.controller.metricsConfig.headlessService }}
   clusterIP: None
   {{- end }}
   {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-service.yaml
@@ -32,6 +32,9 @@ spec:
     {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 4 }}
   sessionAffinity: None
   type: {{ .Values.controller.serviceType }}
+  {{- if and (eq .Values.controller.serviceType "ClusterIP") .Values.controller.headlessService }}
+  clusterIP: None
+  {{- end }}
   {{- if and (eq .Values.controller.serviceType "LoadBalancer") .Values.controller.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml .Values.controller.loadBalancerSourceRanges | nindent 4 }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -83,7 +83,8 @@ controller:
   # -- Globally limits the rate at which pods are created.
   # This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of
   # parallel nodes.
-  resourceRateLimit: {}
+  resourceRateLimit:
+    {}
     # limit: 10
     # burst: 1
 
@@ -213,7 +214,8 @@ controller:
   cronWorkflowWorkers: # 8
   # -- Restricts the Workflows that the controller will process.
   # Only valid for 2.9+
-  workflowRestrictions: {}
+  workflowRestrictions:
+    {}
     # templateReferencing: Strict|Secure
 
   # telemetryConfig controls the path and port for prometheus telemetry. Telemetry is enabled and emitted in the same endpoint
@@ -235,6 +237,7 @@ controller:
     servicePort: 8081
     # -- telemetry service port name
     servicePortName: telemetry
+
   serviceMonitor:
     # -- Enable a prometheus ServiceMonitor
     enabled: false
@@ -285,6 +288,8 @@ controller:
 
   # -- Service type of the controller Service
   serviceType: ClusterIP
+  # -- Whether to use a headless service or not.
+  headlessService: false
   # -- Annotations to be applied to the controller Service
   serviceAnnotations: {}
   # -- Optional labels to add to the controller Service
@@ -307,7 +312,8 @@ controller:
     timeoutSeconds: 30
 
   # -- Extra environment variables to provide to the controller container
-  extraEnv: []
+  extraEnv:
+    []
     # - name: FOO
     #   value: "bar"
 
@@ -380,7 +386,8 @@ controller:
   # -- Configure when workflow controller runs in a different k8s cluster with the workflow workloads,
   # or needs to communicate with the k8s apiserver using an out-of-cluster kubeconfig secret.
   # @default -- `{}` (See [values.yaml])
-  kubeConfig: {}
+  kubeConfig:
+    {}
     # # name of the kubeconfig secret, may not be empty when kubeConfig specified
     # secretName: kubeconfig-secret
     # # key of the kubeconfig secret, may not be empty when kubeConfig specified
@@ -520,7 +527,8 @@ server:
     targetMemoryUtilizationPercentage: 50
     # -- Configures the scaling behavior of the target in both Up and Down directions.
     # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
-    behavior: {}
+    behavior:
+      {}
       # scaleDown:
       #  stabilizationWindowSeconds: 300
       #  policies:
@@ -566,7 +574,8 @@ server:
   secure: false
 
   # -- Extra environment variables to provide to the argo-server container
-  extraEnv: []
+  extraEnv:
+    []
     # - name: FOO
     #   value: "bar"
 
@@ -612,7 +621,8 @@ server:
     # -- List of ingress hosts
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace
-    hosts: []
+    hosts:
+      []
       # - argoworkflows.example.com
 
     # -- List of ingress paths
@@ -622,7 +632,8 @@ server:
     # -- Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`
     pathType: Prefix
     # -- Additional ingress paths
-    extraPaths: []
+    extraPaths:
+      []
       # - path: /*
       #   backend:
       #     serviceName: ssl-redirect
@@ -637,7 +648,8 @@ server:
       #         name: use-annotation
 
     # -- Ingress TLS configuration
-    tls: []
+    tls:
+      []
       # - secretName: argoworkflows-example-tls
       #   hosts:
       #     - argoworkflows.example.com
@@ -662,7 +674,7 @@ server:
     enabled: false
     # -- Domains for the Google Managed Certificate
     domains:
-    - argoworkflows.example.com
+      - argoworkflows.example.com
 
   ## Create a Google FrontendConfig Custom Resource, for use with the GKE Ingress Controller
   ## https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#configuring_ingress_features_through_frontendconfig_parameters
@@ -703,15 +715,16 @@ server:
     rbac:
       # -- Adds ServiceAccount Policy to server (Cluster)Role.
       enabled: true
-    # -- Whitelist to allow server to fetch Secrets
-    ## When present, restricts secrets the server can read to a given list.
-    ## You can use it to restrict the server to only be able to access the
-    ## service account token secrets that are associated with service accounts
-    ## used for authorization.
+      # -- Whitelist to allow server to fetch Secrets
+      ## When present, restricts secrets the server can read to a given list.
+      ## You can use it to restrict the server to only be able to access the
+      ## service account token secrets that are associated with service accounts
+      ## used for authorization.
       secretWhitelist: []
     # -- Scopes requested from the SSO ID provider
     ## The 'groups' scope requests group membership information, which is usually used for authorization decisions.
-    scopes: []
+    scopes:
+      []
       # - groups
     # -- Define how long your login is valid for (in hours)
     ## If omitted, defaults to 10h.
@@ -727,7 +740,8 @@ server:
     insecureSkipVerify: false
     # -- Filter the groups returned by the OIDC provider
     ## A logical "OR" is used between each regex in the list
-    filterGroupsRegex: []
+    filterGroupsRegex:
+      []
       # - ".*argo-wf.*"
       # - ".*argo-workflow.*"
 
@@ -738,7 +752,8 @@ server:
   extraInitContainers: []
 
 # -- Array of extra K8s manifests to deploy
-extraObjects: []
+extraObjects:
+  []
   # - apiVersion: secrets-store.csi.x-k8s.io/v1
   #   kind: SecretProviderClass
   #   metadata:
@@ -770,7 +785,8 @@ artifactRepository:
   archiveLogs: false
   # -- Store artifact in a S3-compliant object store
   # @default -- See [values.yaml]
-  s3: {}
+  s3:
+    {}
     # # Note the `key` attribute is not the actual secret, it's the PATH to
     # # the contents in the associated secret, as defined by the `name` attribute.
     # accessKeySecret:
@@ -793,7 +809,8 @@ artifactRepository:
     #   enableEncryption: true
   # -- Store artifact in a GCS object store
   # @default -- `{}` (See [values.yaml])
-  gcs: {}
+  gcs:
+    {}
     # bucket: <project>-argo
     # keyFormat: "{{ \"{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}\" }}"
     # # serviceAccountKeySecret is a secret selector.
@@ -809,7 +826,8 @@ artifactRepository:
     #   key: serviceAccountKey
   # -- Store artifact in Azure Blob Storage
   # @default -- `{}` (See [values.yaml])
-  azure: {}
+  azure:
+    {}
     # endpoint: https://mystorageaccountname.blob.core.windows.net
     # container: my-container-name
     # blobNameFormat: path/in/container
@@ -841,7 +859,8 @@ customArtifactRepository: {}
 # -- The section of [artifact repository ref](https://argo-workflows.readthedocs.io/en/stable/artifact-repository-ref/).
 # Each map key is the name of configmap
 # @default -- `{}` (See [values.yaml])
-artifactRepositoryRef: {}
+artifactRepositoryRef:
+  {}
   # # -- 1st ConfigMap
   # # If you want to use this config map by default, name it "artifact-repositories".
   # # Otherwise, you can provide a reference to a

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -83,8 +83,7 @@ controller:
   # -- Globally limits the rate at which pods are created.
   # This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of
   # parallel nodes.
-  resourceRateLimit:
-    {}
+  resourceRateLimit: {}
     # limit: 10
     # burst: 1
 
@@ -136,6 +135,8 @@ controller:
     servicePort: 8080
     # -- Service metrics port name
     servicePortName: metrics
+    # -- Flag to enable headless service
+    headlessService: false
     # -- ServiceMonitor relabel configs to apply to samples before scraping
     ## Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     relabelings: []
@@ -214,8 +215,7 @@ controller:
   cronWorkflowWorkers: # 8
   # -- Restricts the Workflows that the controller will process.
   # Only valid for 2.9+
-  workflowRestrictions:
-    {}
+  workflowRestrictions: {}
     # templateReferencing: Strict|Secure
 
   # telemetryConfig controls the path and port for prometheus telemetry. Telemetry is enabled and emitted in the same endpoint
@@ -237,7 +237,6 @@ controller:
     servicePort: 8081
     # -- telemetry service port name
     servicePortName: telemetry
-
   serviceMonitor:
     # -- Enable a prometheus ServiceMonitor
     enabled: false
@@ -288,8 +287,6 @@ controller:
 
   # -- Service type of the controller Service
   serviceType: ClusterIP
-  # -- Whether to use a headless service or not.
-  headlessService: false
   # -- Annotations to be applied to the controller Service
   serviceAnnotations: {}
   # -- Optional labels to add to the controller Service
@@ -312,8 +309,7 @@ controller:
     timeoutSeconds: 30
 
   # -- Extra environment variables to provide to the controller container
-  extraEnv:
-    []
+  extraEnv: []
     # - name: FOO
     #   value: "bar"
 
@@ -386,8 +382,7 @@ controller:
   # -- Configure when workflow controller runs in a different k8s cluster with the workflow workloads,
   # or needs to communicate with the k8s apiserver using an out-of-cluster kubeconfig secret.
   # @default -- `{}` (See [values.yaml])
-  kubeConfig:
-    {}
+  kubeConfig: {}
     # # name of the kubeconfig secret, may not be empty when kubeConfig specified
     # secretName: kubeconfig-secret
     # # key of the kubeconfig secret, may not be empty when kubeConfig specified
@@ -527,8 +522,7 @@ server:
     targetMemoryUtilizationPercentage: 50
     # -- Configures the scaling behavior of the target in both Up and Down directions.
     # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
-    behavior:
-      {}
+    behavior: {}
       # scaleDown:
       #  stabilizationWindowSeconds: 300
       #  policies:
@@ -574,8 +568,7 @@ server:
   secure: false
 
   # -- Extra environment variables to provide to the argo-server container
-  extraEnv:
-    []
+  extraEnv: []
     # - name: FOO
     #   value: "bar"
 
@@ -621,8 +614,7 @@ server:
     # -- List of ingress hosts
     ## Hostnames must be provided if Ingress is enabled.
     ## Secrets must be manually created in the namespace
-    hosts:
-      []
+    hosts: []
       # - argoworkflows.example.com
 
     # -- List of ingress paths
@@ -632,8 +624,7 @@ server:
     # -- Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific`
     pathType: Prefix
     # -- Additional ingress paths
-    extraPaths:
-      []
+    extraPaths: []
       # - path: /*
       #   backend:
       #     serviceName: ssl-redirect
@@ -648,8 +639,7 @@ server:
       #         name: use-annotation
 
     # -- Ingress TLS configuration
-    tls:
-      []
+    tls: []
       # - secretName: argoworkflows-example-tls
       #   hosts:
       #     - argoworkflows.example.com
@@ -674,7 +664,7 @@ server:
     enabled: false
     # -- Domains for the Google Managed Certificate
     domains:
-      - argoworkflows.example.com
+    - argoworkflows.example.com
 
   ## Create a Google FrontendConfig Custom Resource, for use with the GKE Ingress Controller
   ## https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#configuring_ingress_features_through_frontendconfig_parameters
@@ -715,16 +705,15 @@ server:
     rbac:
       # -- Adds ServiceAccount Policy to server (Cluster)Role.
       enabled: true
-      # -- Whitelist to allow server to fetch Secrets
-      ## When present, restricts secrets the server can read to a given list.
-      ## You can use it to restrict the server to only be able to access the
-      ## service account token secrets that are associated with service accounts
-      ## used for authorization.
+    # -- Whitelist to allow server to fetch Secrets
+    ## When present, restricts secrets the server can read to a given list.
+    ## You can use it to restrict the server to only be able to access the
+    ## service account token secrets that are associated with service accounts
+    ## used for authorization.
       secretWhitelist: []
     # -- Scopes requested from the SSO ID provider
     ## The 'groups' scope requests group membership information, which is usually used for authorization decisions.
-    scopes:
-      []
+    scopes: []
       # - groups
     # -- Define how long your login is valid for (in hours)
     ## If omitted, defaults to 10h.
@@ -740,8 +729,7 @@ server:
     insecureSkipVerify: false
     # -- Filter the groups returned by the OIDC provider
     ## A logical "OR" is used between each regex in the list
-    filterGroupsRegex:
-      []
+    filterGroupsRegex: []
       # - ".*argo-wf.*"
       # - ".*argo-workflow.*"
 
@@ -752,8 +740,7 @@ server:
   extraInitContainers: []
 
 # -- Array of extra K8s manifests to deploy
-extraObjects:
-  []
+extraObjects: []
   # - apiVersion: secrets-store.csi.x-k8s.io/v1
   #   kind: SecretProviderClass
   #   metadata:
@@ -785,8 +772,7 @@ artifactRepository:
   archiveLogs: false
   # -- Store artifact in a S3-compliant object store
   # @default -- See [values.yaml]
-  s3:
-    {}
+  s3: {}
     # # Note the `key` attribute is not the actual secret, it's the PATH to
     # # the contents in the associated secret, as defined by the `name` attribute.
     # accessKeySecret:
@@ -809,8 +795,7 @@ artifactRepository:
     #   enableEncryption: true
   # -- Store artifact in a GCS object store
   # @default -- `{}` (See [values.yaml])
-  gcs:
-    {}
+  gcs: {}
     # bucket: <project>-argo
     # keyFormat: "{{ \"{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}\" }}"
     # # serviceAccountKeySecret is a secret selector.
@@ -826,8 +811,7 @@ artifactRepository:
     #   key: serviceAccountKey
   # -- Store artifact in Azure Blob Storage
   # @default -- `{}` (See [values.yaml])
-  azure:
-    {}
+  azure: {}
     # endpoint: https://mystorageaccountname.blob.core.windows.net
     # container: my-container-name
     # blobNameFormat: path/in/container
@@ -859,8 +843,7 @@ customArtifactRepository: {}
 # -- The section of [artifact repository ref](https://argo-workflows.readthedocs.io/en/stable/artifact-repository-ref/).
 # Each map key is the name of configmap
 # @default -- `{}` (See [values.yaml])
-artifactRepositoryRef:
-  {}
+artifactRepositoryRef: {}
   # # -- 1st ConfigMap
   # # If you want to use this config map by default, name it "artifact-repositories".
   # # Otherwise, you can provide a reference to a


### PR DESCRIPTION
This PR adds the ability to use a headless service for the workflow controller as recommended in the [docs](https://argo-workflows.readthedocs.io/en/latest/metrics/#metrics-endpoint) to use when running the workflow controller in HA mode.

Related issue: https://github.com/argoproj/argo-helm/issues/2190

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
