### PR TITLE
chore(argo-rollouts): add option to disable creation of notifications configmap

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.7.2
+appVersion: v1.7.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.2
+version: 2.37.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -19,6 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Added traefik.io apiGroup to Role and ClusterRole
-    - kind: added
       description: Added setting to disable creation of the notifications ConfigMap

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.7.1
+appVersion: v1.7.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
 version: 2.37.2
@@ -20,3 +20,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added traefik.io apiGroup to Role and ClusterRole
+    - kind: added
+      description: Added setting to disable creation of the notifications ConfigMap

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -57,6 +57,7 @@ For full list of changes please check ArtifactHub [changelog].
 | keepCRDs | bool | `true` | Keep CRD's on helm uninstall |
 | kubeVersionOverride | string | `""` | Override the Kubernetes version, which is used to evaluate certain manifests |
 | nameOverride | string | `nil` | String to partially override "argo-rollouts.fullname" template |
+| notifications.configmap.create | bool | `true` | Whether to create notifications configmap |
 | notifications.notifiers | object | `{}` | Configures notification services |
 | notifications.secret.annotations | object | `{}` | Annotations to be added to the notifications secret |
 | notifications.secret.create | bool | `false` | Whether to create notifications secret |

--- a/charts/argo-rollouts/templates/controller/notifications-configmap.yaml
+++ b/charts/argo-rollouts/templates/controller/notifications-configmap.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.notifications.configmap.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,3 +21,4 @@ data:
   subscriptions: |
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -449,6 +449,10 @@ dashboard:
   volumeMounts: []
 
 notifications:
+  configmap:
+    # -- Whether to create notifications configmap
+    create: true
+
   secret:
     # -- Whether to create notifications secret
     create: false


### PR DESCRIPTION
This allows for using the upstream notifications configmap from https://github.com/argoproj/argo-rollouts/blob/master/manifests/notifications-install.yaml

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
