### PR TITLE
feat(argo-rollouts): Add podLabels at the controller & dashboard level

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.36.0
+version: 2.35.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.6
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.35.1
+version: 2.36.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Allow minimum set of RBAC rules for Gateway API resources
+      description: Added pod labels for the controller and the dashboard components

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -116,7 +116,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
-| controller.podLabels | object | `{}` |  |
+| controller.podLabels | object | `{}` | Labels to be added to the application controller pods |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
@@ -169,7 +169,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
-| dashboard.podLabels | object | `{}` |  |
+| dashboard.podLabels | object | `{}` | Labels to be added to the application dashboard pods |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -116,6 +116,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | controller.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
+| controller.podLabels | object | `{}` |  |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
@@ -168,6 +169,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.pdb.maxUnavailable | string | `nil` | Maximum number / percentage of pods that may be made unavailable |
 | dashboard.pdb.minAvailable | string | `nil` | Minimum number / percentage of pods that should remain scheduled |
 | dashboard.podAnnotations | object | `{}` | Annotations to be added to application dashboard pods |
+| dashboard.podLabels | object | `{}` |  |
 | dashboard.podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | dashboard.priorityClassName | string | `""` | [priorityClassName] for the dashboard server |
 | dashboard.readonly | bool | `false` | Set cluster role to readonly |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Values.controller.component }}
-        {{- range $key, $value := .Values.podLabels }}
+        {{- range $key, $value := (mergeOverwrite (deepCopy .Values.podLabels) .Values.controller.podLabels) }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:

--- a/charts/argo-rollouts/templates/dashboard/deployment.yaml
+++ b/charts/argo-rollouts/templates/dashboard/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Values.dashboard.component }}
-        {{- range $key, $value := .Values.podLabels }}
+        {{- range $key, $value := (mergeOverwrite (deepCopy .Values.podLabels) .Values.dashboard.podLabels) }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -53,7 +53,7 @@ controller:
   deploymentLabels: {}
   # -- Annotations to be added to application controller pods
   podAnnotations: {}
-  # Labels to be added to the application controller pods
+  # -- Labels to be added to the application controller pods
   podLabels: {}
   # -- [Node selector]
   nodeSelector: {}
@@ -297,7 +297,7 @@ dashboard:
   deploymentLabels: {}
   # -- Annotations to be added to application dashboard pods
   podAnnotations: {}
-  # Labels to be added to the application dashboard pods
+  # -- Labels to be added to the application dashboard pods
   podLabels: {}
   # -- [Node selector]
   nodeSelector: {}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -53,6 +53,8 @@ controller:
   deploymentLabels: {}
   # -- Annotations to be added to application controller pods
   podAnnotations: {}
+  # Labels to be added to the application controller pods
+  podLabels: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints
@@ -295,6 +297,8 @@ dashboard:
   deploymentLabels: {}
   # -- Annotations to be added to application dashboard pods
   podAnnotations: {}
+  # Labels to be added to the application dashboard pods
+  podLabels: {}
   # -- [Node selector]
   nodeSelector: {}
   # -- [Tolerations] for use with node taints


### PR DESCRIPTION
This aligns with how podAnnotations works and allows for unique labels for each application at the pod level.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
