### PR TITLE
fix(argo-events): Update Jetstream versions as following upstream

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.2
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.6
+version: 2.4.7
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-events to v1.9.2
+    - kind: fixed
+      description: Update Jetstream versions as following upstream

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -65,11 +65,51 @@ done
 | configs.jetstream.streamConfig.maxBytes | string | `"1GB"` |  |
 | configs.jetstream.streamConfig.maxMsgs | int | `1000000` | Maximum number of messages before expiring oldest message |
 | configs.jetstream.streamConfig.replicas | int | `3` | Number of replicas, defaults to 3 and requires minimal 3 |
-| configs.jetstream.versions[0].configReloaderImage | string | `"natsio/nats-server-config-reloader:latest"` |  |
-| configs.jetstream.versions[0].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:latest"` |  |
-| configs.jetstream.versions[0].natsImage | string | `"nats:latest"` |  |
+| configs.jetstream.versions[0].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
+| configs.jetstream.versions[0].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
+| configs.jetstream.versions[0].natsImage | string | `"nats:2.10.10"` |  |
 | configs.jetstream.versions[0].startCommand | string | `"/nats-server"` |  |
 | configs.jetstream.versions[0].version | string | `"latest"` |  |
+| configs.jetstream.versions[1].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[1].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[1].natsImage | string | `"nats:2.8.1"` |  |
+| configs.jetstream.versions[1].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[1].version | string | `"2.8.1"` |  |
+| configs.jetstream.versions[2].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[2].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[2].natsImage | string | `"nats:2.8.1-alpine"` |  |
+| configs.jetstream.versions[2].startCommand | string | `"nats-server"` |  |
+| configs.jetstream.versions[2].version | string | `"2.8.1-alpine"` |  |
+| configs.jetstream.versions[3].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[3].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[3].natsImage | string | `"nats:2.8.2"` |  |
+| configs.jetstream.versions[3].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[3].version | string | `"2.8.2"` |  |
+| configs.jetstream.versions[4].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[4].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[4].natsImage | string | `"nats:2.8.2-alpine"` |  |
+| configs.jetstream.versions[4].startCommand | string | `"nats-server"` |  |
+| configs.jetstream.versions[4].version | string | `"2.8.2-alpine"` |  |
+| configs.jetstream.versions[5].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[5].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[5].natsImage | string | `"nats:2.9.1"` |  |
+| configs.jetstream.versions[5].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[5].version | string | `"2.9.1"` |  |
+| configs.jetstream.versions[6].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[6].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[6].natsImage | string | `"nats:2.9.12"` |  |
+| configs.jetstream.versions[6].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[6].version | string | `"2.9.12"` |  |
+| configs.jetstream.versions[7].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[7].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[7].natsImage | string | `"nats:2.9.16"` |  |
+| configs.jetstream.versions[7].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[7].version | string | `"2.9.16"` |  |
+| configs.jetstream.versions[8].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
+| configs.jetstream.versions[8].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
+| configs.jetstream.versions[8].natsImage | string | `"nats:2.10.10"` |  |
+| configs.jetstream.versions[8].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[8].version | string | `"2.10.10"` |  |
 | configs.nats.versions | list | See [values.yaml] | Supported versions of NATS event bus |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -65,7 +65,51 @@ done
 | configs.jetstream.streamConfig.maxBytes | string | `"1GB"` |  |
 | configs.jetstream.streamConfig.maxMsgs | int | `1000000` | Maximum number of messages before expiring oldest message |
 | configs.jetstream.streamConfig.replicas | int | `3` | Number of replicas, defaults to 3 and requires minimal 3 |
