### PR TITLE
chore: replace bitnami redis image with bitnamilegacy redis image

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           kubectl create namespace redis
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm install redis bitnami/redis --wait --namespace redis --set auth.password=argocd --set architecture=standalone
+          helm install redis bitnami/redis --wait --namespace redis --set auth.password=argocd --set architecture=standalone --set global.image.repository=bitnamilegacy/redis
 
       - name: Run chart-testing (install)
         run: ct install --config ./.github/configs/ct-install.yaml


### PR DESCRIPTION
Closes #3422 
This is just a temporary fix so that we don't hit rate limits on Aug 28th. Bitnami legacy images will not be getting new stable builds so we need to think of an alternative to using them.
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
