### PR TITLE
chore(argo-workflows): Simplify service account name logic in template

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.6.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.45.14
+version: 0.45.15
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Improve argo-workflow controller clusterrole policy
+      description: Simplify service account name logic in template

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -118,7 +118,7 @@ Fields to note:
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |
 | createAggregateRoles | bool | `true` | Create ClusterRoles that extend existing ClusterRoles to interact with Argo Workflows CRDs. |
 | emissary.images | list | `[]` | The command/args for each image on workflow, needed when the command is not specified and the emissary executor is used. |
-| extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
+| extraObjects | list | `[]` | Array of extra kubernetes manifests to deploy |
 | fullnameOverride | string | `nil` | String to fully override "argo-workflows.fullname" template |
 | images.pullPolicy | string | `"Always"` | imagePullPolicy to apply to all containers |
 | images.pullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
@@ -168,7 +168,7 @@ Fields to note:
 | controller.instanceID.enabled | bool | `false` | Configures the controller to filter workflow submissions to only those which have a matching instanceID attribute. |
 | controller.instanceID.explicitID | string | `""` | Use a custom instanceID |
 | controller.instanceID.useReleaseName | bool | `false` | Use ReleaseName as instanceID |
-| controller.kubeConfig | object | `{}` (See [values.yaml]) | Configure when workflow controller runs in a different k8s cluster with the workflow workloads, or needs to communicate with the k8s apiserver using an out-of-cluster kubeconfig secret. |
+| controller.kubeConfig | object | `{}` (See [values.yaml]) | Configure when workflow controller runs in a different kubernetes cluster with the workflow workloads, or needs to communicate with the kubernetes apiserver using an out-of-cluster kubeconfig secret. |
 | controller.links | list | `[]` | Configure Argo Server to show custom [links] |
 | controller.livenessProbe | object | See [values.yaml] | Configure liveness [probe] for the controller |
 | controller.loadBalancerClass | string | `""` | The class of the load balancer implementation |
@@ -206,9 +206,9 @@ Fields to note:
 | controller.podLabels | object | `{}` | Optional labels to add to the controller pods |
 | controller.podSecurityContext | object | `{}` | SecurityContext to set on the controller pods |
 | controller.priorityClassName | string | `""` | Leverage a PriorityClass to ensure your pods survive resource shortages. |
-| controller.rbac.accessAllSecrets | bool | `false` | Allows controller to get, list and watch all k8s secrets. Can only be used if secretWhitelist is empty. |
+| controller.rbac.accessAllSecrets | bool | `false` | Allows controller to get, list and watch all kubernetes secrets. Can only be used if secretWhitelist is empty. |
 | controller.rbac.create | bool | `true` | Adds Role and RoleBinding for the controller. |
-| controller.rbac.secretWhitelist | list | `[]` | Allows controller to get, list, and watch certain k8s secrets |
+| controller.rbac.secretWhitelist | list | `[]` | Allows controller to get, list, and watch certain kubernetes secrets |
 | controller.rbac.writeConfigMaps | bool | `false` | Allows controller to create and update ConfigMaps. Enables memoization feature |
 | controller.replicas | int | `1` | The number of controller pods to run |
 | controller.resourceRateLimit | object | `{}` | Globally limits the rate at which pods are created. This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of parallel nodes. |

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -112,7 +112,7 @@ Create the name of the server service account to use
 {{- if .Values.server.serviceAccount.create -}}
     {{ default (include "argo-workflows.server.fullname" .) .Values.server.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.server.serviceAccount.name }}
+    {{- "default" -}}
 {{- end -}}
 {{- end -}}
 
@@ -123,7 +123,7 @@ Create the name of the controller service account to use
 {{- if .Values.controller.serviceAccount.create -}}
     {{ default (include "argo-workflows.controller.fullname" .) .Values.controller.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.controller.serviceAccount.name }}
