### PR TITLE
feat(argo-cd): Make redis secret initialization optional

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,6 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Added priorityClassName for the redis secret init job
-    - kind: added
       description: Made Redis secret initialization optional with default enabled

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.1
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 6.10.2
+version: 6.11.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added priorityClassName for the redis secret init job
+    - kind: added
+      description: Made Redis secret initialization optional with default enabled

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1359,6 +1359,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | redisSecretInit.containerSecurityContext | object | See [values.yaml] | Application controller container-level security context |
+| redisSecretInit.enabled | bool | `true` | Enable Redis secret initialization. If disabled, secret must be provisioned by alternative methods |
 | redisSecretInit.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Redis secret-init Job |
 | redisSecretInit.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the Redis secret-init Job |
 | redisSecretInit.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the Redis secret-init Job |

--- a/charts/argo-cd/templates/redis-secret-init/job.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/job.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.externalRedis.host }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/role.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/role.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.externalRedis.host }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.externalRedis.host }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.externalRedis.host }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redisSecretInit.serviceAccount.automountServiceAccountToken }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1601,6 +1601,8 @@ externalRedis:
   secretAnnotations: {}
 
 redisSecretInit:
+  # -- Enable Redis secret initialization. If disabled, secret must be provisioned by alternative methods
+  enabled: true
   # -- Redis secret-init name
   name: redis-secret-init
 


### PR DESCRIPTION
This PR makes it possible to disable the redis secret initialization job and manage the secret using alternative means.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).