### PR TITLE
fix(argo-cd): Fix conditional generation of ssh and tls configmaps

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.1
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.0
+version: 7.8.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v2.14.1
+    - kind: fixed
+      description: Make ssh and tls volumes conditional to the configmap creation

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -267,10 +267,14 @@ spec:
             {{- with .Values.applicationSet.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.configs.ssh.create }}
             - mountPath: /app/config/ssh
               name: ssh-known-hosts
+            {{- end }}
+            {{- if .Values.configs.tls.create }}
             - mountPath: /app/config/tls
               name: tls-certs
+            {{- end }}
             - mountPath: /app/config/gpg/source
               name: gpg-keys
             - mountPath: /app/config/gpg/keys
@@ -313,12 +317,16 @@ spec:
         {{- with .Values.applicationSet.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.configs.ssh.create }}
         - name: ssh-known-hosts
           configMap:
             name: argocd-ssh-known-hosts-cm
+        {{- end }}
+        {{- if .Values.configs.tls.create }}
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm
+        {{- end }}
         - name: gpg-keys
           configMap:
             name: argocd-gpg-keys-cm

--- a/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
@@ -146,10 +146,14 @@ spec:
         {{- with .Values.commitServer.extraVolumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.configs.ssh.create }}
         - name: ssh-known-hosts
           mountPath: /app/config/ssh
+        {{- end }}
+        {{- if .Values.configs.tls.create }}
         - name: tls-certs
           mountPath: /app/config/tls
+        {{- end }}
         - name: gpg-keys
           mountPath: /app/config/gpg/source
         - name: gpg-keyring
@@ -178,12 +182,16 @@ spec:
         {{- with .Values.commitServer.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.configs.ssh.create }}
         - name: ssh-known-hosts
           configMap:
             name: argocd-ssh-known-hosts-cm
+        {{- end }}
+        {{- if .Values.configs.tls.create }}
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm
+        {{- end }}
         - name: gpg-keys
           configMap:
             name: argocd-gpg-keys-cm

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -321,10 +321,14 @@ spec:
         {{- if .Values.repoServer.volumeMounts }}
           {{- toYaml .Values.repoServer.volumeMounts | nindent 8 }}
         {{- end }}
+        {{- if .Values.configs.ssh.create }}
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
+        {{- end }}
+        {{- if .Values.configs.tls.create }}
         - mountPath: /app/config/tls
           name: tls-certs
+        {{- end }}
         - mountPath: /app/config/gpg/source
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
@@ -471,12 +475,16 @@ spec:
         emptyDir: {}
           {{- end }}
         {{- end }}
+      {{- if .Values.configs.ssh.create }}
       - name: ssh-known-hosts
         configMap:
           name: argocd-ssh-known-hosts-cm
+      {{- end }}
+      {{- if .Values.configs.tls.create }}
       - name: tls-certs
         configMap:
           name: argocd-tls-certs-cm
+      {{- end }}
       - name: gpg-keys
         configMap:
           name: argocd-gpg-keys-cm

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -387,10 +387,14 @@ spec:
         {{- with .Values.server.volumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.configs.ssh.create }}
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
+        {{- end }}
+        {{- if .Values.configs.tls.create }}
         - mountPath: /app/config/tls
           name: tls-certs
+        {{- end }}
         - mountPath: /app/config/server/tls
           name: argocd-repo-server-tls
         - mountPath: /app/config/dex/tls
@@ -521,12 +525,16 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+      {{- if .Values.configs.ssh.create }}
       - name: ssh-known-hosts
         configMap:
           name: argocd-ssh-known-hosts-cm
+      {{- end }}
+      {{- if .Values.configs.tls.create }}
       - name: tls-certs
         configMap:
           name: argocd-tls-certs-cm
+      {{- end }}
       - name: styles
         configMap:
           name: argocd-styles-cm


### PR DESCRIPTION
Since respectively versions [7.7.11](https://github.com/argoproj/argo-helm/releases/tag/argo-cd-7.7.11) and [7.7.16](https://github.com/argoproj/argo-helm/releases/tag/argo-cd-7.7.16), the configmaps `ssh-known-hosts` and `tls-certs` can be disabled completely from the chart generation  
However, the volumes and volumeMounts of the different elements are not conditioned to be removed if the configmaps are not generated and it causes boot issues due to missing volume configs

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
