### PR TITLE
feat(github): Support redis and extension-installer in Renovate - alternative

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -32,6 +32,7 @@ jobs:
           # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
           renovate-version: 39.86.4
           token: '${{ steps.get_token.outputs.token }}'
+          mount-docker-socket: true
         env:
           LOG_LEVEL: 'debug'
           RENOVATE_REPOSITORIES: '${{ github.repository }}'

--- a/renovate.json
+++ b/renovate.json
@@ -90,7 +90,7 @@
       ],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{{lookup (split depName '/') @last}}} -v {{newVersion}}"]
+        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{ depName }} -v {{newVersion}}"]
       }
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -90,7 +90,7 @@
       ],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{lookup (split depName '/') @last}} -v {{newVersion}}"]
+        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{{lookup (split depName '/') @last}}} -v {{newVersion}}"]
       }
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -83,30 +83,19 @@
         "argoproj/argo-workflows",
         "argoproj/argo-cd",
         "argoproj/argo-events",
-        "argoproj/argo-rollouts"
+        "argoproj/argo-rollouts",
+        "argoproj-labs/argocd-image-updater",
+        "argoprojlabs/argocd-extension-installer",
+        "public.ecr.aws/bitnami/redis-exporter"
       ],
-      "commitMessagePrefix": "chore({{{replace 'argoproj/' '' depName}}}):",
+      "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
-      }
-    },
-    {
-      "matchPackagePatterns": ["argoproj-labs/argocd-image-updater"],
-      "commitMessagePrefix": "chore({{{replace 'argoproj-labs/' '' depName}}}):",
-      "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
+        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{lookup (split depName '/') @last}} -v {{newVersion}}"]
       }
     },
     {
       "matchPackagePatterns": ["redis-ha"],
       "enabled": false
-    },
-    {
-      "matchPackagePatterns": ["public.ecr.aws/bitnami/redis-exporter"],
-      "commitMessagePrefix": "chore({{{replace 'public.ecr.aws/' '' depName}}}):",
-      "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh {{depName}}"]
-      }
     },
     {
       "matchPackageNames": ["ghcr.io/renovatebot/renovate"],

--- a/renovate.json
+++ b/renovate.json
@@ -91,7 +91,10 @@
       ],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}"]
+        "commands": [
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/helm-docs.sh"
+        ]
       }
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -93,8 +93,7 @@
       "postUpgradeTasks": {
         "commands": [
           "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
-          "go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.9.1",
-          "helm-docs"
+          "./scripts/helm-docs.sh"
         ]
       }
     },

--- a/renovate.json
+++ b/renovate.json
@@ -86,11 +86,12 @@
         "argoproj/argo-rollouts",
         "argoproj-labs/argocd-image-updater",
         "argoprojlabs/argocd-extension-installer",
-        "public.ecr.aws/bitnami/redis-exporter"
+        "public.ecr.aws/bitnami/redis-exporter",
+        "public.ecr.aws/docker/library/redis"
       ],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
-        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{ depName }} -v {{newVersion}}"]
+        "commands": ["./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}"]
       }
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -93,7 +93,8 @@
       "postUpgradeTasks": {
         "commands": [
           "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
-          "./scripts/helm-docs.sh"
+          "go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.9.1",
+          "helm-docs"
         ]
       }
     },

--- a/scripts/renovate-bump-version.sh
+++ b/scripts/renovate-bump-version.sh
@@ -19,6 +19,9 @@ if [ -z "${dependency_name}" ] || [ -z "${dependency_version}" ] || [ -z "${char
 fi
 
 chart_yaml_path="charts/${chart}/Chart.yaml"
+# Split dependency by '/' and only use last element
+# This way we can drop prefixes like "argoproj/..." , "argoproj-labs/..." , "quay.io/foo/..."
+dependency_name="${dependency_name##*/}"
 
 # Bump the chart version by one patch version
 version=$(grep '^version:' "${chart_yaml_path}" | awk '{print $2}')


### PR DESCRIPTION
This is an alternative approach of:
- #3106

> In order to pass https://github.com/argoproj/argo-helm/pull/3104 , I modified scripts.
> Related to https://github.com/argoproj/argo-helm/pull/3072

## Testing
I tested the changes on my personal fork:
[full job-logs.txt](https://github.com/user-attachments/files/18565697/tested_on_fork_job-logs_2.txt)

Here you can see the script invokes by Renovate
```log
2025-01-27T23:03:36.9964962Z        "command": "./scripts/renovate-bump-version.sh -c argo-cd -d public.ecr.aws/docker/library/redis -v 7.4.2"
2025-01-27T23:03:37.0199099Z        "command": "./scripts/helm-docs.sh"
2025-01-27T23:03:38.2032791Z        "command": "./scripts/renovate-bump-version.sh -c argo-cd -d public.ecr.aws/docker/library/redis -v 7.4.2"
2025-01-27T23:03:38.2247721Z        "command": "./scripts/helm-docs.sh"
2025-01-27T23:03:43.1657071Z        "command": "./scripts/renovate-bump-version.sh -c argo-cd -d public.ecr.aws/bitnami/redis-exporter -v 1.67.0"
2025-01-27T23:03:43.1866295Z        "command": "./scripts/helm-docs.sh"
```

### PRs created during testing

- https://github.com/mkilchhofer/argo-helm/pull/34
- https://github.com/mkilchhofer/argo-helm/pull/35

---
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
