### PR TITLE
feat(argo-cd): use dual-stack AWS ECR registry for redis

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,7 +9,7 @@ jobs:
   linter-artifacthub:
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/artifacthub/ah:v1.14.0
+      image: ecr-public.aws.com/artifacthub/ah:v1.14.0
       options: --user 1001
     steps:
       - name: Checkout

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.0.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.0.11
+version: 8.0.12
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-cd to v3.0.4
+      description: use dual-stack AWS ECR registry for redis

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1406,6 +1406,7 @@ The main options are listed here:
 | redis-ha.haproxy.containerSecurityContext | object | See [values.yaml] | HAProxy container-level security context |
 | redis-ha.haproxy.enabled | bool | `true` | Enabled HAProxy LoadBalancing/Proxy |
 | redis-ha.haproxy.hardAntiAffinity | bool | `true` | Whether the haproxy pods should be forced to run on separate nodes. |
+| redis-ha.haproxy.image.repository | string | `"ecr-public.aws.com/docker/library/haproxy"` | HAProxy Image Repository |
 | redis-ha.haproxy.labels | object | `{"app.kubernetes.io/name":"argocd-redis-ha-haproxy"}` | Custom labels for the haproxy pod. This is relevant for Argo CD CLI. |
 | redis-ha.haproxy.metrics.enabled | bool | `true` | HAProxy enable prometheus metric scraping |
 | redis-ha.haproxy.tolerations | list | `[]` | [Tolerations] for use with node taints for haproxy pods. |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1324,7 +1324,7 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | redis.extraArgs | list | `[]` | Additional command line arguments to pass to redis-server |
 | redis.extraContainers | list | `[]` | Additional containers to be added to the redis pod |
 | redis.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Redis image pull policy |
-| redis.image.repository | string | `"public.ecr.aws/docker/library/redis"` | Redis repository |
+| redis.image.repository | string | `"ecr-public.aws.com/docker/library/redis"` | Redis repository |
 | redis.image.tag | string | `"7.2.8-alpine"` | Redis tag |
 | redis.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | redis.initContainers | list | `[]` | Init containers to add to the redis pod |
@@ -1410,7 +1410,7 @@ The main options are listed here:
 | redis-ha.haproxy.metrics.enabled | bool | `true` | HAProxy enable prometheus metric scraping |
 | redis-ha.haproxy.tolerations | list | `[]` | [Tolerations] for use with node taints for haproxy pods. |
 | redis-ha.hardAntiAffinity | bool | `true` | Whether the Redis server pods should be forced to run on separate nodes. |
-| redis-ha.image.repository | string | `"public.ecr.aws/docker/library/redis"` | Redis repository |
+| redis-ha.image.repository | string | `"ecr-public.aws.com/docker/library/redis"` | Redis repository |
 | redis-ha.image.tag | string | `"7.2.8-alpine"` | Redis tag |
 | redis-ha.persistentVolume.enabled | bool | `false` | Configures persistence on Redis nodes |
 | redis-ha.redis.config | object | See [values.yaml] | Any valid redis config options in this section will be applied to each server (see `redis-ha` chart) |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1735,6 +1735,9 @@ redis-ha:
     # --  Custom labels for the haproxy pod. This is relevant for Argo CD CLI.
     labels:
       app.kubernetes.io/name: argocd-redis-ha-haproxy
+    image:
+      # -- HAProxy Image Repository
+      repository: ecr-public.aws.com/docker/library/haproxy
     metrics:
       # -- HAProxy enable prometheus metric scraping
       enabled: true

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1416,7 +1416,7 @@ redis:
   ## Redis image
   image:
     # -- Redis repository
-    repository: public.ecr.aws/docker/library/redis
+    repository: ecr-public.aws.com/docker/library/redis
     # -- Redis tag
     ## Do not upgrade to >= 7.4.0, otherwise you are no longer using an open source version of Redis
     tag: 7.2.8-alpine
@@ -1703,7 +1703,7 @@ redis-ha:
   ## Redis image
   image:
     # -- Redis repository
-    repository: public.ecr.aws/docker/library/redis
+    repository: ecr-public.aws.com/docker/library/redis
     # -- Redis tag
     ## Do not upgrade to >= 7.4.0, otherwise you are no longer using an open source version of Redis
     tag: 7.2.8-alpine

--- a/renovate.json
+++ b/renovate.json
@@ -99,7 +99,7 @@
     },
     {
       "matchPackageNames": [
-        "public.ecr.aws/docker/library/redis"
+        "ecr-public.aws.com/docker/library/redis"
       ],
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Improve ipv6 readiness, for https://github.com/argoproj/argo-helm/issues/3326

This shows the same image is available on both endpoints:
```
$ podman pull public.ecr.aws/docker/library/redis
Trying to pull public.ecr.aws/docker/library/redis:latest...
Getting image source signatures
Copying blob 61320b01ae5e done   | 
Copying blob 4f4fb700ef54 done   | 
Copying blob b8f8315b617a done   | 
Copying blob f8f9e5369fdd done   | 
Copying blob eb61abf5b105 done   | 
Copying blob 03bc4ee78aa8 done   | 
Copying blob 93cd3c5153ab done   | 
Copying config 90b270fb6d done   | 
Writing manifest to image destination
90b270fb6df331ff456014744f4fd3de812584386de75e762dc73add32533311


$ podman pull ecr-public.aws.com/docker/library/redis
Trying to pull ecr-public.aws.com/docker/library/redis:latest...
Getting image source signatures
Copying blob 4f4fb700ef54 skipped: already exists  
Copying blob f8f9e5369fdd skipped: already exists  
Copying blob b8f8315b617a skipped: already exists  
Copying blob eb61abf5b105 skipped: already exists  
Copying blob 03bc4ee78aa8 skipped: already exists  
Copying blob 61320b01ae5e skipped: already exists  
Copying blob 93cd3c5153ab skipped: already exists  
Copying config 90b270fb6d done   | 
Writing manifest to image destination
90b270fb6df331ff456014744f4fd3de812584386de75e762dc73add32533311
```


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
