### PR TITLE
fix(argo-cd): Fix repo-server honorLabels config template

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Bump argocd-extension-installer to v0.0.8
+    - kind: changed
+      description: Fix honorLabels config template

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.13.1
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.7.8
+version: 7.7.9
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,7 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-extension-installer to v0.0.8
-    - kind: changed
+    - kind: fixed
       description: Fix honorLabels config template

--- a/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
@@ -34,8 +34,8 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.repoServer.metrics.serviceMonitor.scheme }}
       honorLabels: {{ .Values.repoServer.metrics.serviceMonitor.honorLabels }}
+      {{- with .Values.repoServer.metrics.serviceMonitor.scheme }}
       scheme: {{ . }}
       {{- end }}
       {{- with .Values.repoServer.metrics.serviceMonitor.tlsConfig }}


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/argoproj/argo-helm/commit/0061e14563571f1cd0447fcac0e90407a600bbc4#diff-ef4a32480a793da4e68fa5b4e320523c5a1acf86064769abfc1d97a1462143eeR38 where the honorLabels config for the repo-server was put inside the `with` statement. In that case, if `.Values.repoServer.metrics.serviceMonitor.scheme` is set, the honorLabels value can't be found because the `.Values` object is not accessible from within the `with` block.
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
