### PR TITLE
feat(argo-workflows): Allow adding additional ServiceAccounts to RoleBinding

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.6
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.41.3
+version: 0.41.4
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Fix hyphen typo in values.yaml comments
+    - kind: added
+      description: Added option to add service accounts to RoleBindings

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -134,6 +134,7 @@ Fields to note:
 |-----|------|---------|-------------|
 | workflow.namespace | string | `nil` | Deprecated; use controller.workflowNamespaces instead. |
 | workflow.rbac.create | bool | `true` | Adds Role and RoleBinding for the above specified service account to be able to run workflows. A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below) |
+| workflow.rbac.serviceAccounts | list | `[]` | Extra service accounts to be added to the RoleBinding |
 | workflow.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | workflow.serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | workflow.serviceAccount.labels | object | `{}` | Labels applied to created service account |
@@ -146,6 +147,7 @@ Fields to note:
 |-----|------|---------|-------------|
 | controller.affinity | object | `{}` | Assign custom [affinity] rules |
 | controller.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the controller to access ClusterWorkflowTemplates. |
+| controller.clusterWorkflowTemplates.serviceAccounts | list | `[]` | Extra service accounts to be added to the ClusterRoleBinding |
 | controller.columns | list | `[]` | Configure Argo Server to show custom [columns] |
 | controller.configMap.create | bool | `true` | Create a ConfigMap for the controller |
 | controller.configMap.name | string | `""` | ConfigMap name |

--- a/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-crb.yaml
@@ -41,5 +41,10 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "argo-workflows.controllerServiceAccountName" . }}
     namespace: {{ include "argo-workflows.namespace" . | quote }}
+{{- range .Values.controller.clusterWorkflowTemplates.serviceAccounts }}
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ .namespace | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-rb.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-rb.yaml
@@ -17,8 +17,11 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ $.Values.workflow.serviceAccount.name }}
-    {{- with $namespace }}
-    namespace: {{ . }}
-    {{- end }}
+    namespace: {{ $namespace }}
+  {{- range $.Values.workflow.rbac.serviceAccounts }}
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ .namespace | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -69,6 +69,10 @@ workflow:
     # -- Adds Role and RoleBinding for the above specified service account to be able to run workflows.
     # A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below)
     create: true
+    # -- Extra service accounts to be added to the RoleBinding
+    serviceAccounts: []
+      # - name: my-service-account
+      #   namespace: my-namespace
 
 controller:
   image:
@@ -361,6 +365,10 @@ controller:
   clusterWorkflowTemplates:
     # -- Create a ClusterRole and CRB for the controller to access ClusterWorkflowTemplates.
     enabled: true
+    # -- Extra service accounts to be added to the ClusterRoleBinding
+    serviceAccounts: []
+      # - name: my-service-account
+      #   namespace: my-namespace
   # -- Extra containers to be added to the controller deployment
   extraContainers: []
 


### PR DESCRIPTION
I added an option to add additional SAs to the RoleBinding and ClusterRoleBinding that is created by default under `controller.clusterWorkflowTemplates` and `workflow.rbac`. This way users can configure other Service Accounts to be bound to that default Role.

Example: by providing a list of ServiceAccounts:
```yaml
    serviceAccounts:
      - name: my-service-account
        namespace: my-namespace
```
I got the following result (`helm template -f values.yaml . --show-only templates/controller/workflow-rb.yaml`):

```yaml
---
# Source: argo-workflows/templates/controller/workflow-rb.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: release-name-argo-workflows-workflow
  labels:
    helm.sh/chart: argo-workflows-0.41.4
    app.kubernetes.io/name: argo-workflows-workflow-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workflow-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argo-workflows
  namespace: default
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: release-name-argo-workflows-workflow
subjects:
  - kind: ServiceAccount
    name: argo-workflow
    namespace: default
  - kind: ServiceAccount
    name: my-service-account
    namespace: "my-namespace"
---
# Source: argo-workflows/templates/controller/workflow-rb.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: release-name-argo-workflows-workflow
  labels:
    helm.sh/chart: argo-workflows-0.41.4
    app.kubernetes.io/name: argo-workflows-workflow-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workflow-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argo-workflows
  namespace: argo
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: release-name-argo-workflows-workflow
subjects:
  - kind: ServiceAccount
    name: argo-workflow
    namespace: argo
  - kind: ServiceAccount
    name: my-service-account
    namespace: "my-namespace"
```

And CRB (`helm template -f values.yaml . --show-only templates/controller/workflow-controller-crb.yaml`):
```yaml
---
# Source: argo-workflows/templates/controller/workflow-controller-crb.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name-argo-workflows-workflow-controller
  labels:
    helm.sh/chart: argo-workflows-0.41.4
    app.kubernetes.io/name: argo-workflows-workflow-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workflow-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argo-workflows
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: release-name-argo-workflows-workflow-controller
subjects:
  - kind: ServiceAccount
    name: release-name-argo-workflows-workflow-controller
    namespace: "argo"
---
# Source: argo-workflows/templates/controller/workflow-controller-crb.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name-argo-workflows-workflow-controller-cluster-template
  labels:
    helm.sh/chart: argo-workflows-0.41.4
    app.kubernetes.io/name: argo-workflows-workflow-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workflow-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argo-workflows
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: release-name-argo-workflows-workflow-controller-cluster-template
subjects:
  - kind: ServiceAccount
    name: release-name-argo-workflows-workflow-controller
    namespace: "argo"
  - kind: ServiceAccount
    name: my-service-account
    namespace: "my-namespace"

```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
