### PR TITLE
feat(argo-workflows): add configurable scrape interval for metrics and telemetry

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.11
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.42.3
+version: 0.42.4
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-workflows to v3.5.11
+      description: Scrape interval for metrics and telemetry data can now be set

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -177,6 +177,7 @@ Fields to note:
 | controller.metricsConfig.headlessService | bool | `false` | Flag to enable headless service |
 | controller.metricsConfig.honorLabels | bool | `false` | When true, honorLabels preserves the metric’s labels when they collide with the target’s labels. |
 | controller.metricsConfig.ignoreErrors | bool | `false` | Flag that instructs prometheus to ignore metric emission errors. |
+| controller.metricsConfig.interval | string | `"30s"` | Frequency at which prometheus scrapes metrics |
 | controller.metricsConfig.metricRelabelings | list | `[]` | ServiceMonitor metric relabel configs to apply to samples before ingestion |
 | controller.metricsConfig.metricsTTL | string | `""` | How often custom metrics are cleared from memory |
 | controller.metricsConfig.path | string | `"/metrics"` | Path is the path where metrics are emitted. Must start with a "/". |
@@ -224,6 +225,7 @@ Fields to note:
 | controller.serviceType | string | `"ClusterIP"` | Service type of the controller Service |
 | controller.telemetryConfig.enabled | bool | `false` | Enables prometheus telemetry server |
 | controller.telemetryConfig.ignoreErrors | bool | `false` | Flag that instructs prometheus to ignore metric emission errors. |
+| controller.telemetryConfig.interval | string | `"30s"` | Frequency at which prometheus scrapes telemetry data |
 | controller.telemetryConfig.metricsTTL | string | `""` | How often custom metrics are cleared from memory |
 | controller.telemetryConfig.path | string | `"/telemetry"` | telemetry path |
 | controller.telemetryConfig.port | int | `8081` | telemetry container port |

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
   {{- if .Values.controller.metricsConfig.enabled }}
     - port: {{ .Values.controller.metricsConfig.servicePortName }}
       path: {{ .Values.controller.metricsConfig.path }}
-      interval: 30s
+      interval: {{ .Values.controller.metricsConfig.interval }}
       {{- with .Values.controller.metricsConfig.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.controller.telemetryConfig.enabled }}
     - port: telemetry
       path: {{ .Values.controller.telemetryConfig.path }}
-      interval: 30s
+      interval: {{ .Values.controller.telemetryConfig.interval }}
       {{- with .Values.controller.metricsConfig.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -127,6 +127,8 @@ controller:
     enabled: false
     # -- Path is the path where metrics are emitted. Must start with a "/".
     path: /metrics
+    # -- Frequency at which prometheus scrapes metrics
+    interval: 30s
     # -- Port is the port where metrics are emitted
     port: 9090
     # -- How often custom metrics are cleared from memory
@@ -234,6 +236,8 @@ controller:
     enabled: false
     # -- telemetry path
     path: /telemetry
+    # -- Frequency at which prometheus scrapes telemetry data
+    interval: 30s
     # -- telemetry container port
     port: 8081
     # -- How often custom metrics are cleared from memory


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
