### PR TITLE
feat(argocd-image-updater): add commit signing support

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.9.7
+version: 0.9.8
 appVersion: v0.12.2
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -20,3 +20,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Allow defining extraEnvFrom for the deployment
+    - kind: added
+      description: Added optional environment variables for commit signing configuration

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -64,6 +64,68 @@ If you need support for ECR, you can reference this issue, [Support ECR authenti
 
 The `config.registries` value can be used exactly as it looks in the documentation as it gets dumped directly into a configmap in this chart.
 
+### Commit Signing
+
+Commit signing requires the repository be accessed using HTTPS or SSH with a user account.
+Repositories accessed using a GitHub App can not be verified when using the git command line at this time.
+
+Each Git commit associated with an author's name and email address can be signed via a public SSH key or GPG key.
+Commit signing requires a bot account with a GPG or SSH key and the username and email address configured to match the bot account.
+
+Commit Sign Off can be enabled by setting `git.commit-sign-off: "true"`
+
+**SSH:**
+
+Both private and public keys must be mounted and accessible on the `argocd-image-updater` pod.
+
+Set `git.commit-signing-key` `argocd-image-updater-config` ConfigMap to the path of your public key:
+
+```yaml
+data:
+  git.commit-sign-off: "true"
+  git.commit-signing-key: /app/.ssh/id_rsa.pub
+```
+
+The matching private key must be available in the same location.
+
+Create a new SSH secret or add the public key to your existing SSH secret:
+```bash
+kubectl -n argocd-image-updater create secret generic ssh-git-creds \
+  --from-file=sshPrivateKey=~/.ssh/id_rsa \
+  --from-file=sshPublicKey=~/.ssh/id_rsa.pub
+```
+
+**GPG:**
+
+The GPG private key must be installed and available in the `argocd-image-updater` pod.
+Set `git.commit-signing-key` in the `argocd-image-updater-config` ConfigMap to the GPG key ID you want to use:
+
+```yaml
+data:
+  git.commit-sign-off: "true"
+  git.commit-signing-key: 3AA5C34371567BD2
+```
+
+Volume configuration must be added to mount your SSH signing keys:
+
+```yaml
+volumeMounts:
+- name: ssh-signing-key
+  mountPath: /app/.ssh/id_rsa
+  readOnly: true
+  subPath: sshPrivateKey
+- name: ssh-signing-key
+  mountPath: /app/.ssh/id_rsa.pub
+  readOnly: true
+  subPath: sshPublicKey
+
+volumes:
+- name: ssh-signing-key
+  secret:
+    secretName: ssh-git-creds
+  optional: true
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/argocd-image-updater/README.md.gotmpl
+++ b/charts/argocd-image-updater/README.md.gotmpl
@@ -64,6 +64,69 @@ If you need support for ECR, you can reference this issue, [Support ECR authenti
 
 The `config.registries` value can be used exactly as it looks in the documentation as it gets dumped directly into a configmap in this chart.
 
+### Commit Signing
+
+Commit signing requires the repository be accessed using HTTPS or SSH with a user account.
+Repositories accessed using a GitHub App can not be verified when using the git command line at this time.
+
+Each Git commit associated with an author's name and email address can be signed via a public SSH key or GPG key.
+Commit signing requires a bot account with a GPG or SSH key and the username and email address configured to match the bot account.
+
+
+Commit Sign Off can be enabled by setting `git.commit-sign-off: "true"`
+
+**SSH:**
+
+Both private and public keys must be mounted and accessible on the `argocd-image-updater` pod.
+
+Set `git.commit-signing-key` `argocd-image-updater-config` ConfigMap to the path of your public key:
+
+```yaml
+data:
+  git.commit-sign-off: "true"
+  git.commit-signing-key: /app/.ssh/id_rsa.pub
+```
+
+The matching private key must be available in the same location.
+
+Create a new SSH secret or add the public key to your existing SSH secret:
+```bash
+kubectl -n argocd-image-updater create secret generic ssh-git-creds \
+  --from-file=sshPrivateKey=~/.ssh/id_rsa \
+  --from-file=sshPublicKey=~/.ssh/id_rsa.pub
+```
+
+**GPG:**
+
+The GPG private key must be installed and available in the `argocd-image-updater` pod.
+Set `git.commit-signing-key` in the `argocd-image-updater-config` ConfigMap to the GPG key ID you want to use:
+
+```yaml
+data:
+  git.commit-sign-off: "true"
+  git.commit-signing-key: 3AA5C34371567BD2
+```
+
+Volume configuration must be added to mount your SSH signing keys:
+
+```yaml
+volumeMounts:
+- name: ssh-signing-key
+  mountPath: /app/.ssh/id_rsa
+  readOnly: true
+  subPath: sshPrivateKey
+- name: ssh-signing-key
+  mountPath: /app/.ssh/id_rsa.pub
+  readOnly: true
+  subPath: sshPublicKey
+
+volumes:
+- name: ssh-signing-key
+  secret:
+    secretName: ssh-git-creds
+  optional: true
+```
+
 {{ template "chart.valuesSection" . }}
 
 ----------------------------------------------

--- a/charts/argocd-image-updater/templates/configmap.yaml
+++ b/charts/argocd-image-updater/templates/configmap.yaml
@@ -27,6 +27,12 @@ data:
   {{- with .Values.config.gitCommitMail }}
   git.email: {{ . | quote }}
   {{- end }}
+  {{- with .Values.config.gitCommitSigningKey }}
+  git.commit-signing-key: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.gitCommitSignOff }}
+  git.commit-sign-off: {{ . | quote }}
+  {{- end }}
   {{- with .Values.config.gitCommitTemplate }}
   git.commit-message-template: |
     {{- nindent 4 . }}

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -95,6 +95,18 @@ spec:
                 key: git.email
                 name: argocd-image-updater-config
                 optional: true
+        - name: GIT_COMMIT_SIGNING_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-signing-key
+              name: argocd-image-updater-config
+              optional: true
+        - name: GIT_COMMIT_SIGN_OFF
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-sign-off
+              name: argocd-image-updater-config
+              optional: true
           - name: IMAGE_UPDATER_KUBE_EVENTS
             valueFrom:
               configMapKeyRef:

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -130,6 +130,12 @@ config:
   # -- E-Mail address to use for Git commits
   gitCommitMail: ""
 
+  # -- Path to public SSH key mounted in container, or GPG key ID used to sign commits
+  gitCommitSigningKey: ""
+
+  # -- Enables sign off on commits
+  gitCommitSignOff: false
+
   # -- Changing the Git commit message
   gitCommitTemplate: ""
 


### PR DESCRIPTION
Added support for commit key signing via SSH and GPG key along with documentation updates

Relies on https://github.com/argoproj-labs/argocd-image-updater/pull/710

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
