### PR TITLE
fix(argo-cd): set loglevel and logformat cli args without quotes

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.17
+version: 7.8.18
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Moved to oliver006/redis_exporter to support mutli-arch images
+      description: Remove quotation marks around loglevel and logformat CLI args

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -70,10 +70,10 @@ spec:
             - --argocd-repo-server={{ template "argo-cd.repoServer.fullname" . }}:{{ .Values.repoServer.service.port }}
             - --secret-name={{ .Values.notifications.secret.name }}
             {{- with .Values.notifications.logLevel }}
-            - --loglevel={{ . | quote }}
+            - --loglevel={{ . }}
             {{- end }}
             {{- with .Values.notifications.logFormat }}
-            - --logformat={{ . | quote }}
+            - --logformat={{ . }}
             {{- end }}
             {{- range .Values.notifications.extraArgs }}
             - {{ . | squote }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -73,10 +73,10 @@ spec:
         command:
         - /shared/argocd-dex
         {{- with .Values.dex.logLevel }}
-        - --loglevel={{ . | quote }}
+        - --loglevel={{ . }}
         {{- end }}
         {{- with .Values.dex.logFormat }}
-        - --logformat={{ . | quote }}
+        - --logformat={{ . }}
         {{- end }}
         args:
         - rundex


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

When using the deprecated `notifications.{logLevel,logFormat}` and `dex.{logLevel,logFormat}` values, changes introduced by https://github.com/argoproj/argo-helm/pull/3209 set the CLI arguments to a format like `--loglevel="debug"`, which isn't recognized by ArgoCD and causes a crash, e.g. here for the notifications controller:
```
Error: failed to parse log level: not a valid logrus Level: "\"debug\""
```

We remove `quote` from the CLI arguments templating to fix this.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
