### PR TITLE
fix(argo-cd): Address inconsistent redis-secret-init SA handling

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.4
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.3.5
+version: 7.3.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Address oversights of feature `namespaceOverride`
+      description: Address inconsistent redis-secret-init ServiceAccount handling

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -99,7 +99,7 @@ Create the name of the Redis secret-init service account to use
 */}}
 {{- define "argo-cd.redisSecretInit.serviceAccountName" -}}
 {{- if .Values.redisSecretInit.serviceAccount.create -}}
-    {{ default (include "argo-cd.redisSecretInit.fullname" .) .Values.redis.serviceAccount.name }}
+    {{ default (include "argo-cd.redisSecretInit.fullname" .) .Values.redisSecretInit.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.redisSecretInit.serviceAccount.name }}
 {{- end -}}

--- a/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (not .Values.externalRedis.host) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redisSecretInit.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
Fixes #2810

---
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
