### PR TITLE
refactor(argo-cd): use dataString in repo credentials

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.2.0
+version: 7.2.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,6 +26,8 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: changed
+      description: Repository credentials Secret will use stringData to increase compatibility with plugins like helm-secrets
     - kind: removed
       description: Remove `server.certificate.secretName`, as the expected secret name is static (argocd-server-tls)
     - kind: removed

--- a/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
+++ b/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml
@@ -14,8 +14,8 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
-data:
+stringData:
   {{- range $key, $value := $repo_cred_value }}
-  {{ $key }}: {{ $value | toString | b64enc }}
+  {{ $key }}: {{ $value | toString }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

---

Repository credentials [template](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-configs/repository-credentials-secret.yaml) uses `b64enc` function. This makes it working with plugins like [helm-secrets](https://github.com/jkroepke/helm-secrets) very difficult. Multiline secrets like the private key will only be encoded for the first line.

Changing to `stringData` is a non-breaking change but removes any problems around multiline formatting
