### PR TITLE
fix(argo-workflows): `BASE_HREF` -> `ARGO_BASE_HREF` for forward compat

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.41.7
+version: 0.41.8
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v3.5.7
+    - kind: fixed
+      description: changed BASE_HREF to ARGO_BASE_HREF for forward compat

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -95,7 +95,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: BASE_HREF
+            - name: ARGO_BASE_HREF
               value: {{ .Values.server.baseHref | quote }}
           {{- with .Values.server.extraEnv }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Summary

`BASE_HREF` is redundant and will be removed in a future release (see https://github.com/argoproj/argo-workflows/pull/12653), so move to the existing `ARGO_BASE_HREF` for forward compat

### Details

- Change env var in Server Deployment to `ARGO_BASE_HREF`
  - Was pointed to this line by https://github.com/argoproj/argo-workflows/pull/12653#issuecomment-1968808565

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [n/a] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [n/a] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
