### PR TITLE
fix(argo-cd): add allowed audiences parameter to values.yaml

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -28,5 +28,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added commented allowedAudiences parameter to values.yaml
-    - kind: changed
-      description: Bump argo-cd to v3.0.0

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -30,3 +30,5 @@ annotations:
       description: Added commented allowedAudiences parameter to values.yaml
     - kind: added
       description: Added comments from upstream docs to align better
+    - kind: added
+      description: Added missing keys from upstream docs

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added commented allowedAudiences parameter to values.yaml
+    - kind: added
+      description: Added comments from upstream docs to align better

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.0.0
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.0.0
+version: 8.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: added
+      description: Added commented allowedAudiences parameter to values.yaml
     - kind: changed
       description: Bump argo-cd to v3.0.0

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,9 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Added commented allowedAudiences parameter to values.yaml
-    - kind: added
-      description: Added comments from upstream docs to align better
-    - kind: added
-      description: Added missing keys from upstream docs
+    - kind: changed
+      description: Added more example code regarding `oidc.config` from upstream docs to align better

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -225,6 +225,11 @@ configs:
     #     -----BEGIN CERTIFICATE-----
     #     ... encoded certificate data here ...
     #     -----END CERTIFICATE-----
+
+    # Optional list of allowed aud claims. If omitted or empty, defaults to the clientID value above (and the
+    # cliClientID, if that is also specified). If you specify a list and want the clientID to be allowed, you must
+    # explicitly include it in the list.
+    # Token verification will pass if any of the token's audiences matches any of the audiences in this list.
     #   allowedAudiences:
     #     - aaaabbbbccccddddeee
     #     - qqqqwwwweeeerrrrttt

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -225,6 +225,9 @@ configs:
     #     -----BEGIN CERTIFICATE-----
     #     ... encoded certificate data here ...
     #     -----END CERTIFICATE-----
+    #   allowedAudiences:
+    #     - aaaabbbbccccddddeee
+    #     - qqqqwwwweeeerrrrttt
     #   requestedIDTokenClaims:
     #     groups:
     #       essential: true

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -219,8 +219,15 @@ configs:
     # oidc.config: |
     #   name: AzureAD
     #   issuer: https://login.microsoftonline.com/TENANT_ID/v2.0
-    #   clientID: CLIENT_ID
+    #   clientID: aaaabbbbccccddddeee
     #   clientSecret: $oidc.azuread.clientSecret
+
+    # Some OIDC providers require a separate clientID for different callback URLs.
+    # For example, if configuring Argo CD with self-hosted Dex, you will need a separate client ID
+    # for the 'localhost' (CLI) client to Dex. This field is optional. If omitted, the CLI will
+    # use the same clientID as the Argo CD server
+    #   cliClientID: vvvvwwwwxxxxyyyyzzzz
+
     #   rootCA: |
     #     -----BEGIN CERTIFICATE-----
     #     ... encoded certificate data here ...
@@ -233,13 +240,23 @@ configs:
     #   allowedAudiences:
     #     - aaaabbbbccccddddeee
     #     - qqqqwwwweeeerrrrttt
+
+    # Optional set of OIDC claims to request on the ID token.
     #   requestedIDTokenClaims:
     #     groups:
     #       essential: true
+
+    # Optional set of OIDC scopes to request. If omitted, defaults to: ["openid", "profile", "email", "groups"]
     #   requestedScopes:
     #     - openid
     #     - profile
     #     - email
+
+    # PKCE authentication flow processes authorization flow from browser only - default false
+    # uses the clientID
+    # make sure the Identity Provider (IdP) is public and doesn't need clientSecret
+    # make sure the Identity Provider (IdP) has this redirect URI registered: https://argocd.example.com/pkce/verify
+    #   enablePKCEAuthentication: true
 
     # Extension Configuration
     ## Ref: https://argo-cd.readthedocs.io/en/latest/developer-guide/extensions/proxy-extensions/


### PR DESCRIPTION
I spent a bunch of time trying to figure out why authentication was failed because I didn't look at the argocd docs (I was looking at helm).
This should help improve visibility into how to fix the issue related to `Failed to verify token: token verification failed for all audiences` 

I should note that I had to add the cliClientID and clientID to the allowedAudiences because it was giving me the above error despite the docs saying that it should allow the clientIDs by default (if allowedAudiences isn't specified) this possibly could be a bug, I'm happy to open an issue for that if wanted.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
