### PR TITLE
fix(argo-rollouts,argo-workflows): Replace "float64" with "int" to fix Helm 3.18 incompatibility

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.2
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.39.5
+version: 2.39.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: argo-rollouts will re-deploy if changes are made to the argo-rollouts configmap.
+      description: Fix installation process with Helm 3.18.

--- a/charts/argo-rollouts/templates/dashboard/ingress.yaml
+++ b/charts/argo-rollouts/templates/dashboard/ingress.yaml
@@ -45,7 +45,7 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  {{- if kindIs "float64" $servicePort }}
+                  {{- if kindIs "int" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
@@ -72,7 +72,7 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  {{- if kindIs "float64" $servicePort }}
+                  {{- if kindIs "int" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.6.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.45.15
+version: 0.45.16
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Restart server when configMap is updated
+      description: Fix installation process with Helm 3.18.

--- a/charts/argo-workflows/templates/server/server-ingress.yaml
+++ b/charts/argo-workflows/templates/server/server-ingress.yaml
@@ -45,7 +45,7 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  {{- if kindIs "float64" $servicePort }}
+                  {{- if kindIs "int" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
@@ -72,7 +72,7 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  {{- if kindIs "float64" $servicePort }}
+                  {{- if kindIs "int" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Following this issue: https://github.com/argoproj/argo-helm/issues/3318 
The installation process on helm 3.18 failes due to wrong type testing

Replace "float64" with "int" to fix Helm 3.18 incompatibility

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
