### PR TITLE
chore(github): Support redis-exporter to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -102,6 +102,13 @@
       "enabled": false
     },
     {
+      "matchPackagePatterns": ["public.ecr.aws/bitnami/redis-exporter"],
+      "commitMessagePrefix": "chore({{{replace 'public.ecr.aws/' '' depName}}}):",
+      "postUpgradeTasks": {
+        "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
+      }
+    },
+    {
       "matchPackageNames": ["ghcr.io/renovatebot/renovate"],
       "extends": ["schedule:monthly"]
     }


### PR DESCRIPTION
Related to https://github.com/argoproj/argo-helm/pull/3104 .
In order to bump version and changelog for `public.ecr.aws/bitnami/redis-exporter`, I adjusted renovate.json.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
