### PR TITLE
feat(argocd-image-updater): Allow defining extraEnvFrom for the deployment

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.9.6
+version: 0.9.7
 appVersion: v0.12.2
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,9 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Properly quoting the config map values
-    - kind: fixed
-      description: Only adding a data field to argocd-image-updater-ssh-config when there's data to be added
-    - kind: changed
-      description: Only include config.argocd if config.applicationsAPIKind is set to 'argocd'
+    - kind: added
+      description: Allow defining extraEnvFrom for the deployment

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -86,6 +86,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | config.sshConfig | object | `{}` | Argo CD Image Updater ssh client parameter configuration. |
 | extraArgs | list | `[]` | Extra arguments for argocd-image-updater not defined in `config.argocd`. If a flag contains both key and value, they need to be split to a new entry |
 | extraEnv | list | `[]` | Extra environment variables for argocd-image-updater |
+| extraEnvFrom | list | `[]` | Extra envFrom to pass to argocd-image-updater |
 | extraObjects | list | `[]` | Extra K8s manifests to deploy for argocd-image-updater |
 | fullnameOverride | string | `""` | Global fullname (argocd-image-updater.fullname in _helpers.tpl) override |
 | image.pullPolicy | string | `"Always"` | Default image pull policy |

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
           {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -44,6 +44,13 @@ extraEnv: []
   # - name: AWS_REGION
   #   value: "us-west-1"
 
+# -- Extra envFrom to pass to argocd-image-updater
+extraEnvFrom: []
+  # - configMapRef:
+  #     name: config-map-name
+  # - secretRef:
+  #     name: secret-name
+
 # -- Extra K8s manifests to deploy for argocd-image-updater
 ## Note: Supports use of custom Helm templates
 extraObjects: []


### PR DESCRIPTION
This PR allows defining envFrom vars for image updater to be used, as it is possible in the argo-cd chart.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
