### PR TITLE
feat(argo-cd): Added chart values deprecation parameters

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.12.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.6.7
+version: 7.7.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Added values depreciation pattern for Chart, to make easier upgrade process.
+      description: Added values deprecation pattern for Chart, to make easier upgrade process.

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Arrange for ApplicationSet in any namespace.
+    - kind: added
+      description: Added values depreciation pattern for Chart, to make easier upgrade process.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -670,7 +670,7 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiVersionOverrides | object | `{}` |  |
-| checkDeprecation | bool | `true` | Checks if any deprecated values are used |
+| checkDeprecation | bool | `false` | Checks if any deprecated values are used |
 | crds.additionalLabels | object | `{}` | Addtional labels to be added to all CRDs |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -670,6 +670,7 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiVersionOverrides | object | `{}` |  |
+| checkDeprecation | bool | `true` | Checks if any deprecated values are used |
 | crds.additionalLabels | object | `{}` | Addtional labels to be added to all CRDs |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-cd/templates/argocd-server/deprecation.yaml
+++ b/charts/argo-cd/templates/argocd-server/deprecation.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.checkDeprecation }}
+   {{- if .Values.server.config }}
+      {{ fail "`server.config` does no longer exist. It has been renamed to `configs`" }}
+   {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/deprecation.yaml
+++ b/charts/argo-cd/templates/argocd-server/deprecation.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.checkDeprecation }}
    {{- if .Values.server.config }}
-      {{ fail "`server.config` does no longer exist. It has been renamed to `configs`" }}
+      {{ fail "`server.config` no longer exists. It has been renamed to `configs`" }}
    {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -3721,3 +3721,7 @@ notifications:
     # For more information: https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/triggers/#default-triggers
     # defaultTriggers: |
     #   - on-sync-status-unknown
+
+# -- Checks if any deprecated values are used
+checkDeprecation: true
+

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -3723,5 +3723,5 @@ notifications:
     #   - on-sync-status-unknown
 
 # -- Checks if any deprecated values are used
-checkDeprecation: true
+checkDeprecation: false
 


### PR DESCRIPTION
Added chart values deprecation parameters. This will simplify updates for changes in charts.

Pattern copied from https://github.com/jenkinsci/helm-charts/blob/jenkins-5.7.1/charts/jenkins/templates/deprecation.yaml

By default now disabled, in future release will put as enabled

---
Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->