-| configs.jetstream.versions | list | `[]` | Additional Supported versions of JetStream eventbus |
+| configs.jetstream.versions[0].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
+| configs.jetstream.versions[0].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
+| configs.jetstream.versions[0].natsImage | string | `"nats:2.10.10"` |  |
+| configs.jetstream.versions[0].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[0].version | string | `"latest"` |  |
+| configs.jetstream.versions[1].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[1].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[1].natsImage | string | `"nats:2.8.1"` |  |
+| configs.jetstream.versions[1].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[1].version | string | `"2.8.1"` |  |
+| configs.jetstream.versions[2].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[2].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[2].natsImage | string | `"nats:2.8.1-alpine"` |  |
+| configs.jetstream.versions[2].startCommand | string | `"nats-server"` |  |
+| configs.jetstream.versions[2].version | string | `"2.8.1-alpine"` |  |
+| configs.jetstream.versions[3].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[3].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[3].natsImage | string | `"nats:2.8.2"` |  |
+| configs.jetstream.versions[3].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[3].version | string | `"2.8.2"` |  |
+| configs.jetstream.versions[4].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[4].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[4].natsImage | string | `"nats:2.8.2-alpine"` |  |
+| configs.jetstream.versions[4].startCommand | string | `"nats-server"` |  |
+| configs.jetstream.versions[4].version | string | `"2.8.2-alpine"` |  |
+| configs.jetstream.versions[5].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[5].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[5].natsImage | string | `"nats:2.9.1"` |  |
+| configs.jetstream.versions[5].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[5].version | string | `"2.9.1"` |  |
+| configs.jetstream.versions[6].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[6].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[6].natsImage | string | `"nats:2.9.12"` |  |
+| configs.jetstream.versions[6].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[6].version | string | `"2.9.12"` |  |
+| configs.jetstream.versions[7].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
+| configs.jetstream.versions[7].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
+| configs.jetstream.versions[7].natsImage | string | `"nats:2.9.16"` |  |
+| configs.jetstream.versions[7].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[7].version | string | `"2.9.16"` |  |
+| configs.jetstream.versions[8].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
+| configs.jetstream.versions[8].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
+| configs.jetstream.versions[8].natsImage | string | `"nats:2.10.10"` |  |
+| configs.jetstream.versions[8].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[8].version | string | `"2.10.10"` |  |
 | configs.nats.versions | list | See [values.yaml] | Supported versions of NATS event bus |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -65,51 +65,7 @@ done
 | configs.jetstream.streamConfig.maxBytes | string | `"1GB"` |  |
 | configs.jetstream.streamConfig.maxMsgs | int | `1000000` | Maximum number of messages before expiring oldest message |
 | configs.jetstream.streamConfig.replicas | int | `3` | Number of replicas, defaults to 3 and requires minimal 3 |
-| configs.jetstream.versions[0].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
-| configs.jetstream.versions[0].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
-| configs.jetstream.versions[0].natsImage | string | `"nats:2.10.10"` |  |
-| configs.jetstream.versions[0].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[0].version | string | `"latest"` |  |
-| configs.jetstream.versions[1].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[1].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[1].natsImage | string | `"nats:2.8.1"` |  |
-| configs.jetstream.versions[1].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[1].version | string | `"2.8.1"` |  |
-| configs.jetstream.versions[2].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[2].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[2].natsImage | string | `"nats:2.8.1-alpine"` |  |
-| configs.jetstream.versions[2].startCommand | string | `"nats-server"` |  |
-| configs.jetstream.versions[2].version | string | `"2.8.1-alpine"` |  |
-| configs.jetstream.versions[3].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[3].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[3].natsImage | string | `"nats:2.8.2"` |  |
-| configs.jetstream.versions[3].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[3].version | string | `"2.8.2"` |  |
-| configs.jetstream.versions[4].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[4].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[4].natsImage | string | `"nats:2.8.2-alpine"` |  |
-| configs.jetstream.versions[4].startCommand | string | `"nats-server"` |  |
-| configs.jetstream.versions[4].version | string | `"2.8.2-alpine"` |  |
-| configs.jetstream.versions[5].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[5].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[5].natsImage | string | `"nats:2.9.1"` |  |
-| configs.jetstream.versions[5].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[5].version | string | `"2.9.1"` |  |
-| configs.jetstream.versions[6].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[6].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[6].natsImage | string | `"nats:2.9.12"` |  |
-| configs.jetstream.versions[6].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[6].version | string | `"2.9.12"` |  |
-| configs.jetstream.versions[7].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
-| configs.jetstream.versions[7].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.9.1"` |  |
-| configs.jetstream.versions[7].natsImage | string | `"nats:2.9.16"` |  |
-| configs.jetstream.versions[7].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[7].version | string | `"2.9.16"` |  |
-| configs.jetstream.versions[8].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
-| configs.jetstream.versions[8].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
-| configs.jetstream.versions[8].natsImage | string | `"nats:2.10.10"` |  |
-| configs.jetstream.versions[8].startCommand | string | `"/nats-server"` |  |
-| configs.jetstream.versions[8].version | string | `"2.10.10"` |  |
+| configs.jetstream.versions | list | `[]` | Additional Supported versions of JetStream eventbus |
 | configs.nats.versions | list | See [values.yaml] | Supported versions of NATS event bus |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-events/templates/argo-events-controller/config.yaml
