### PR TITLE
feat(argocd-apps): allow plugin config in applicationsets

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: A Helm chart for managing additional Argo CD Applications and Projects
 type: application
-version: 2.0.0
+version: 2.1.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -18,4 +18,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: make the chart use maps instead of lists
+      description: allow config of applicationsets plugin

--- a/charts/argocd-apps/templates/applicationsets.yaml
+++ b/charts/argocd-apps/templates/applicationsets.yaml
@@ -67,6 +67,10 @@ spec:
       sources:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .plugin }}
+      plugin:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       destination:
         {{- toYaml .destination | nindent 8 }}
       {{- with .syncPolicy }}


### PR DESCRIPTION
This change enables configuration of configuration management plugins (cmp) in an ApplicationSet template.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
