### PR TITLE
feat(argo-rollouts): configurable automountServiceAccountToken

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.8
+version: 2.37.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fixed rendering of plugins in the ConfigMap
+    - kind: changed
+      description: Add configurable automountServiceAccountToken

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -134,6 +134,7 @@ For full list of changes please check ArtifactHub [changelog].
 | podLabels | object | `{}` | Labels to be added to the Rollout pods |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automount | bool | `true` | Specifies wether a service account should be automounted |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceAnnotations | object | `{}` | Annotations to be added to the Rollout service |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -44,6 +44,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       containers:
       - image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
         args:

--- a/charts/argo-rollouts/templates/dashboard/deployment.yaml
+++ b/charts/argo-rollouts/templates/dashboard/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}-dashboard
+      automountServiceAccountToken: {{ .Values.dashboard.serviceAccount.automount }}
       containers:
       - image: "{{ .Values.dashboard.image.registry }}/{{ .Values.dashboard.image.repository }}:{{ default .Chart.AppVersion .Values.dashboard.image.tag }}"
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -229,6 +229,8 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # -- Specifies wether a service account should be automounted
+  automount: true
 
 # -- Annotations to be added to all CRDs
 crdAnnotations: {}
@@ -384,7 +386,9 @@ dashboard:
     # -- The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
-
+    # -- Specifies wether a service account should be automounted
+    automount: true
+  
   ## Configure Pod Disruption Budget for the dashboard
   pdb:
     # -- Labels to be added to dashboard [Pod Disruption Budget]


### PR DESCRIPTION
Inspired by https://github.com/argoproj/argo-helm/pull/2625

Adding a configurable option for `automountServiceAccountToken` in argo-rollouts chart. This is my first contribution so please let me know if I am missing anything.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

