### PR TITLE
fix(argocd-image-updater): Add new env to respect log level setting

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: v0.15.0
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-image-updater to v0.15.0
+    - kind: fix
+      description: Fix some of the logs don't respect the log level setting

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -82,6 +82,12 @@ spec:
                 key: log.level
                 name: argocd-image-updater-config
                 optional: true
+          - name: ARGOCD_LOGLEVEL
+            valueFrom:
+              configMapKeyRef:
+                key: log.level
+                name: argocd-image-updater-config
+                optional: true
           - name: GIT_COMMIT_USER
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This is a follow-up PR for https://github.com/argoproj-labs/argocd-image-updater/pull/904; that PR resolved the logs generated by the code in argo-image-updater repo. This PR aims to resolve the logs generated by https://github.com/argoproj/gitops-engine/blob/master/pkg/utils/tracing/logging.go#L43 as I mentioned in the description of that PR. 

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
