### PR TITLE
fix(argo-workflows): container and mainContainer imagePullPolicy

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.6.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.45.4
+version: 0.45.5
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Support configuring workflow events in the controller
+    - kind: fixed
+      description: Fix main container and executor pull policy option

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -31,7 +31,7 @@ data:
     {{- with .Values.controller.initialDelay }}
     initialDelay: {{ . }}
     {{- end }}
-    {{- if or .Values.mainContainer.resources .Values.mainContainer.env .Values.mainContainer.envFrom .Values.mainContainer.securityContext}}
+    {{- if or .Values.images.pullPolicy .Values.mainContainer}}
     mainContainer:
       imagePullPolicy: {{ default (.Values.images.pullPolicy) .Values.mainContainer.imagePullPolicy }}
       {{- with .Values.mainContainer.resources }}
@@ -47,7 +47,7 @@ data:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
-    {{- if or .Values.executor.resources .Values.executor.env .Values.executor.args .Values.executor.securityContext}}
+    {{- if or .Values.images.pullPolicy .Values.executor}}
     executor:
       imagePullPolicy: {{ default (.Values.images.pullPolicy) .Values.executor.image.pullPolicy }}
       {{- with .Values.executor.resources }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

I found a strange behavior with the mainContainer "imagePullPolicy" (and the same with executor since they work similary). 

With the current release, if I apply the chart with the following values.yaml
```yaml
mainContainer:
  imagePullPolicy: "Always"
```
My controller config-map does not have the expecting output : 
```yaml
data:
  config: |
    nodeEvents:
      enabled: true
    workflowEvents:
      enabled: true
```

When we only set **imagePullPolicy** option for the **mainContainer** or the **executor**, it’s not applied. 

Plus, the [doc](https://artifacthub.io/packages/helm/argo/argo-workflows#workflow-main-container) specifies that the default value for those fields are "Values.images.pullPolicy". So, I expect the config map to contains according pull policy for executor and main container when I apply the chart with an empty values.yaml, but it's not the case, I obtain the same config map mentioned earlier. 

It’s my first contribution, I have read the CONTRIBUTING.md but any feedback is welcome !
