### PR TITLE
fix(argocd-apps): don't render empty app description

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -17,5 +17,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed 
+    - kind: fixed
       description: not rendering empty app description

--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: A Helm chart for managing additional Argo CD Applications and Projects
 type: application
-version: 2.0.0
+version: 2.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -17,5 +17,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: make the chart use maps instead of lists
+    - kind: fixed 
+      description: not rendering empty app description

--- a/charts/argocd-apps/templates/projects.yaml
+++ b/charts/argocd-apps/templates/projects.yaml
@@ -25,7 +25,9 @@ spec:
   {{- with $projectData.permitOnlyProjectScopedClusters }}
   permitOnlyProjectScopedClusters: {{ . }}
   {{- end }}
-  description: {{ $projectData.description }}
+  {{- with $projectData.description }}
+  description: {{ . }}
+  {{- end }}
   {{- with $projectData.sourceRepos }}
   sourceRepos:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Rendering empty description leads to failed validation when using kubeconform.

Signed-off-by: Zoltán Reegn <zoltan.reegn@gmail.com>

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
