### PR TITLE
chore(argo-cd): Fix typo on README

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.12.3
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.5.0
+version: 7.5.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: bumped redis chart
+    - kind: fixed
+      description: Correct typo on README

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -315,7 +315,7 @@ Upstream steps in the [FAQ] are not enough, since we chose a different approach.
 Steps to roteate the secret when using the helm chart (bold step is additional to upstream):
 * Delete `argocd-redis` secret in the namespace where Argo CD is installed.
   ```bash
-  kubectl delete secret argocd-redis -n <argocd namesapce>
+  kubectl delete secret argocd-redis -n <argocd namespace>
   ```
 * **Perform a helm upgrade**
   ```bash

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -315,7 +315,7 @@ Upstream steps in the [FAQ] are not enough, since we chose a different approach.
 Steps to roteate the secret when using the helm chart (bold step is additional to upstream):
 * Delete `argocd-redis` secret in the namespace where Argo CD is installed. 
   ```bash
-  kubectl delete secret argocd-redis -n <argocd namesapce>
+  kubectl delete secret argocd-redis -n <argocd namespace>
   ```
 * **Perform a helm upgrade**
   ```bash


### PR DESCRIPTION
I take over https://github.com/argoproj/argo-helm/pull/2757 .
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
