### PR TITLE
fix(argo-cd): Add egress for network policies

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.11.5
 kubeVersion: ">=1.23.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.3.8
+version: 7.4.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Add Redis Sentinel variables to application controller deployment
+    - kind: Added
+      description: Add egress for network policies

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -683,6 +683,8 @@ NAME: my-release
 | global.logging.level | string | `"info"` | Set the global logging level. One of: `debug`, `info`, `warn` or `error` |
 | global.networkPolicy.create | bool | `false` | Create NetworkPolicy objects for all components |
 | global.networkPolicy.defaultDenyIngress | bool | `false` | Default deny all ingress traffic |
+| global.networkPolicy.egress.create | `bool` | `false` | Create egress NetworkPolicy rules for all components. |
+| global.networkPolicy.egress.ipBlock | `list` | `[]` | List of egress IP blocks and ports. Each block specifies a CIDR and associated ports. |
 | global.nodeSelector | object | `{}` | Default node selector for all components |
 | global.podAnnotations | object | `{}` | Annotations for the all deployed pods |
 | global.podLabels | object | `{}` | Labels for the all deployed pods |

--- a/charts/argo-cd/templates/argocd-application-controller/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/networkpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
   name: {{ template "argo-cd.controller.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
 spec:
   ingress:
   - from:
@@ -17,4 +17,18 @@ spec:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
@@ -3,12 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "argo-cd.applicationSet.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
 spec:
   ingress:
-  {{- if .Values.applicationSet.ingress.enabled }}
+    {{- if .Values.applicationSet.ingress.enabled }}
   - ports:
     - port: webhook
   {{- end }}
@@ -23,4 +23,20 @@ spec:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.applicationSet.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- if .Values.global.networkPolicy.egress.ipBlock }}
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "argo-cd.notifications.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" .Values.notifications.name) | nindent 4 }}
 spec:
@@ -17,4 +17,20 @@ spec:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.notifications.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- if .Values.global.networkPolicy.egress.ipBlock }}
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/networkpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" .Values.repoServer.name) | nindent 4 }}
   name: {{ template "argo-cd.repoServer.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
 spec:
   ingress:
   - from:
@@ -37,4 +37,20 @@ spec:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.repoServer.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- if .Values.global.networkPolicy.egress.ipBlock }}
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr | default "0.0.0.0/0" }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-server/networkpolicy.yaml
@@ -5,13 +5,29 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
   name: {{ template "argo-cd.server.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
 spec:
   ingress:
-  - {}
+  - {}  
   podSelector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- if .Values.global.networkPolicy.egress.ipBlock }}
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/dex/networkpolicy.yaml
+++ b/charts/argo-cd/templates/dex/networkpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.dex.name "name" .Values.dex.name) | nindent 4 }}
   name: {{ template "argo-cd.dex.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
 spec:
   ingress:
   - from:
@@ -29,4 +29,20 @@ spec:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.dex.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- if .Values.global.networkPolicy.egress.ipBlock }}
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr | default "0.0.0.0/0" }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/redis/networkpolicy.yaml
+++ b/charts/argo-cd/templates/redis/networkpolicy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}
   name: {{ template "argo-cd.redis.fullname" . }}
-  namespace: {{ include  "argo-cd.namespace" . }}
+  namespace: {{ include "argo-cd.namespace" . }}
 spec:
   ingress:
   - from:
@@ -34,4 +34,20 @@ spec:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.redis.name) | nindent 6 }}
   policyTypes:
   - Ingress
