### PR TITLE
fix(argo-rollouts): Change type of trafficRouterPlugins and trafficRouterPlugins as list

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.8
+version: 2.37.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed rendering of plugins in the ConfigMap
+      description: Updated values.yaml examples for the non-stringigied options. No effective change

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.7.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.9
+version: 2.38.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Updated values.yaml examples for the non-stringigied options. No effective change
+      description: Updated plugin values.yaml example and it's implementation to not need to include the stringification or the plugins block that it used to

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -102,7 +102,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.logging.format | string | `"text"` | Set the logging format (one of: `text`, `json`) |
 | controller.logging.kloglevel | string | `"0"` | Set the klog logging level |
 | controller.logging.level | string | `"info"` | Set the logging level (one of: `debug`, `info`, `warn`, `error`) |
-| controller.metricProviderPlugins | object | `{}` | Configures 3rd party metric providers for controller |
+| controller.metricProviderPlugins | list | `[]` | Configures 3rd party metric providers for controller |
 | controller.metrics.enabled | bool | `false` | Deploy metrics service |
 | controller.metrics.service.annotations | object | `{}` | Service annotations |
 | controller.metrics.service.port | int | `8090` | Metrics service port |
@@ -127,7 +127,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the controller |
-| controller.trafficRouterPlugins | object | `{}` | Configures 3rd party traffic router plugins for controller |
+| controller.trafficRouterPlugins | list | `[]` | Configures 3rd party traffic router plugins for controller |
 | controller.volumeMounts | list | `[]` | Additional volumeMounts to add to the controller container |
 | controller.volumes | list | `[]` | Additional volumes to add to the controller pod |
 | podAnnotations | object | `{}` | Annotations for the all deployed pods |

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -209,17 +209,15 @@ controller:
 
   # -- Configures 3rd party metric providers for controller
   ## Ref: https://argo-rollouts.readthedocs.io/en/stable/analysis/plugins/
-  metricProviderPlugins: {}
-    # metricProviderPlugins:
-    #   - name: "argoproj-labs/sample-prometheus" # name of the plugin, it must match the name required by the plugin so that it can find its configuration
-    #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+  metricProviderPlugins: []
+    # - name: "argoproj-labs/sample-prometheus" # name of the plugin, it must match the name required by the plugin so that it can find its configuration
+    #   location: "file://./my-custom-plugin" # supports http(s):// urls and file://
 
   # -- Configures 3rd party traffic router plugins for controller
   ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
-  trafficRouterPlugins: {}
-    # trafficRouterPlugins:
-    #   - name: "argoproj-labs/sample-nginx" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
-    #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+  trafficRouterPlugins: []
+    # - name: "argoproj-labs/sample-nginx" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
+    #   location: "file://./my-custom-plugin" # supports http(s):// urls and file://
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -210,14 +210,14 @@ controller:
   # -- Configures 3rd party metric providers for controller
   ## Ref: https://argo-rollouts.readthedocs.io/en/stable/analysis/plugins/
   metricProviderPlugins: {}
-    # metricProviderPlugins: |-
+    # metricProviderPlugins:
     #   - name: "argoproj-labs/sample-prometheus" # name of the plugin, it must match the name required by the plugin so that it can find its configuration
     #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
 
   # -- Configures 3rd party traffic router plugins for controller
   ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
   trafficRouterPlugins: {}
-    # trafficRouterPlugins: |-
+    # trafficRouterPlugins:
     #   - name: "argoproj-labs/sample-nginx" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
     #     location: "file://./my-custom-plugin" # supports http(s):// urls and file://
 


### PR DESCRIPTION
The change I made here https://github.com/argoproj/argo-helm/pull/3014 broken the examples. 

This works w/ my original change:
```
controller:
  trafficRouterPlugins:
    - name: "argoproj-labs/gatewayAPI"
      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-arm64"
      sha256: "07e2fe515c900899c96777aac0ab490437a3d62c8adb94512ccb8b859325eb11"
```

But the example shows stringification is needed.

I feel having it "look like a real thing instead of a string" is more user friendly.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
