### PR TITLE
feat(argo-rollouts): add annotations for notifications secret

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.36.0
+version: 2.36.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-rollouts to v1.7.0
+      description: Add annotations for notifications secret

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -58,6 +58,7 @@ For full list of changes please check ArtifactHub [changelog].
 | kubeVersionOverride | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests |
 | nameOverride | string | `nil` | String to partially override "argo-rollouts.fullname" template |
 | notifications.notifiers | object | `{}` | Configures notification services |
+| notifications.secret.annotations | object | `{}` | Annotations to be added to the notifications secret |
 | notifications.secret.create | bool | `false` | Whether to create notifications secret |
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the notifications secret |
 | notifications.templates | object | `{}` | Notification templates |

--- a/charts/argo-rollouts/templates/controller/notifications-secret.yaml
+++ b/charts/argo-rollouts/templates/controller/notifications-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: argo-rollouts-notification-secret
   namespace: {{ .Release.Namespace | quote }}
+  {{- with .Values.notifications.secret.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: {{ .Values.controller.component }}
     {{- include "argo-rollouts.labels" . | nindent 4 }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -454,6 +454,8 @@ notifications:
     # -- Generic key:value pairs to be inserted into the notifications secret
     items: {}
       # slack-token:
+    # -- Annotations to be added to the notifications secret
+    annotations: {}
 
   # -- Configures notification services
   notifiers: {}


### PR DESCRIPTION

Most users of Argo-rollouts may store secrets on `vault` which allows to auto inject secrets directly to secrets object using annotations.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes:
<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->