+++ b/charts/argo-events/templates/argo-events-controller/config.yaml
@@ -17,6 +17,7 @@ data:
           metricsExporterImage: {{ .metricsExporterImage }}
         {{- end }}
       {{- end }}
+      {{- if .Values.configs.jetstream.versions }}
       jetstream:
         # Default JetStream settings, could be overridden by EventBus JetStream specs
         settings: |
@@ -32,51 +33,6 @@ data:
           replicas: {{ .Values.configs.jetstream.streamConfig.replicas }}
           duplicates: {{ .Values.configs.jetstream.streamConfig.duplicates }}
         versions:
-        - version: latest
-          natsImage: nats:2.10.10
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
-          startCommand: /nats-server
-        - version: 2.8.1
-          natsImage: nats:2.8.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.8.1-alpine
-          natsImage: nats:2.8.1-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: nats-server
-        - version: 2.8.2
-          natsImage: nats:2.8.2
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.8.2-alpine
-          natsImage: nats:2.8.2-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: nats-server
-        - version: 2.9.1
-          natsImage: nats:2.9.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.9.12
-          natsImage: nats:2.9.12
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.9.16
-          natsImage: nats:2.9.16
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-          startCommand: /nats-server
-        - version: 2.10.10
-          natsImage: nats:2.10.10
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
-          startCommand: /nats-server
         {{- range .Values.configs.jetstream.versions }}
         - version: {{ .version }}
           natsImage: {{ .natsImage }}
@@ -84,3 +40,4 @@ data:
           configReloaderImage: {{ .configReloaderImage }}
           startCommand: {{ .startCommand }}
         {{- end }}
+      {{- end }}

--- a/charts/argo-events/templates/argo-events-controller/config.yaml
+++ b/charts/argo-events/templates/argo-events-controller/config.yaml
@@ -17,7 +17,6 @@ data:
           metricsExporterImage: {{ .metricsExporterImage }}
         {{- end }}
       {{- end }}
-      {{- if .Values.configs.jetstream.versions }}
       jetstream:
         # Default JetStream settings, could be overridden by EventBus JetStream specs
         settings: |
@@ -33,6 +32,51 @@ data:
           replicas: {{ .Values.configs.jetstream.streamConfig.replicas }}
           duplicates: {{ .Values.configs.jetstream.streamConfig.duplicates }}
         versions:
+        - version: latest
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.8.1
+          natsImage: nats:2.8.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.1-alpine
+          natsImage: nats:2.8.1-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.8.2
+          natsImage: nats:2.8.2
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.2-alpine
+          natsImage: nats:2.8.2-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.9.1
+          natsImage: nats:2.9.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.16
+          natsImage: nats:2.9.16
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.10.10
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
         {{- range .Values.configs.jetstream.versions }}
         - version: {{ .version }}
           natsImage: {{ .natsImage }}
@@ -40,4 +84,3 @@ data:
           configReloaderImage: {{ .configReloaderImage }}
           startCommand: {{ .startCommand }}
         {{- end }}
