### PR TITLE
fix(argo-cd): Use correct Secret name for optional (external-)Redis auth

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.0.0
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.0.0
+version: 8.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.0.0
+    - kind: fixed
+      description: Use correct Secret name for optional (external-)Redis authentication

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -280,12 +280,13 @@ ipFamilies: {{ toYaml . | nindent 4 }}
 secretKeyRef of env variable REDIS_USERNAME
 */}}
 {{- define "argo-cd.redisUsernameSecretRef" -}}
-    {{- if and .Values.externalRedis.host -}}
-name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
+    {{- if .Values.externalRedis.host -}}
+name: {{ default "argocd-redis" .Values.externalRedis.existingSecret }}
 key: redis-username
-optional: true
+optional: {{ if .Values.externalRedis.username }}false{{ else }}true{{ end }}
+
     {{- else -}}
-name: {{ include "argo-cd.redis.fullname" . }}
+name: "argocd-redis"
 key: redis-username
 optional: true
     {{- end -}}


### PR DESCRIPTION
Fixes #3293 

Appears in:
- https://github.com/argoproj/argo-helm/pull/3238#issuecomment-2862002024

Xref:
- https://github.com/argoproj/argo-helm/issues/2705

Can you please give feedback @varkey since you raised this regression?
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
