### PR TITLE
fix(argo-cd): fixed shard value in clusterCredentials Secret

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.12.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.6.9
+version: 7.6.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: added missing events create for run actions
+      description: fixed shard value in cluster credentials Secret to be string

--- a/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
+++ b/charts/argo-cd/templates/argocd-configs/cluster-secrets.yaml
@@ -20,7 +20,7 @@ metadata:
 type: Opaque
 stringData:
   {{- if $cluster_value.shard }}
-  shard: {{ $cluster_value.shard }}
+  shard: {{ $cluster_value.shard | quote }}
   {{- end }}
   name: {{ required "A valid .Values.configs.clusterCredentials.CLUSTERNAME.name entry is required!" $cluster_key }}
   server: {{ required "A valid .Values.configs.clusterCredentials.CLUSTERNAME.server entry is required!" $cluster_value.server }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Quotes `shard` value in clusterCredential Secret object otherwise it is parsed as number and throws

`json: cannot unmarshal number into Go struct field Secret.stringData of type string`

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
