### PR TITLE
chore(argo-cd): Update comment about Redis username if existingSecret is set

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.0.5
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.0.14
+version: 8.0.15
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Added hydrator.enabled parameter to support the hydrator feature
+    - kind: changed
+      description: Update comment about externalRedis.username if externalRedis.existingSecret is set

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1436,7 +1436,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis (must contain key `redis-password`) and Sentinel credentials. When it's set, the `externalRedis.password` parameter is ignored |
+| externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis (must contain key `redis-password`. And should contain `redis-username` if username is not `default`) and Sentinel credentials. When it's set, the `externalRedis.username` and `externalRedis.password` parameters are ignored |
 | externalRedis.host | string | `""` | External Redis server host |
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1804,8 +1804,8 @@ externalRedis:
   password: ""
   # -- External Redis server port
   port: 6379
-  # -- The name of an existing secret with Redis (must contain key `redis-password`) and Sentinel credentials.
-  # When it's set, the `externalRedis.password` parameter is ignored
+  # -- The name of an existing secret with Redis (must contain key `redis-password`. And should contain `redis-username` if username is not `default`) and Sentinel credentials.
+  # When it's set, the `externalRedis.username` and `externalRedis.password` parameters are ignored
   existingSecret: ""
   # -- External Redis Secret annotations
   secretAnnotations: {}


### PR DESCRIPTION
## PR Description

This PR updates the comment for `externalRedis.username` to clarify its behavior when `externalRedis.existingSecret` is set. Specifically, when `externalRedis.existingSecret` is configured, both `externalRedis.username` and `externalRedis.password` are ignored. This change aims to prevent misconfiguration, such as omitting the `redis-username` key in the specified `existingSecret` when the Redis username is not `default`.

**Behavior Examples:**
1. When `externalRedis.existingSecret` is set:
```
helm template my-argo-cd oci://ghcr.io/argoproj/argo-helm/argo-cd --version 8.0.14 \
  --set externalRedis.host="redis.example.com" \
  --set externalRedis.username="myuser" \
  --set externalRedis.existingSecret="redis-credentials" | grep REDIS_USERNAME -A 11
```

Output:
```
- name: REDIS_USERNAME
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: redis-username
      optional: false
- name: REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      name: redis-credentials
      key: redis-password
      optional: false
```

2. When `externalRedis.existingSecret` is not set:
```
helm template my-argo-cd oci://ghcr.io/argoproj/argo-helm/argo-cd --version 8.0.14 \
  --set externalRedis.host="redis.example.com" \
  --set externalRedis.username="myuser" | grep REDIS_USERNAME -A 11
```

Output:
```
- name: REDIS_USERNAME
  valueFrom:
    secretKeyRef:
      name: argocd-redis
      key: redis-username
      optional: false
- name: REDIS_PASSWORD
  valueFrom:
    secretKeyRef:
      name: argocd-redis
      key: redis-password
      optional: true
```

Additionally, the `argocd-redis` secret will include the `redis-username` value:
```
helm template my-argo-cd oci://ghcr.io/argoproj/argo-helm/argo-cd --version 8.0.14 \
  --set externalRedis.host="redis.example.com" \
  --set externalRedis.username="myuser" | yq eval-all 'select(.kind == "Secret" and .metadata.name == "argocd-redis")' | yq '.data.redis-username' | base64 -d
```
Output:
```
myuser
```
This clarification ensures users understand the behavior of `externalRedis.existingSecret` and avoid potential misconfigurations.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
