### PR TITLE
fix(argo-rollouts): Add subscriptions into notifcations-configmap

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-rollouts to v1.7.0
+      description: Add subscriptions into notifications-configmap

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.36.0
+version: 2.36.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -61,6 +61,7 @@ For full list of changes please check ArtifactHub [changelog].
 | notifications.secret.annotations | object | `{}` | Annotations to be added to the notifications secret |
 | notifications.secret.create | bool | `false` | Whether to create notifications secret |
 | notifications.secret.items | object | `{}` | Generic key:value pairs to be inserted into the notifications secret |
+| notifications.subscriptions | object | `{}` | The subscriptions define the subscriptions to the triggers in a general way for all rollouts |
 | notifications.templates | object | `{}` | Notification templates |
 | notifications.triggers | object | `{}` | The trigger defines the condition when the notification should be sent |
 | providerRBAC.additionalRules | list | `[]` | Additional RBAC rules for others providers |

--- a/charts/argo-rollouts/templates/controller/notifcations-configmap.yaml
+++ b/charts/argo-rollouts/templates/controller/notifcations-configmap.yaml
@@ -16,3 +16,7 @@ data:
   {{- with .Values.notifications.triggers }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with .Values.notifications.subscriptions }}
+  subscriptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -477,3 +477,11 @@ notifications:
     # trigger.on-purple: |
     #   - send: [my-purple-template]
     #     when: rollout.spec.template.spec.containers[0].image == 'argoproj/rollouts-demo:purple'
+
+  # -- The subscriptions define the subscriptions to the triggers in a general way for all rollouts
+  subscriptions: {}
+    # subscriptions:      
+    #   recipients:
+    #     - slack:<channel>
+    #   triggers:
+    #     - on-rollout-completed

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -482,7 +482,7 @@ notifications:
 
   # -- The subscriptions define the subscriptions to the triggers in a general way for all rollouts
   subscriptions: {}
-    # subscriptions:      
+    # subscriptions:
     #   recipients:
     #     - slack:<channel>
     #   triggers:


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/2792 
Add subscriptions into notification-configmap.
https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/subscriptions/#default-subscriptions

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