+    {{- "default" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -100,9 +100,9 @@ controller:
   rbac:
     # -- Adds Role and RoleBinding for the controller.
     create: true
-    # -- Allows controller to get, list, and watch certain k8s secrets
+    # -- Allows controller to get, list, and watch certain kubernetes secrets
     secretWhitelist: []
-    # -- Allows controller to get, list and watch all k8s secrets. Can only be used if secretWhitelist is empty.
+    # -- Allows controller to get, list and watch all kubernetes secrets. Can only be used if secretWhitelist is empty.
     accessAllSecrets: false
     # -- Allows controller to create and update ConfigMaps. Enables memoization feature
     writeConfigMaps: false
@@ -400,18 +400,18 @@ controller:
 
   nodeEvents:
     # -- Enable to emit events on node completion.
-    ## This can take up a lot of space in k8s (typically etcd) resulting in errors when trying to create new events:
+    ## This can take up a lot of space in kubernetes (typically etcd) resulting in errors when trying to create new events:
     ## "Unable to create audit event: etcdserver: mvcc: database space exceeded"
     enabled: true
 
   workflowEvents:
     # -- Enable to emit events on workflow status changes.
-    ## This can take up a lot of space in k8s (typically etcd), resulting in errors when trying to create new events:
+    ## This can take up a lot of space in kubernetes (typically etcd), resulting in errors when trying to create new events:
     ## "Unable to create audit event: etcdserver: mvcc: database space exceeded"
     enabled: true
 
-  # -- Configure when workflow controller runs in a different k8s cluster with the workflow workloads,
-  # or needs to communicate with the k8s apiserver using an out-of-cluster kubeconfig secret.
+  # -- Configure when workflow controller runs in a different kubernetes cluster with the workflow workloads,
+  # or needs to communicate with the kubernetes apiserver using an out-of-cluster kubeconfig secret.
   # @default -- `{}` (See [values.yaml])
   kubeConfig: {}
     # # name of the kubeconfig secret, may not be empty when kubeConfig specified
@@ -799,7 +799,7 @@ server:
     # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
     successThreshold: 1
 
-# -- Array of extra K8s manifests to deploy
+# -- Array of extra kubernetes manifests to deploy
 extraObjects: []
   # - apiVersion: secrets-store.csi.x-k8s.io/v1
   #   kind: SecretProviderClass
@@ -862,8 +862,8 @@ artifactRepository:
     # bucket: <project>-argo
     # keyFormat: "{{ \"{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}\" }}"
     # # serviceAccountKeySecret is a secret selector.
-    # # It references the k8s secret named 'my-gcs-credentials'.
-    # # This secret is expected to have have the key 'serviceAccountKey',
+    # # It references the kubernetes secret named 'my-gcs-credentials'.
+    # # This secret is expected to have the key 'serviceAccountKey',
     # # containing the base64 encoded credentials
     # # to the bucket.
     # #
@@ -879,7 +879,7 @@ artifactRepository:
     # container: my-container-name
     # blobNameFormat: path/in/container
     # # accountKeySecret is a secret selector.
-    # # It references the k8s secret named 'my-azure-storage-credentials'.
+    # # It references the kubernetes secret named 'my-azure-storage-credentials'.
     # # This secret is expected to have have the key 'account-access-key',
     # # containing the base64 encoded credentials to the storage account.
     # # If a managed identity has been assigned to the machines running the
@@ -935,8 +935,8 @@ artifactRepositoryRef: {}
   #        endpoint: http://oss-cn-zhangjiakou-internal.aliyuncs.com
   #        bucket: $mybucket
   #        # accessKeySecret and secretKeySecret are secret selectors.
-  #        # It references the k8s secret named 'bucket-workflow-artifect-credentials'.
-  #        # This secret is expected to have have the keys 'accessKey'
+  #        # It references the kubernetes secret named 'bucket-workflow-artifect-credentials'.
+  #        # This secret is expected to have the keys 'accessKey'
   #        # and 'secretKey', containing the base64 encoded credentials
   #        # to the bucket.
   #        accessKeySecret:


### PR DESCRIPTION
When `controller.serviceAccount.create` is set to false and `controller.serviceAccount.name` is set to 'test', the workflow-controller deployment will use the serviceAccountName 'test', but the serviceaccount 'test' does not exist. This should always be the default when `controller.serviceAccount.create` is false.

https://github.com/argoproj/argo-helm/blob/main/charts/argo-workflows/templates/controller/workflow-controller-sa.yaml#L1

```yaml
# values.yaml
controller:
  serviceAccount:
    create: false
    name: "test"
```    

![image](https://github.com/user-attachments/assets/8864fb39-0c24-4c03-a36c-ffe1367a56e9)

```
kubectl get deploy argo-workflows-controller -o jsonpath='{.spec.template.spec.serviceAccountName}'
kubectl get deploy argo-workflows-server -o jsonpath='{.spec.template.spec.serviceAccountName}'
```

- When `.Values.controller.serviceAccount.create` is true:
  - Use `.Values.controller.serviceAccount.name` if set
  - Fallback to `argo-workflows.controller.fullname` if not set
- When false, always return "default" (ignore user-provided name)

In addition, I changed the name in the values to k8s -> kubernetes

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