+  {{- if .Values.global.networkPolicy.egress.create }}
+  - Egress
+  egress:
+    {{- if .Values.global.networkPolicy.egress.ipBlock }}
+    {{- range .Values.global.networkPolicy.egress.ipBlock }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr | default "0.0.0.0/0" }}
+      ports:
+        {{- range .ports }}
+        - port: {{ .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -111,6 +111,23 @@ global:
     create: false
     # -- Default deny all ingress traffic
     defaultDenyIngress: false
+    # -- egress rules for all components
+    egress:
+      create: false
+      # ipBlock:
+      #   - cidr: 192.168.1.0/24
+      #     ports:
+      #       - port: 443
+      #         protocol: TCP
+      #       - port: 80
+      #         protocol: TCP
+      #   - cidr: 172.16.0.0/16
+      #     ports:
+      #       - port: 53
+      #         protocol: UDP
+      #       - port: 5432
+      #         protocol: TCP
+
 
   # -- Default priority class for all components
   priorityClassName: ""


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

---

Fixes: #2807 
Add an option for egress rules. The following values.yaml snippet:
```yaml
global:
  networkPolicy:
    create: true
    defaultDenyIngress: true
    egress:
      create: true
      ipBlock:
        - cidr: 192.168.1.0/24
          ports:
            - port: 443
              protocol: TCP
            - port: 80
              protocol: TCP
        - cidr: 172.16.0.0/16
          ports:
            - port: 53
              protocol: UDP
            - port: 5432
              protocol: TCP
```
will generate the following manifests:
```yaml
---
# Source: argo-cd/templates/argocd-application-controller/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    helm.sh/chart: argo-cd-7.3.8
    app.kubernetes.io/name: argocd-application-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: application-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
  name: release-name-argocd-application-controller
  namespace: default
spec:
  ingress:
  - from:
    - namespaceSelector: {}
    ports:
    - port: metrics
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-application-controller
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
---
---
# Source: argo-cd/templates/argocd-applicationset/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: release-name-argocd-applicationset-controller
  namespace: default
  labels:
    helm.sh/chart: argo-cd-7.4.0
    app.kubernetes.io/name: argocd-applicationset-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: applicationset-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
spec:
  ingress:
  - from:
    - namespaceSelector: {}
    ports:
    - port: metrics
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-applicationset-controller
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
  - Egress
  egress:
    - to:
        - ipBlock:
            cidr: 192.168.1.0/24
      ports:
        - port: 443
          protocol: TCP
        - port: 80
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 172.16.0.0/16
      ports:
        - port: 53
          protocol: UDP
        - port: 5432
          protocol: TCP
---
---
# Source: argo-cd/templates/argocd-notifications/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: release-name-argocd-notifications-controller
  namespace: default
  labels:
    helm.sh/chart: argo-cd-7.4.0
    app.kubernetes.io/name: argocd-notifications-controller
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: notifications-controller
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
spec:
  ingress:
  - from:
    - namespaceSelector: {}
    ports:
    - port: metrics
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-notifications-controller
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
  - Egress
  egress:
    - to:
        - ipBlock:
            cidr: 192.168.1.0/24
      ports:
        - port: 443
          protocol: TCP
        - port: 80
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 172.16.0.0/16
      ports:
        - port: 53
          protocol: UDP
        - port: 5432
          protocol: TCP
---
---
# Source: argo-cd/templates/argocd-repo-server/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    helm.sh/chart: argo-cd-7.4.0
    app.kubernetes.io/name: argocd-repo-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: repo-server
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
  name: release-name-argocd-repo-server
  namespace: default
spec:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-server
          app.kubernetes.io/instance: release-name
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-application-controller
          app.kubernetes.io/instance: release-name
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-notifications-controller
          app.kubernetes.io/instance: release-name
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-applicationset-controller
          app.kubernetes.io/instance: release-name
    ports:
    - port: repo-server
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-repo-server
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
  - Egress
  egress:
    - to:
        - ipBlock:
            cidr: 192.168.1.0/24
      ports:
        - port: 443
          protocol: TCP
        - port: 80
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 172.16.0.0/16
      ports:
        - port: 53
          protocol: UDP
        - port: 5432
          protocol: TCP
---
---
# Source: argo-cd/templates/argocd-server/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    helm.sh/chart: argo-cd-7.4.0
    app.kubernetes.io/name: argocd-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: server
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
  name: release-name-argocd-server
  namespace: default
spec:
  ingress:
  - {}  
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-server
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
  - Egress
  egress:
    - to:
        - ipBlock:
            cidr: 192.168.1.0/24
      ports:
        - port: 443
          protocol: TCP
        - port: 80
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 172.16.0.0/16
      ports:
        - port: 53
          protocol: UDP
        - port: 5432
          protocol: TCP
---
---
# Source: argo-cd/templates/dex/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    helm.sh/chart: argo-cd-7.4.0
    app.kubernetes.io/name: argocd-dex-server
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: dex-server
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
  name: release-name-argocd-dex-server
  namespace: default
spec:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-server
          app.kubernetes.io/instance: release-name
    ports:
    - port: http
      protocol: TCP
    - port: grpc
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-dex-server
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
  - Egress
  egress:
    - to:
        - ipBlock:
            cidr: 192.168.1.0/24
      ports:
        - port: 443
          protocol: TCP
        - port: 80
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 172.16.0.0/16
      ports:
        - port: 53
          protocol: UDP
        - port: 5432
          protocol: TCP
---
---
# Source: argo-cd/templates/redis/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
    helm.sh/chart: argo-cd-7.4.0
    app.kubernetes.io/name: argocd-redis
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: redis
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: argocd
    app.kubernetes.io/version: "v2.11.5"
  name: release-name-argocd-redis
  namespace: default
spec:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-server
          app.kubernetes.io/instance: release-name
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-repo-server
          app.kubernetes.io/instance: release-name
    - podSelector:
        matchLabels:
          app.kubernetes.io/name: argocd-application-controller
          app.kubernetes.io/instance: release-name
    ports:
    - port: redis
      protocol: TCP
  podSelector:
    matchLabels:
      app.kubernetes.io/name: argocd-redis
      app.kubernetes.io/instance: release-name
  policyTypes:
  - Ingress
  - Egress
  egress:
    - to:
        - ipBlock:
            cidr: 192.168.1.0/24
      ports:
        - port: 443
          protocol: TCP
        - port: 80
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 172.16.0.0/16
      ports:
        - port: 53
          protocol: UDP
        - port: 5432
          protocol: TCP
```