### PR TITLE
fix(argo-rollouts): Replace "float64" with "int" to fix Helm 3.18 incompatibility

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.0
+version: 2.40.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Support ability to set .Values.namespaceOverride
+    - kind: fixed
+      description: compatibility with Helm 3.18+

--- a/charts/argo-rollouts/templates/dashboard/ingress.yaml
+++ b/charts/argo-rollouts/templates/dashboard/ingress.yaml
@@ -45,7 +45,7 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  {{- if kindIs "float64" $servicePort }}
+                  {{- if kindIs "int" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}
@@ -72,7 +72,7 @@ spec:
               service:
                 name: {{ $serviceName }}
                 port:
-                  {{- if kindIs "float64" $servicePort }}
+                  {{- if kindIs "int" $servicePort }}
                   number: {{ $servicePort }}
                   {{- else }}
                   name: {{ $servicePort }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Note: this was originally done in #3338 but that has gone stale. I tried directly editing that and failed. Credit for this work needs to be shared with @NicolasDierick

Closes #3318

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
