### PR TITLE
fix(argo-cd): Pass commit.server parameter to the application controller to account for the commitServer service name.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.3
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.7
+version: 7.8.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed broken topologySpreadConstraints template in commitServer component
+      description: Pass commit.server parameter to the application controller to account for the commitServer service name.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1674,6 +1674,8 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | commitServer.runtimeClassName | string | `""` (defaults to global.runtimeClassName) | Runtime class name for the commit server |
 | commitServer.service.annotations | object | `{}` | commit server service annotations |
 | commitServer.service.labels | object | `{}` | commit server service labels |
+| commitServer.service.port | int | `8086` | commit server service port |
+| commitServer.service.portName | string | `"server"` | commit server service port name |
 | commitServer.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | commitServer.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | commitServer.serviceAccount.create | bool | `true` | Create commit server service account |

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -238,7 +238,10 @@ NOTE: Configuration keys must be stored as dict because YAML treats dot as separ
 {{- $_ := set $presets "server.dex.server" (include "argo-cd.dex.server" .) -}}
 {{- $_ := set $presets "server.dex.server.strict.tls" .Values.dex.certificateSecret.enabled -}}
 {{- end -}}
-{{- range $component := tuple "applicationsetcontroller" "controller" "server" "reposerver" -}}
+{{- if .Values.commitServer.enabled -}}
+{{- $_ := set $presets "commit.server" (printf "%s:%s" (include "argo-cd.commitServer.fullname" .) (.Values.commitServer.service.port | toString)) -}}
+{{- end -}}
+{{- range $component := tuple "applicationsetcontroller" "controller" "server" "reposerver" "commitserver" -}}
 {{- $_ := set $presets (printf "%s.log.format" $component) $.Values.global.logging.format -}}
 {{- $_ := set $presets (printf "%s.log.level" $component) $.Values.global.logging.level -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -109,6 +109,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.repo.error.grace.period.seconds
                 optional: true
+          - name: ARGOCD_APPLICATION_CONTROLLER_COMMIT_SERVER
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: commit.server
+                optional: true
           - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -108,6 +108,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.repo.error.grace.period.seconds
                 optional: true
+          - name: ARGOCD_APPLICATION_CONTROLLER_COMMIT_SERVER
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: commit.server
+                optional: true
           - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-commit-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/service.yaml
@@ -17,10 +17,10 @@ metadata:
   {{- end }}
 spec:
   ports:
-  - name: server
+  - name: {{ .Values.commitServer.service.portName }}
     protocol: TCP
-    port: 8086
-    targetPort: 8086
+    port: {{ .Values.commitServer.service.port }}
+    targetPort: server
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.commitServer.name) | nindent 4 }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -3821,6 +3821,10 @@ commitServer:
     annotations: {}
     # -- commit server service labels
     labels: {}
+    # -- commit server service port
+    port: 8086
+    # -- commit server service port name
+    portName: server
 
   # -- Automount API credentials for the Service Account into the pod.
   automountServiceAccountToken: false


### PR DESCRIPTION
- pass `commit.server` parameter to the application controller to account for the commitServer service name.
- align service definition for commitServer with rest of the chart
- respect global log settings in commitserver component

Diff
```diff
diff --recursive .tmp/manifests_old/argo-cd/templates/argocd-application-controller/statefulset.yaml .tmp/manifests_new/argo-cd/templates/argocd-application-controller/statefulset.yaml
27c27
<         checksum/cmd-params: 7f9ab655f97c07d18371fb74e1eed52ab343b2e05812ea40bae8b868fcae8d37
---
>         checksum/cmd-params: 8292fa4e5925f6f9c66e744f6d44187809f0f9d851e09b24506c6fab32061f91
75a76,81
>                 optional: true
>           - name: ARGOCD_APPLICATION_CONTROLLER_COMMIT_SERVER
>             valueFrom:
>               configMapKeyRef:
>                 name: argocd-cmd-params-cm
>                 key: commit.server
diff --recursive .tmp/manifests_old/argo-cd/templates/argocd-applicationset/deployment.yaml .tmp/manifests_new/argo-cd/templates/argocd-applicationset/deployment.yaml
26c26
<         checksum/cmd-params: 7f9ab655f97c07d18371fb74e1eed52ab343b2e05812ea40bae8b868fcae8d37
---
>         checksum/cmd-params: 8292fa4e5925f6f9c66e744f6d44187809f0f9d851e09b24506c6fab32061f91
diff --recursive .tmp/manifests_old/argo-cd/templates/argocd-commit-server/service.yaml .tmp/manifests_new/argo-cd/templates/argocd-commit-server/service.yaml
21c21
<     targetPort: 8086
---
>     targetPort: server
diff --recursive .tmp/manifests_old/argo-cd/templates/argocd-configs/argocd-cmd-params-cm.yaml .tmp/manifests_new/argo-cd/templates/argocd-configs/argocd-cmd-params-cm.yaml
23a24,26
>   commit.server: test-argocd-commit-server:8086
>   commitserver.log.format: text
>   commitserver.log.level: info
diff --recursive .tmp/manifests_old/argo-cd/templates/argocd-repo-server/deployment.yaml .tmp/manifests_new/argo-cd/templates/argocd-repo-server/deployment.yaml
26c26
<         checksum/cmd-params: 7f9ab655f97c07d18371fb74e1eed52ab343b2e05812ea40bae8b868fcae8d37
---
>         checksum/cmd-params: 8292fa4e5925f6f9c66e744f6d44187809f0f9d851e09b24506c6fab32061f91
diff --recursive .tmp/manifests_old/argo-cd/templates/argocd-server/deployment.yaml .tmp/manifests_new/argo-cd/templates/argocd-server/deployment.yaml
26c26
<         checksum/cmd-params: 7f9ab655f97c07d18371fb74e1eed52ab343b2e05812ea40bae8b868fcae8d37
---
>         checksum/cmd-params: 8292fa4e5925f6f9c66e744f6d44187809f0f9d851e09b24506c6fab32061f91
diff --recursive .tmp/manifests_old/argo-cd/templates/dex/deployment.yaml .tmp/manifests_new/argo-cd/templates/dex/deployment.yaml
26c26
<         checksum/cmd-params: 7f9ab655f97c07d18371fb74e1eed52ab343b2e05812ea40bae8b868fcae8d37
---
>         checksum/cmd-params: 8292fa4e5925f6f9c66e744f6d44187809f0f9d851e09b24506c6fab32061f91
```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
