### PR TITLE
fix(argocd-image-updater): Rename disableKubeEvents to enableKubeEvents

### DIFF
--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -77,7 +77,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | config.argocd.plaintext | bool | `false` | If specified, use an unencrypted HTTP connection to the Argo CD API instead of TLS. |
 | config.argocd.serverAddress | string | `""` | Connect to the Argo CD API server at server address |
 | config.argocd.token | string | `""` | If specified, the secret with Argo CD API key will be created. |
-| config.disableKubeEvents | bool | `false` | Disable kubernetes events |
+| config.enableKubeEvents | bool | `false` | Enable kubernetes events |
 | config.gitCommitMail | string | `""` | E-Mail address to use for Git commits |
 | config.gitCommitSignOff | bool | `false` | Enables sign off on commits |
 | config.gitCommitSigningKey | string | `""` | Path to public SSH key mounted in container, or GPG key ID used to sign commits |

--- a/charts/argocd-image-updater/templates/configmap.yaml
+++ b/charts/argocd-image-updater/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
   {{- with .Values.config.gitCommitSigningMethod }}
   git.commit-signing-method: {{ . | quote }}
   {{- end }}
-  kube.events: {{ .Values.config.disableKubeEvents | quote }}
+  kube.events: {{ .Values.config.enableKubeEvents | quote }}
   {{- with .Values.config.registries }}
   registries.conf: |
     registries:

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -121,8 +121,8 @@ config:
     # -- If specified, the secret with Argo CD API key will be created.
     token: ""
 
-  # -- Disable kubernetes events
-  disableKubeEvents: false
+  # -- Enable kubernetes events
+  enableKubeEvents: false
 
   # -- Username to use for Git commits
   gitCommitUser: ""


### PR DESCRIPTION
This PR should fix: #2902 

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
