### PR TITLE
fix(github): Support redis/argocd-extension-installer to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -99,7 +99,7 @@
     },
     {
       "matchPackagePatterns": ["argoprojlabs/argocd-extension-installer"],
-      "commitMessagePrefix": "chore({{{replace 'argoprojlabs/' '' depName}}}):",
+      "commitMessagePrefix": "chore({{{replace '*' 'argo-cd' depName}}}):",
       "postUpgradeTasks": {
         "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
       }
@@ -110,7 +110,7 @@
     },
     {
       "matchPackagePatterns": ["public.ecr.aws/bitnami/redis-exporter"],
-      "commitMessagePrefix": "chore({{{replace 'public.ecr.aws/' '' depName}}}):",
+      "commitMessagePrefix": "chore({{{replace '*' 'argo-cd' depName}}}):",
       "postUpgradeTasks": {
         "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
       }

--- a/renovate.json
+++ b/renovate.json
@@ -99,7 +99,7 @@
     },
     {
       "matchPackagePatterns": ["argoprojlabs/argocd-extension-installer"],
-      "commitMessagePrefix": "chore({{{replace '*' 'argo-cd' depName}}}):",
+      "commitMessagePrefix": "chore({{{parentDir}}}):",
       "postUpgradeTasks": {
         "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
       }
@@ -110,7 +110,7 @@
     },
     {
       "matchPackagePatterns": ["public.ecr.aws/bitnami/redis-exporter"],
-      "commitMessagePrefix": "chore({{{replace '*' 'argo-cd' depName}}}):",
+      "commitMessagePrefix": "chore({{{parentDir}}}):",
       "postUpgradeTasks": {
         "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
       }

--- a/renovate.json
+++ b/renovate.json
@@ -98,6 +98,13 @@
       }
     },
     {
+      "matchPackagePatterns": ["argoprojlabs/argocd-extension-installer"],
+      "commitMessagePrefix": "chore({{{replace 'argoprojlabs/' '' depName}}}):",
+      "postUpgradeTasks": {
+        "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
+      }
+    },
+    {
       "matchPackagePatterns": ["redis-ha"],
       "enabled": false
     },

--- a/scripts/renovate-bump-version.sh
+++ b/scripts/renovate-bump-version.sh
@@ -10,7 +10,14 @@ chartName=$(echo "$depName" | sed -e "s+^argoproj/++" -e "s+^argoproj-labs/++")
 echo "Changed chart name is: $chartName"
 echo "----------------------------------------"
 
-parentDir="charts/${chartName}"
+case "${chartName}" in
+  *"redis"*|*"argocd-extension-installer")
+    parentDir="charts/argo-cd"
+    ;;
+  *)
+    parentDir="charts/${chartName}"
+    ;;
+esac
 
 # Bump the chart version by one patch version
 version=$(grep '^version:' "${parentDir}/Chart.yaml" | awk '{print $2}')


### PR DESCRIPTION
In order to pass https://github.com/argoproj/argo-helm/pull/3104 , I modified scripts.
Related to https://github.com/argoproj/argo-helm/pull/3072

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
