### PR TITLE
docs(argo-cd): update NOTES.txt for conditional rootpath

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.0.12
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.2.4
+version: 8.2.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix inheritance of 'global.logging' values for the commit server component.
+    - kind: added
+      description: Add condition for rootpath in NOTES.txt

--- a/charts/argo-cd/templates/NOTES.txt
+++ b/charts/argo-cd/templates/NOTES.txt
@@ -12,10 +12,13 @@ DEPRECATED option dex.logFormat - Use `configs.params."dexserver.log.format"`
 {{- end }}
 In order to access the server UI you have the following options:
 
+{{ $rootpath := default "" (index .Values "configs" "params" "server.rootpath") -}}
 1. kubectl port-forward service/{{ include "argo-cd.fullname" . }}-server -n {{ include  "argo-cd.namespace" . }} 8080:443
-
+{{ if $rootpath }}
+    and then open the browser on http://localhost:8080/{{ $rootpath }} and accept the certificate
+{{ else }}
     and then open the browser on http://localhost:8080 and accept the certificate
-
+{{ end }}
 2. enable ingress in the values file `server.ingress.enabled` and either
       - Add the annotation for ssl passthrough: https://argo-cd.readthedocs.io/en/stable/operator-manual/ingress/#option-1-ssl-passthrough
       - Set the `configs.params."server.insecure"` in the values file and terminate SSL at your ingress: https://argo-cd.readthedocs.io/en/stable/operator-manual/ingress/#option-2-multiple-ingress-objects-and-hosts


### PR DESCRIPTION
Fixes #3406

### Summary
This PR updates the NOTES.txt template in the Argo CD Helm chart to properly reflect the configs.params.server.rootpath value (if set).
When server.rootpath is configured, the access URL shown after port-forwarding now correctly includes the root path.

### why 
While testing with a custom server.rootpath (e.g., argocd), the output of helm install or helm upgrade still displayed the default URL:
`http://localhost:8080`
This could mislead users and result in confusion, especially when reverse proxies or base path routing are involved.

### How
- Conditionally renders the access URL in `NOTES.txt`
- If configs.params.server.rootpath is not defined or empty, the default behavior is unchanged.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
