### PR TITLE
fix(argo-cd): Default repo-server init container resources to empty

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.2.0
+version: 7.2.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,7 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: removed
-      description: Remove `server.certificate.secretName`, as the expected secret name is static (argocd-server-tls)
-    - kind: removed
-      description: Remove `applicationSet.certificate.secretName`, as the expected secret name is static (argocd-applicationset-controller-tls)
+    - kind: changed
+      description: Default argocd repo-server init container replicas to empty

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -359,10 +359,8 @@ spec:
         image: {{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
         name: copyutil
-        {{- with .Values.repoServer.resources }}
         resources:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.repoServer.resources | nindent 10 }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

This is a small fix to address diff of deployed manifest vs desired manifest.
Kubernetes will inject default `resources: {}` when it is not set, which appears as a diff in argocd and other tools.
This resolves the diff as it will properly set the resources to the default value of `{}` and there will be no diff.
Additionally, resources for init container should be defined the same way as normal container, for consistency.

`helm template --values=values.yaml .`
Before:
![image](https://github.com/argoproj/argo-helm/assets/14805373/48fe9b67-eee1-4fc4-b051-228f5c2bd1f9)

After:
![image](https://github.com/argoproj/argo-helm/assets/14805373/4992c738-80f3-4b68-8209-2330e5b03fd2)


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
