### PR TITLE
chore(github): Use correct email of the Renovate bot

### DIFF
--- a/.github/configs/renovate-config.js
+++ b/.github/configs/renovate-config.js
@@ -1,6 +1,7 @@
 module.exports = {
     platform: 'github',
-    gitAuthor: 'renovate[bot] <renovate[bot]@users.noreply.github.com>',
+    // This ensures that the gitAuthor and gitSignOff fields match
+    gitAuthor: 'argoproj-renovate[bot] <161757507+argoproj-renovate[bot]@users.noreply.github.com>',
     autodiscover: false,
     allowPostUpgradeCommandTemplating: true,
     allowedPostUpgradeCommands: [".*"],

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
   },
   "extends": [
     "config:recommended",
-    "docker:enableMajor"
+    "docker:enableMajor",
+    ":gitSignOff"
   ],
   "labels": ["renovate"],
   "includePaths": [


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
This should fix comments from renovate like this

> ![Renvate comment](https://github.com/user-attachments/assets/b624d841-f3dd-4b17-9129-672133543852)
> 
> Source: https://github.com/argoproj/argo-helm/pull/2937#issuecomment-2374987187

---

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
