### PR TITLE
chore(argo-cd): Support string type of "true" for `statusbadge.enabled`

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.12.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.4.5
+version: 7.4.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-cd to v2.12.2
+      description: Support string type of "true" for `statusbadge.enabled`

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -183,7 +183,7 @@ Argo Configuration Preset Values (Influenced by Values configuration)
 {{- define "argo-cd.config.cm.presets" -}}
 {{- $presets := dict -}}
 {{- $_ := set $presets "url" (printf "https://%s" .Values.global.domain) -}}
-{{- if index .Values.configs.cm "statusbadge.enabled" | eq true -}}
+{{- if eq (toString (index .Values.configs.cm "statusbadge.enabled")) "true" -}}
 {{- $_ := set $presets "statusbadge.url" (printf "https://%s/" .Values.global.domain) -}}
 {{- end -}}
 {{- if .Values.configs.styles -}}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/2869

[`.Values.configs.cm."exec.enabled"`](https://github.com/yu-croco/argo-helm/blob/3019415efe744109fd1e96a98e52d1ab802ce227/charts/argo-cd/templates/argocd-server/clusterrole.yaml#L36) supports string of `true`, though the official type in agro-helm is bool. So I think it's kind for users to align the behavior of `.Values.configs.cm."statusbadge.enabled"` as well.

If I set `statusbadge.enabled` as `"true"`, helm template fails as below.
*argo-helm provides the type of parameters (e.g. [Argo CD Configs](https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd#argo-cd-configs)) and the type of `statusbadge.enabled` is bool, so it's not a bug.

```
$ helm template . > foo.yaml
Error: template: argo-cd/templates/argocd-server/deployment.yaml:31:24: executing "argo-cd/templates/argocd-server/deployment.yaml" at <include (print $.Template.BasePath "/argocd-configs/argocd-cm.yaml") .>: error calling include: template: argo-cd/templates/argocd-configs/argocd-cm.yaml:16:6: executing "argo-cd/templates/argocd-configs/argocd-cm.yaml" at <include "argo-cd.config.cm" .>: error calling include: template: argo-cd/templates/_helpers.tpl:200:15: executing "argo-cd.config.cm" at <include "argo-cd.config.cm.presets" .>: error calling include: template: argo-cd/templates/_helpers.tpl:186:56: executing "argo-cd.config.cm.presets" at <eq true>: error calling eq: incompatible types for comparison
```

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
