### PR TITLE
fix(argo-workflows): Make Argo Agent and Artifact GC permissions optional for workflows SA

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.6.0
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.44.0
+version: 0.45.0
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Remove excessive RBAC privileges from workflow-role.
+      description: Make Argo Agent and Artifact GC permissions optional for workflows SA

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -133,7 +133,7 @@ Fields to note:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | workflow.namespace | string | `nil` | Deprecated; use controller.workflowNamespaces instead. |
-| workflow.rbac.agentPermissions | bool | `false` | Allows permissions for the Argo Agent. Only required if using http templates |
+| workflow.rbac.agentPermissions | bool | `false` | Allows permissions for the Argo Agent. Only required if using http/plugin templates |
 | workflow.rbac.artifactGC | bool | `false` | Allows permissions for the Argo Artifact GC pod. Only required if using artifact gc |
 | workflow.rbac.create | bool | `true` | Adds Role and RoleBinding for the above specified service account to be able to run workflows. A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below) |
 | workflow.rbac.serviceAccounts | list | `[]` | Extra service accounts to be added to the RoleBinding |

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -133,6 +133,8 @@ Fields to note:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | workflow.namespace | string | `nil` | Deprecated; use controller.workflowNamespaces instead. |
+| workflow.rbac.agentPermissions | bool | `false` | Allows permissions for the Argo Agent. Only required if using http templates |
+| workflow.rbac.artifactGC | bool | `false` | Allows permissions for the Argo Artifact GC pod. Only required if using artifact gc |
 | workflow.rbac.create | bool | `true` | Adds Role and RoleBinding for the above specified service account to be able to run workflows. A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below) |
 | workflow.rbac.serviceAccounts | list | `[]` | Extra service accounts to be added to the RoleBinding |
 | workflow.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |

--- a/charts/argo-workflows/templates/controller/agent-rb.yaml
+++ b/charts/argo-workflows/templates/controller/agent-rb.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.workflow.rbac.agentPermissions -}}
+  {{- range $namespace := or .Values.singleNamespace false | ternary (list "") (append .Values.controller.workflowNamespaces (coalesce .Values.workflow.namespace (include "argo-workflows.namespace" .)) | uniq)  }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "argo-workflows.fullname" $ }}-workflow-agent
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
+    {{- with $namespace }}
+  namespace: {{ . }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "argo-workflows.fullname" $ }}-workflow-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.workflow.serviceAccount.name }}
+    {{- with $namespace }}
+    namespace: {{ . }}
+    {{- end }}
+  {{- range $.Values.workflow.rbac.serviceAccounts }}
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ .namespace | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/controller/agent-role.yaml
+++ b/charts/argo-workflows/templates/controller/agent-role.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.workflow.rbac.agentPermissions -}}
+  {{- range $namespace := or .Values.singleNamespace false | ternary (list "") (append .Values.controller.workflowNamespaces (coalesce .Values.workflow.namespace (include "argo-workflows.namespace" .)) | uniq)  }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "argo-workflows.fullname" $ }}-workflow-agent
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
+    {{- with $namespace }}
+  namespace: {{ . }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtasksets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowtasksets/status
+    verbs:
+      - patch
+  {{- end }}
+
+{{- end }}

--- a/charts/argo-workflows/templates/controller/artifact-gc-rb.yaml
+++ b/charts/argo-workflows/templates/controller/artifact-gc-rb.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.workflow.rbac.artifactGC -}}
+  {{- range $namespace := or .Values.singleNamespace false | ternary (list "") (append .Values.controller.workflowNamespaces (coalesce .Values.workflow.namespace (include "argo-workflows.namespace" .)) | uniq)  }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "argo-workflows.fullname" $ }}-wf-artifactgc
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
+    {{- with $namespace }}
+  namespace: {{ . }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "argo-workflows.fullname" $ }}-wf-artifactgc
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.workflow.serviceAccount.name }}
+    {{- with $namespace }}
+    namespace: {{ . }}
+    {{- end }}
+  {{- range $.Values.workflow.rbac.serviceAccounts }}
+  - kind: ServiceAccount
+    name: {{ .name }}
+    namespace: {{ .namespace | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-workflows/templates/controller/artifact-gc-role.yaml
+++ b/charts/argo-workflows/templates/controller/artifact-gc-role.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.workflow.rbac.artifactGC -}}
+  {{- range $namespace := or .Values.singleNamespace false | ternary (list "") (append .Values.controller.workflowNamespaces (coalesce .Values.workflow.namespace (include "argo-workflows.namespace" .)) | uniq)  }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "argo-workflows.fullname" $ }}-wf-artifactgc
+  labels:
+    {{- include "argo-workflows.labels" (dict "context" $ "component" $.Values.controller.name "name" $.Values.controller.name) | nindent 4 }}
+    {{- with $namespace }}
+  namespace: {{ . }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowartifactgctasks
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - workflowartifactgctasks/status
+    verbs:
+      - patch
+  {{- end }}
+
+{{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -18,21 +18,6 @@ rules:
     verbs:
       - create
       - patch
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - workflowtasksets
-      - workflowartifactgctasks
-    verbs:
-      - list
-      - watch
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - workflowtasksets/status
-      - workflowartifactgctasks/status
-    verbs:
-      - patch
   {{- end }}
 
 {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -69,6 +69,10 @@ workflow:
     # -- Adds Role and RoleBinding for the above specified service account to be able to run workflows.
     # A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below)
     create: true
+    # -- Allows permissions for the Argo Agent. Only required if using http templates
+    agentPermissions: false
+    # -- Allows permissions for the Argo Artifact GC pod. Only required if using artifact gc
+    artifactGC: false
     # -- Extra service accounts to be added to the RoleBinding
     serviceAccounts: []
       # - name: my-service-account

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -69,7 +69,7 @@ workflow:
     # -- Adds Role and RoleBinding for the above specified service account to be able to run workflows.
     # A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below)
     create: true
-    # -- Allows permissions for the Argo Agent. Only required if using http templates
+    # -- Allows permissions for the Argo Agent. Only required if using http/plugin templates
     agentPermissions: false
     # -- Allows permissions for the Argo Artifact GC pod. Only required if using artifact gc
     artifactGC: false


### PR DESCRIPTION
This changes the permissions on the workflows Service Account.

Previously we gave permissions for the Argo Agent and Artifact GC to every workflow SA, this was overly permissive. Now with this PR, these things are disabled by default but can be enabled by the user if those features are used.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
