### PR TITLE
feat(argo-cd): Expose cluster's project as a label

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.12.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.6.8
+version: 7.6.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Set affinity in redis secret-init job.
+      description: Add the cluster project as a label.

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -11,6 +11,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
     argocd.argoproj.io/secret-type: cluster
+    {{- if $cluster_value.project }}
+    argocd.argoproj.io/project: {{ $cluster_value.project | quote }}
+    {{- end }}
   {{- with $cluster_value.annotations }}
   annotations:
     {{- range $key, $value := . }}


### PR DESCRIPTION
Given that [Argo CD's ApplicationSet cluster generator ](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Cluster/) allows selecting clusters using arbitrary labels, it'd be useful for operators to have the clusters' project available as label to for instance easily deploy a single application to all the clusters of a given project.

More info: https://github.com/argoproj/argo-helm/discussions/2949

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
