### PR TITLE
fix(argo-rollouts): plugin block rendering was incorrect

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.7
+version: 2.37.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -20,3 +20,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: add description for manual secret creation
+    - kind: fixed
+      description: Fixed rendering of plugins in the ConfigMap

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -18,7 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: add description for manual secret creation
     - kind: fixed
       description: Fixed rendering of plugins in the ConfigMap

--- a/charts/argo-rollouts/templates/controller/configmap.yaml
+++ b/charts/argo-rollouts/templates/controller/configmap.yaml
@@ -8,8 +8,10 @@ metadata:
     {{- include "argo-rollouts.labels" . | nindent 4 }}
 data:
   {{- with .Values.controller.metricProviderPlugins }}
-    {{- toYaml . | nindent 2 }}
+  metricProviderPlugins: |-
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.controller.trafficRouterPlugins }}
-    {{- toYaml . | nindent 2 }}
+  trafficRouterPlugins: |-
+    {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/2957
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

the config map was getting rendered as 
```
data:
  - location: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-arm64
    name: argoproj-labs/gatewayAPI
```

this changes it to 
```
data:
  trafficRouterPlugins: |-
    - location: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-arm64
      name: argoproj-labs/gatewayAPI
```
as shown in [metricPlugin](https://argoproj.github.io/argo-rollouts/analysis/plugins/#mounting-the-plugin-executable-into-the-rollouts-controller-container) and [trafficPlugin](https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/#mounting-the-plugin-executable-into-the-rollouts-controller-container)