### PR TITLE
fix(argo-cd): Align default value of automountServiceAccountToken as true

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.9
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.23
+version: 7.8.24
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Secret for embedded Redis deployments now always uses the same name and key
+      description: Align default value of automountServiceAccountToken as true

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v2.14.9
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.24
+version: 7.9.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1329,7 +1329,7 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | redis.service.annotations | object | `{}` | Redis service annotations |
 | redis.service.labels | object | `{}` | Additional redis service labels |
 | redis.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
-| redis.serviceAccount.automountServiceAccountToken | bool | `false` | Automount API credentials for the Service Account |
+| redis.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |
 | redis.serviceAccount.create | bool | `false` | Create a service account for the redis pod |
 | redis.serviceAccount.name | string | `""` | Service account name for redis pod |
 | redis.servicePort | int | `6379` | Redis service port |
@@ -1629,7 +1629,7 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | commitServer.affinity | object | `{}` (defaults to global.affinity preset) | Assign custom [affinity] rules |
-| commitServer.automountServiceAccountToken | bool | `false` | Automount API credentials for the Service Account into the pod. |
+| commitServer.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account into the pod. |
 | commitServer.containerSecurityContext | object | See [values.yaml] | commit server container-level security context |
 | commitServer.deploymentAnnotations | object | `{}` | Annotations to be added to commit server Deployment |
 | commitServer.deploymentStrategy | object | `{}` | Deployment strategy to be added to the commit server Deployment |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -278,6 +278,9 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 7.9.0
+In order to align the default value of `automountServiceAccountToken`, we changed `redis.serviceAccount.automountServiceAccountToken` and `commitServer.automountServiceAccountToken` to `true` .
+
 ### 7.0.0
 
 We changed the type of `.Values.configs.clusterCredentials` from `list` to `object`.

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -278,6 +278,9 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 7.9.0
+In order to align the default value of `automountServiceAccountToken`, we changed `redis.serviceAccount.automountServiceAccountToken` and `commitServer.automountServiceAccountToken` to `true` .
+
 ### 7.0.0
 
 We changed the type of `.Values.configs.clusterCredentials` from `list` to `object`.

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1515,7 +1515,7 @@ redis:
     # -- Annotations applied to created service account
     annotations: {}
     # -- Automount API credentials for the Service Account
-    automountServiceAccountToken: false
+    automountServiceAccountToken: true
 
   service:
     # -- Redis service annotations
@@ -3825,7 +3825,7 @@ commitServer:
     labels: {}
 
   # -- Automount API credentials for the Service Account into the pod.
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
 
   serviceAccount:
     # -- Create commit server service account


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/3241 .

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
