### PR TITLE
feat(argo-cd): Add option to disable API checks in all servicemonitor

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.2
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.0.0
+version: 7.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Represent cluster credentials as a map
+    - kind: added
+      description: Add option to disable API checks in all servicemonitor

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -803,6 +803,7 @@ NAME: my-release
 | controller.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | controller.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | controller.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| controller.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | controller.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | controller.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | controller.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
@@ -896,6 +897,7 @@ NAME: my-release
 | repoServer.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | repoServer.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | repoServer.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| repoServer.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | repoServer.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | repoServer.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | repoServer.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
@@ -1045,6 +1047,7 @@ NAME: my-release
 | server.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | server.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | server.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| server.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | server.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | server.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | server.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
@@ -1154,6 +1157,7 @@ NAME: my-release
 | dex.metrics.service.portName | string | `"http-metrics"` | Metrics service port name |
 | dex.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | dex.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| dex.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | dex.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | dex.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | dex.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
@@ -1255,6 +1259,7 @@ NAME: my-release
 | redis.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | redis.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | redis.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| redis.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | redis.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | redis.metrics.serviceMonitor.interval | string | `"30s"` | Interval at which metrics should be scraped |
 | redis.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
@@ -1446,6 +1451,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | applicationSet.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | applicationSet.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| applicationSet.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | applicationSet.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | applicationSet.metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | applicationSet.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
@@ -1526,6 +1532,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.metrics.service.type | string | `"ClusterIP"` | Metrics service type |
 | notifications.metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
 | notifications.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations |
+| notifications.metrics.serviceMonitor.disableAPICheck | bool | `false` | Disable API check to enable servicemonitor |
 | notifications.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | notifications.metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | notifications.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.controller.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.controller.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.controller.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.applicationSet.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.applicationSet.metrics.enabled .Values.applicationSet.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.applicationSet.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.applicationSet.metrics.enabled .Values.applicationSet.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.applicationSet.metrics.enabled .Values.applicationSet.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.applicationSet.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.applicationSet.metrics.enabled .Values.applicationSet.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.notifications.enabled .Values.notifications.metrics.enabled .Values.notifications.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.notifications.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.notifications.enabled .Values.notifications.metrics.enabled .Values.notifications.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.repoServer.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.repoServer.metrics.enabled .Values.repoServer.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.repoServer.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.repoServer.metrics.enabled .Values.repoServer.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.repoServer.metrics.enabled .Values.repoServer.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.repoServer.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.repoServer.metrics.enabled .Values.repoServer.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.server.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.server.metrics.enabled .Values.server.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.server.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.server.metrics.enabled .Values.server.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.server.metrics.enabled .Values.server.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.server.metrics.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.server.metrics.enabled .Values.server.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/dex/servicemonitor.yaml
+++ b/charts/argo-cd/templates/dex/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.dex.metrics.enabled .Values.dex.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.dex.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.dex.metrics.enabled .Values.dex.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/templates/redis/servicemonitor.yaml
+++ b/charts/argo-cd/templates/redis/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- $redisHa := (index .Values "redis-ha") -}}
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.redis.enabled (not $redisHa.enabled) .Values.redis.metrics.enabled .Values.redis.metrics.serviceMonitor.enabled -}}
+{{- if and (or .Values.redis.metrics.serviceMonitor.disableAPICheck (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) .Values.redis.enabled (not $redisHa.enabled) .Values.redis.metrics.enabled .Values.redis.metrics.serviceMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -823,6 +823,8 @@ controller:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Prometheus ServiceMonitor interval
       interval: 30s
       # -- Prometheus [RelabelConfigs] to apply to samples before scraping
@@ -915,6 +917,8 @@ dex:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Prometheus ServiceMonitor interval
       interval: 30s
       # -- Prometheus [RelabelConfigs] to apply to samples before scraping
@@ -1470,6 +1474,8 @@ redis:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Interval at which metrics should be scraped
       interval: 30s
       # -- Prometheus [RelabelConfigs] to apply to samples before scraping
@@ -2094,6 +2100,8 @@ server:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Prometheus ServiceMonitor interval
       interval: 30s
       # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
@@ -2665,6 +2673,8 @@ repoServer:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Prometheus ServiceMonitor interval
       interval: 30s
       # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
@@ -2822,6 +2832,8 @@ applicationSet:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Prometheus ServiceMonitor interval
       interval: 30s
       # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
@@ -3224,6 +3236,8 @@ notifications:
     serviceMonitor:
       # -- Enable a prometheus ServiceMonitor
       enabled: false
+      # -- Disable API check to enable servicemonitor
+      disableAPICheck: false
       # -- Prometheus ServiceMonitor selector
       selector: {}
         # prometheus: kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

This helm attempts to verify the API version during deployment processes. However, in some environments, direct access to the API is not available beforehand, which complicates the deployment.

This situation is particularly problematic in two notable scenarios:

- **Offline Manifest Generation and Application**: When the manifests are generated in one environment (e.g., a **CI/CD** pipeline or a local machine) and then applied to another cluster, there's no way to verify the API version during the generation phase.
- **Manifest Generation Using Kustomize**: In environments where manifests are created using tools like **kustomize**,  the version check becomes redundant and can lead to deployment issues.

My PR proposes modifications that bypass the API version check under these specific conditions, ensuring smoother and more flexible deployments in environments lacking direct API connectivity.


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