-      {{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -94,13 +94,53 @@ configs:
       replicas: 3
       # -- Not documented at the moment
       duplicates: 300s
-    # -- Additional Supported versions of JetStream eventbus
-    versions: []
-      # - version: latest
-      #   natsImage: nats:2.10.10
-      #   metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-      #   configReloaderImage: natsio/nats-server-config-reloader:0.14.0
-      #   startCommand: /nats-server
+    # Supported versions of JetStream eventbus
+    versions:
+      - version: latest
+        natsImage: nats:2.10.10
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+        configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+        startCommand: /nats-server
+      - version: 2.8.1
+        natsImage: nats:2.8.1
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: /nats-server
+      - version: 2.8.1-alpine
+        natsImage: nats:2.8.1-alpine
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: nats-server
+      - version: 2.8.2
+        natsImage: nats:2.8.2
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: /nats-server
+      - version: 2.8.2-alpine
+        natsImage: nats:2.8.2-alpine
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: nats-server
+      - version: 2.9.1
+        natsImage: nats:2.9.1
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: /nats-server
+      - version: 2.9.12
+        natsImage: nats:2.9.12
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: /nats-server
+      - version: 2.9.16
+        natsImage: nats:2.9.16
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+        startCommand: /nats-server
+      - version: 2.10.10
+        natsImage: nats:2.10.10
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+        configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+        startCommand: /nats-server
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -94,53 +94,13 @@ configs:
       replicas: 3
       # -- Not documented at the moment
       duplicates: 300s
-    # Supported versions of JetStream eventbus
-    versions:
-    - version: latest
-      natsImage: nats:2.10.10
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-      configReloaderImage: natsio/nats-server-config-reloader:0.14.0
-      startCommand: /nats-server
-    - version: 2.8.1
-      natsImage: nats:2.8.1
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: /nats-server
-    - version: 2.8.1-alpine
-      natsImage: nats:2.8.1-alpine
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: nats-server
-    - version: 2.8.2
-      natsImage: nats:2.8.2
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: /nats-server
-    - version: 2.8.2-alpine
-      natsImage: nats:2.8.2-alpine
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: nats-server
-    - version: 2.9.1
-      natsImage: nats:2.9.1
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: /nats-server
-    - version: 2.9.12
-      natsImage: nats:2.9.12
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: /nats-server
-    - version: 2.9.16
-      natsImage: nats:2.9.16
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-      startCommand: /nats-server
-    - version: 2.10.10
-      natsImage: nats:2.10.10
-      metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-      configReloaderImage: natsio/nats-server-config-reloader:0.14.0
-      startCommand: /nats-server
+    # -- Additional Supported versions of JetStream eventbus
+    versions: []
+      # - version: latest
+      #   natsImage: nats:2.10.10
+      #   metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+      #   configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+      #   startCommand: /nats-server
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -96,11 +96,51 @@ configs:
       duplicates: 300s
     # Supported versions of JetStream eventbus
     versions:
-      - version: "latest"
-        natsImage: nats:latest
-        metricsExporterImage: natsio/prometheus-nats-exporter:latest
-        configReloaderImage: natsio/nats-server-config-reloader:latest
-        startCommand: /nats-server
+    - version: latest
+      natsImage: nats:2.10.10
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+      configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+      startCommand: /nats-server
+    - version: 2.8.1
+      natsImage: nats:2.8.1
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: /nats-server
+    - version: 2.8.1-alpine
+      natsImage: nats:2.8.1-alpine
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: nats-server
+    - version: 2.8.2
+      natsImage: nats:2.8.2
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: /nats-server
+    - version: 2.8.2-alpine
+      natsImage: nats:2.8.2-alpine
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: nats-server
+    - version: 2.9.1
+      natsImage: nats:2.9.1
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: /nats-server
+    - version: 2.9.12
+      natsImage: nats:2.9.12
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: /nats-server
+    - version: 2.9.16
+      natsImage: nats:2.9.16
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+      startCommand: /nats-server
+    - version: 2.10.10
+      natsImage: nats:2.10.10
+      metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+      configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+      startCommand: /nats-server
 
 # -- Array of extra K8s manifests to deploy
 ## Note: Supports use of custom Helm templates


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/2787

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
