### PR TITLE
fix(argo-cd): Make REDIS_PASSWORD environment variables optional always

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.3
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.3.2
+version: 7.3.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for passing redis - sentinel credentials
+    - kind: changed
+      description: make REDIS_PASSWORD environment variables optional always

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -205,9 +205,9 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ default "argocd-redis" .Values.externalRedis.existingSecret }}
+                optional: true
                 {{- if .Values.externalRedis.host }}
                 key: redis-password
-                optional: true
                 {{- else }}
                 key: auth
                 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -182,9 +182,9 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ default "argocd-redis" .Values.externalRedis.existingSecret }}
+                optional: true
                 {{- if .Values.externalRedis.host }}
                 key: redis-password
-                optional: true
                 {{- else }}
                 key: auth
                 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -250,9 +250,9 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ default "argocd-redis" .Values.externalRedis.existingSecret }}
+                optional: true
                 {{- if .Values.externalRedis.host }}
                 key: redis-password
-                optional: true
                 {{- else }}
                 key: auth
                 {{- end }}


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
