### PR TITLE
feat(argo-workflows): Add executor.image.cmdArgDefinition

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.41.1
+version: 0.41.2
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,6 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add the ability to use a headless service for the workflow controller
+      description: Add the ability to use place executor image definition to ConfigMap
+    - kind: changed
+      description: Default placement of definition of executor image was changes from command-line argument of Controller to ConfigMap

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -251,6 +251,7 @@ Fields to note:
 |-----|------|---------|-------------|
 | executor.args | list | `[]` | Passes arguments to the executor processes |
 | executor.env | list | `[]` | Adds environment variables for the executor. |
+| executor.image.cmdArgDefinition | bool | `false` | if true image is defined as Controller's command line argument otherwise defined in ConfigMap. |
 | executor.image.pullPolicy | string | `""` | Image PullPolicy to use for the Workflow Executors. Defaults to `.Values.images.pullPolicy`. |
 | executor.image.registry | string | `"quay.io"` | Registry to use for the Workflow Executors |
 | executor.image.repository | string | `"argoproj/argoexec"` | Repository to use for the Workflow Executors |

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -43,8 +43,11 @@ data:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
-    {{- if or .Values.executor.resources .Values.executor.env .Values.executor.args .Values.executor.securityContext}}
+    {{- if or .Values.executor.resources .Values.executor.env .Values.executor.args .Values.executor.securityContext (not .Values.executor.image.cmdArgDefinition) }}
     executor:
+      {{- if not .Values.executor.image.cmdArgDefinition }}
+      image: "{{- include "argo-workflows.image" (dict "context" . "image" .Values.executor.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag }}"
+      {{- end }}
       imagePullPolicy: {{ default (.Values.images.pullPolicy) .Values.executor.image.pullPolicy }}
       {{- with .Values.executor.resources }}
       resources: {{- toYaml . | nindent 8 }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -46,8 +46,10 @@ spec:
           args:
           - "--configmap"
           - "{{ template "argo-workflows.controller.config-map.name" . }}"
+          {{- if .Values.executor.image.cmdArgDefinition }}
           - "--executor-image"
           - "{{- include "argo-workflows.image" (dict "context" . "image" .Values.executor.image) }}:{{ default (include "argo-workflows.defaultTag" .) .Values.executor.image.tag }}"
+          {{- end }}
           - "--loglevel"
           - "{{ .Values.controller.logging.level }}"
           - "--gloglevel"

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -424,6 +424,8 @@ executor:
     tag: ""
     # -- Image PullPolicy to use for the Workflow Executors. Defaults to `.Values.images.pullPolicy`.
     pullPolicy: ""
+    # -- if true image is defined as Controller's command line argument otherwise defined in ConfigMap.
+    cmdArgDefinition: false
   # -- Resource limits and requests for the Workflow Executors
   resources: {}
   # -- Passes arguments to the executor processes


### PR DESCRIPTION
This PR addes the ability to use place executor image definition to ConfigMap

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
