### PR TITLE
fix(argo-cd): Fix escaping in values.yaml.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.12.0
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.4.3
+version: 7.4.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: "Added liveness and readiness probes to the notification controller."
+      description: "Added propper backtick escapig to PrometheusRule.Spec"

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -895,12 +895,13 @@ controller:
       #   labels:
       #     severity: warning
       #   annotations:
+{% raw %}
       #     summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
       #     description: >
       #       The application [{{`{{$labels.name}}`}} has not been synchronized for over
       #       12 hours which means that the state of this cloud has drifted away from the
       #       state inside Git.
-
+{% endraw %}
   ## Enable this and set the rules: to whatever custom rules you want for the Cluster Role resource.
   ## Defaults to off
   clusterRoleRules:


### PR DESCRIPTION

Not escaping these variables properly leads to jinja2 templating issue.

```
Error:·template·rendering·failed.
unexpected·char·u'`'·at·36823
```

.


