### PR TITLE
fix(argo-events): Fix events-webhook Service using non-default port

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.2
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.7
+version: 2.4.8
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Update Jetstream versions as following upstream
+      description: events-webhook Service using non-default port

--- a/charts/argo-events/templates/argo-events-webhook/service.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "argo-events.labels" (dict "context" . "name" .Values.webhook.name) | nindent 4 }}
 spec:
   ports:
-  - port: 443
+  - port: {{ int .Values.webhook.port }}
     targetPort: webhook
   selector:
     {{- include "argo-events.selectorLabels" (dict "context" $ "name" $.Values.webhook.name) | nindent 4 }}


### PR DESCRIPTION
Resolves #2926

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).