### PR TITLE
fix(argo-rollouts): Correct metricsPort arg

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.3
+version: 2.40.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: support dnsConfig for controller and dashboard pods
+    - kind: fixed
+      description: Correct metricsPort arg

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       - image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
         args:
         - --healthzPort={{ .Values.controller.containerPorts.healthz }}
-        - --metricsport={{ .Values.controller.containerPorts.metrics }}
+        - --metricsPort={{ .Values.controller.containerPorts.metrics }}
         - "--loglevel={{ .Values.controller.logging.level }}"
         - "--logformat={{ .Values.controller.logging.format }}"
         - "--kloglevel={{ .Values.controller.logging.kloglevel }}"


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-helm/issues/3418
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
