### PR TITLE
fix(argo-cd): Deprecate logLevel and logFormat values for dex and notifications controller

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.15
+version: 7.8.16
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,13 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade redis-ha
+    - kind: fixed
+      description: Fixed the log level and log format override for components "dexserver" and "notificationscontroller"
+    - kind: deprecated
+      description: Value `notifications.logLevel` is depreacted in favor of `configs.params."notificationscontroller.log.level"`
+    - kind: deprecated
+      description: Value `notifications.logFormat` is depreacted in favor of `configs.params."notificationscontroller.log.format"`
+    - kind: deprecated
+      description: Value `dex.logLevel` is depreacted in favor of `configs.params."dexserver.log.level"`
+    - kind: deprecated
+      description: Value `dex.logFormat` is depreacted in favor of `configs.params."dexserver.log.format"`

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1189,8 +1189,6 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | dex.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | dex.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
 | dex.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
-| dex.logFormat | string | `""` (defaults to global.logging.format) | Dex log format. Either `text` or `json` |
-| dex.logLevel | string | `""` (defaults to global.logging.level) | Dex log level. One of: `debug`, `info`, `warn`, `error` |
 | dex.metrics.enabled | bool | `false` | Deploy metrics service |
 | dex.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | dex.metrics.service.labels | object | `{}` | Metrics service labels |
@@ -1570,8 +1568,6 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | notifications.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
 | notifications.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
-| notifications.logFormat | string | `""` (defaults to global.logging.format) | Notifications controller log format. Either `text` or `json` |
-| notifications.logLevel | string | `""` (defaults to global.logging.level) | Notifications controller log level. One of: `debug`, `info`, `warn`, `error` |
 | notifications.metrics.enabled | bool | `false` | Enables prometheus metrics server |
 | notifications.metrics.port | int | `9001` | Metrics port |
 | notifications.metrics.service.annotations | object | `{}` | Metrics service annotations |

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -1,3 +1,15 @@
+{{- if .Values.notifications.logLevel }}
+DEPRECATED option notifications.logLevel - Use `configs.params."notificationscontroller.log.level"`
+{{- end }}
+{{- if .Values.notifications.logFormat }}
+DEPRECATED option notifications.logFormat - Use `configs.params."notificationscontroller.log.format"`
+{{- end }}
+{{- if .Values.dex.logLevel }}
+DEPRECATED option dex.logLevel - Use `configs.params."dexserver.log.level"`
+{{- end }}
+{{- if .Values.dex.logFormat }}
+DEPRECATED option dex.logFormat - Use `configs.params."dexserver.log.format"`
+{{- end }}
 In order to access the server UI you have the following options:
 
 1. kubectl port-forward service/{{ include "argo-cd.fullname" . }}-server -n {{ include  "argo-cd.namespace" . }} 8080:443

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -238,7 +238,7 @@ NOTE: Configuration keys must be stored as dict because YAML treats dot as separ
 {{- $_ := set $presets "server.dex.server" (include "argo-cd.dex.server" .) -}}
 {{- $_ := set $presets "server.dex.server.strict.tls" .Values.dex.certificateSecret.enabled -}}
 {{- end -}}
-{{- range $component := tuple "applicationsetcontroller" "controller" "server" "reposerver" -}}
+{{- range $component := tuple "applicationsetcontroller" "controller" "server" "reposerver" "notificationscontroller" "dexserver" -}}
 {{- $_ := set $presets (printf "%s.log.format" $component) $.Values.global.logging.format -}}
 {{- $_ := set $presets (printf "%s.log.level" $component) $.Values.global.logging.level -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -66,11 +66,15 @@ spec:
           args:
             - /usr/local/bin/argocd-notifications
             - --metrics-port={{ .Values.notifications.containerPorts.metrics }}
-            - --loglevel={{ default .Values.global.logging.level .Values.notifications.logLevel }}
-            - --logformat={{ default .Values.global.logging.format .Values.notifications.logFormat }}
             - --namespace={{ include "argo-cd.namespace" . }}
             - --argocd-repo-server={{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
             - --secret-name={{ .Values.notifications.secret.name }}
+            {{- with .Values.notifications.logLevel }}
+            - --loglevel={{ . | quote }}
+            {{- end }}
+            {{- with .Values.notifications.logFormat }}
+            - --logformat={{ . | quote }}
+            {{- end }}
             {{- range .Values.notifications.extraArgs }}
             - {{ . | squote }}
             {{- end }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -72,8 +72,12 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.image.imagePullPolicy }}
         command:
         - /shared/argocd-dex
-        - --logformat={{ default .Values.global.logging.format .Values.dex.logFormat }}
-        - --loglevel={{ default .Values.global.logging.level .Values.dex.logLevel }}
+        {{- with .Values.dex.logLevel }}
+        - --loglevel={{ . | quote }}
+        {{- end }}
+        {{- with .Values.dex.logFormat }}
+        - --logformat={{ . | quote }}
+        {{- end }}
         args:
         - rundex
         {{- with .Values.dex.extraArgs }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1252,12 +1252,13 @@ dex:
     #   maxSurge: 25%
     #   maxUnavailable: 25%
 
+  # DEPRECATED - Use configs.params to override
   # -- Dex log format. Either `text` or `json`
   # @default -- `""` (defaults to global.logging.format)
-  logFormat: ""
+  # logFormat: ""
   # -- Dex log level. One of: `debug`, `info`, `warn`, `error`
   # @default -- `""` (defaults to global.logging.level)
-  logLevel: ""
+  # logLevel: ""
 
 ## Redis
 redis:
@@ -3236,12 +3237,13 @@ notifications:
   # @default -- `[]` (defaults to global.imagePullSecrets)
   imagePullSecrets: []
 
+  # DEPRECATED - Use configs.params to override
   # -- Notifications controller log format. Either `text` or `json`
   # @default -- `""` (defaults to global.logging.format)
-  logFormat: ""
+  # logFormat: ""
   # -- Notifications controller log level. One of: `debug`, `info`, `warn`, `error`
   # @default -- `""` (defaults to global.logging.level)
-  logLevel: ""
+  # logLevel: ""
 
   # -- Extra arguments to provide to the notifications controller
   extraArgs: []


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-helm/issues/3010

According to the official documentation page, all ArgoCD components' log level and log format settings are supposed to be configured via `argocd-cmd-params-cm` ConfigMap (managed via `config.params.*` values in this Helm chart):
https://argo-cd.readthedocs.io/en/stable/operator-manual/argocd-cmd-params-cm-yaml/

It was done for all core components in 2 steps earlier:
- Deprecation of old params: https://github.com/argoproj/argo-helm/pull/1267
- Removal of old params: https://github.com/argoproj/argo-helm/pull/2407

However, `dex` and `notificationscontroller` were left behind and their log level & format are still overridden via CLI arguments. That causes a confusion, as described in https://github.com/argoproj/argo-helm/issues/3010

### Changes

This PR streamlines the approach of setting a log level for `dex` and `notificationscontroller` with the same as it's done for all other components.

Backward compatibility is preserved: if the deprecated params `notifications.{logFormat,logLevel}` and `dex.{logFormat,logLevel}` are set, their values are respected and they are passed explicitly via the CLI argument. That takes precedence over the settings in `argocd-cmd-params-cm` ConfigMap.

Otherwise, the settings in `argocd-cmd-params-cm` ConfigMap are now rendered properly, using `"argo-cd.config.params.presets"` Helm helper, as it's done any other component.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
