### PR TITLE
feat(argo-workflows): allow additional rules for service account that runs the workflows

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.6.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.45.8
+version: 0.45.9
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Support livenessProbe to server
+      description: Support additional rules for service account that runs workflows

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -136,6 +136,7 @@ Fields to note:
 | workflow.rbac.agentPermissions | bool | `false` | Allows permissions for the Argo Agent. Only required if using http/plugin templates |
 | workflow.rbac.artifactGC | bool | `false` | Allows permissions for the Argo Artifact GC pod. Only required if using artifact gc |
 | workflow.rbac.create | bool | `true` | Adds Role and RoleBinding for the above specified service account to be able to run workflows. A Role and Rolebinding pair is also created for each namespace in controller.workflowNamespaces (see below) |
+| workflow.rbac.rules | list | `[]` | Additional rules for the service account that runs the workflows. |
 | workflow.rbac.serviceAccounts | list | `[]` | Extra service accounts to be added to the RoleBinding |
 | workflow.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | workflow.serviceAccount.create | bool | `false` | Specifies whether a service account should be created |

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -18,9 +18,9 @@ rules:
     verbs:
       - create
       - patch
-    {{- with $.Values.workflow.rbac.rules }}
-      {{- toYaml . | nindent 2 }}
-    {{- end }}
+  {{- with $.Values.workflow.rbac.rules }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- end }}
 
 {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-role.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-role.yaml
@@ -18,6 +18,9 @@ rules:
     verbs:
       - create
       - patch
+    {{- with $.Values.workflow.rbac.rules }}
+      {{- toYaml . | nindent 2 }}
+    {{- end }}
   {{- end }}
 
 {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -77,6 +77,8 @@ workflow:
     serviceAccounts: []
       # - name: my-service-account
       #   namespace: my-namespace
+    # -- Additional rules for the service account that runs the workflows.
+    rules: []
 
 controller:
   image:


### PR DESCRIPTION
- feat(argo-workflows): allow additional rules for the service account that runs the workflows

resolve https://github.com/argoproj/argo-helm/issues/3148

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
