### PR TITLE
fix(argo-rollouts): missing permission in cluster role

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.2
+version: 2.37.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Added traefik.io apiGroup to Role and ClusterRole
+    - kind: fixed
+      description: Fixed missing permissions in the default service account

--- a/charts/argo-rollouts/templates/controller/role.yaml
+++ b/charts/argo-rollouts/templates/controller/role.yaml
@@ -68,6 +68,7 @@ rules:
   - get
   - list
   - watch
+  - update
 # services patch needed to update selector of canary/stable/active/preview services
 # services create needed to create and delete services for experiments
 - apiGroups:


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Add missing permissions `apps.Deployment.update` in default SA #2795
Resolves https://github.com/argoproj/argo-helm/issues/2795

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
