### PR TITLE
feat(argo-workflows): Support ephemeral credentials for s3

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.6.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.45.2
+version: 0.45.3
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Reference to ingress link was fixed
+    - kind: added
+      description: Support ephemeral credentials for s3 artifact repository

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -83,6 +83,11 @@ data:
         secretKeySecret:
           key: {{ tpl .Values.artifactRepository.s3.secretKeySecret.key . }}
           name: {{ tpl .Values.artifactRepository.s3.secretKeySecret.name . }}
+        {{- if .Values.artifactRepository.s3.sessionTokenSecret }}
+        sessionTokenSecret:
+          key: {{ tpl .Values.artifactRepository.s3.sessionTokenSecret.key . }}
+          name: {{ tpl .Values.artifactRepository.s3.sessionTokenSecret.name . }}
+        {{- end }}
         {{- end }}
         bucket: {{ tpl (.Values.artifactRepository.s3.bucket | default "") . }}
         endpoint: {{ tpl (.Values.artifactRepository.s3.endpoint | default "") . }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -812,6 +812,9 @@ artifactRepository:
     # secretKeySecret:
     #   name: "{{ .Release.Name }}-minio"
     #   key: secretkey
+    # sessionTokenSecret:
+    #   name: "{{ .Release.Name }}-minio"
+    #   key: sessionToken
     # # insecure will disable TLS. Primarily used for minio installs not configured with TLS
     # insecure: false
     # caSecret:


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

In https://github.com/argoproj/argo-workflows/pull/12467, support for ephemeral S3 credentials was added. These are used when using AWS S3 Grants or AWS IAM Roles. This PR adds support for the `sessionTokenSecret` field to the argo-workflows helm chart.


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
