### PR TITLE
fix(github): Add dex to renovate-bump-version.sh

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -87,7 +87,8 @@
         "argoproj-labs/argocd-image-updater",
         "argoprojlabs/argocd-extension-installer",
         "public.ecr.aws/bitnami/redis-exporter",
-        "public.ecr.aws/docker/library/redis"
+        "public.ecr.aws/docker/library/redis",
+        "ghcr.io/dexidp/dex"
       ],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Resolves https://github.com/argoproj/argo-helm/issues/3173 .

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
