### PR TITLE
feat(argo-rollouts): add support for stepPlugins

### DIFF
--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -873,6 +873,7 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | controller.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | controller.serviceAccount.name | string | `"argocd-application-controller"` | Service account name |
 | controller.statefulsetAnnotations | object | `{}` | Annotations for the application controller StatefulSet |
+| controller.stepPlugins | list | `[]` | Configures 3rd party stepPlugins for controller |
 | controller.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | controller.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the application controller |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -873,7 +873,6 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | controller.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | controller.serviceAccount.name | string | `"argocd-application-controller"` | Service account name |
 | controller.statefulsetAnnotations | object | `{}` | Annotations for the application controller StatefulSet |
-| controller.stepPlugins | list | `[]` | Configures 3rd party stepPlugins for controller |
 | controller.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | controller.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the application controller |

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-rollouts to v1.8.0
+    - kind: added
+      description: Support stepPlugins in the controller configmap

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.39.0
+version: 2.39.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -126,6 +126,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
+| controller.stepPlugins | list | `[]` | Configures 3rd party stepPlugins for controller |
 | controller.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | controller.tolerations | list | `[]` | [Tolerations] for use with node taints |
 | controller.topologySpreadConstraints | list | `[]` | Assign custom [TopologySpreadConstraints] rules to the controller |

--- a/charts/argo-rollouts/templates/controller/configmap.yaml
+++ b/charts/argo-rollouts/templates/controller/configmap.yaml
@@ -11,6 +11,10 @@ data:
   metricProviderPlugins: |-
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.controller.stepPlugins }}
+  stepPlugins: |-
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.controller.trafficRouterPlugins }}
   trafficRouterPlugins: |-
     {{- toYaml . | nindent 4 }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -217,6 +217,12 @@ controller:
     # - name: "argoproj-labs/sample-prometheus" # name of the plugin, it must match the name required by the plugin so that it can find its configuration
     #   location: "file://./my-custom-plugin" # supports http(s):// urls and file://
 
+  # -- Configures 3rd party stepPlugins for controller
+  ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/canary/plugins/
+  stepPlugins: []
+    # - name: "argoproj-labs/step-exec" # name of the plugin, it must match the name required by the plugin so it can find it's configuration
+    #   location: "file://./my-custom-plugin" # supports http(s):// urls and file://
+
   # -- Configures 3rd party traffic router plugins for controller
   ## Ref: https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/plugins/
   trafficRouterPlugins: []


### PR DESCRIPTION
We just built a custom stepPlugin but realized there's no support in the chart to add it into the configmap. Here's a quick fix for that.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
