### PR TITLE
fix(argo-cd): Fixed broken topologySpreadConstraints template in commitServer component

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.5
+version: 7.8.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Added a comment how to pass values into argocd-cm ConfigMap
+    - kind: fixed
+      description: Fixed broken topologySpreadConstraints template in commitServer component

--- a/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
@@ -223,7 +223,7 @@ spec:
         {{- if not $constraint.labelSelector }}
         labelSelector:
           matchLabels:
-            {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.commitServer.name) | nindent 12 }}
+            {{- include "argo-cd.selectorLabels" (dict "context" $ "name" $.Values.commitServer.name) | nindent 12 }}
         {{- end }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

following values causing template error

```yaml
global:
  topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: kubernetes.io/hostname
      whenUnsatisfiable: DoNotSchedule

commitServer:
  enabled: true

```

`Error: template: argo-cd/templates/argocd-commit-server/deployment.yaml:226:81: executing "argo-cd/templates/argocd-commit-server/deployment.yaml" at <.Values.commitServer.name>: nil pointer evaluating interface {}.commitServer`
