### PR TITLE
feat(argo-workflows): add configuration for database synchronization

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.7.1
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.45.22
+version: 0.45.23
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v3.7.1
+    - kind: added
+      description: configuration for database synchronization

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -227,6 +227,7 @@ Fields to note:
 | controller.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | controller.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | controller.serviceType | string | `"ClusterIP"` | Service type of the controller Service |
+| controller.synchronization | object | `{}` | enable Synchronization to use a database.  Postgres and MySQL (>= 5.7.8) are available. |
 | controller.telemetryConfig.enabled | bool | `false` | Enables prometheus telemetry server |
 | controller.telemetryConfig.ignoreErrors | bool | `false` | Flag that instructs prometheus to ignore metric emission errors. |
 | controller.telemetryConfig.interval | string | `"30s"` | Frequency at which prometheus scrapes telemetry data |

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -180,6 +180,9 @@ data:
       filterGroupsRegex: {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
+    {{- if .Values.controller.synchronization }}
+    synchronization:
+{{ toYaml .Values.controller.synchronization | indent 6 }}{{- end }}
     {{- with .Values.controller.workflowRestrictions }}
     workflowRestrictions: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -180,9 +180,9 @@ data:
       filterGroupsRegex: {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
-    {{- if .Values.controller.synchronization }}
-    synchronization:
-{{ toYaml .Values.controller.synchronization | indent 6 }}{{- end }}
+    {{- with .Values.controller.synchronization }}
+    synchronization: {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .Values.controller.workflowRestrictions }}
     workflowRestrictions: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -437,6 +437,41 @@ controller:
   # @default -- `5s` (Argo Workflows default)
   podGCDeleteDelayDuration: ""
 
+  # -- enable Synchronization to use a database.  Postgres and MySQL (>= 5.7.8) are available.
+  ## Ref: https://argo-workflows.readthedocs.io/en/latest/workflow-controller-configmap/#syncconfig
+  synchronization: {}
+  # controllerName: argo-workflows
+  # connectionPool:
+  #   maxIdleConns: 100
+  #   maxOpenConns: 0
+  # postgresql:
+  #   host: localhost
+  #   port: 5432
+  #   database: postgres
+  #   tableName: argo_workflows
+  #   # the database secrets must be in the same namespace of the controller
+  #   userNameSecret:
+  #     name: argo-postgres-config
+  #     key: username
+  #   passwordSecret:
+  #     name: argo-postgres-config
+  #     key: password
+  #   ssl: true
+  #   # sslMode must be one of: disable, require, verify-ca, verify-full
+  #   # you can find more information about those ssl options here: https://godoc.org/github.com/lib/pq
+  #   sslMode: require
+  # mysql:
+  #   host: localhost
+  #   port: 3306
+  #   database: argo
+  #   tableName: argo_workflows
+  #   userNameSecret:
+  #     name: argo-mysql-config
+  #     key: username
+  #   passwordSecret:
+  #     name: argo-mysql-config
+  #     key: password
+
 # mainContainer adds default config for main container that could be overriden in workflows template
 mainContainer:
   # -- imagePullPolicy to apply to Workflow main container. Defaults to `.Values.images.pullPolicy`.


### PR DESCRIPTION
Adding configuration options to enable the configuration of database synchronization to the argo-workflows helm chart. I took inspiration from how the `persistence` section is configured.

closes: https://github.com/argoproj/argo-helm/issues/3448

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
