### PR TITLE
chore(argo-rollouts): use named port for service

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: support dnsConfig for controller and dashboard pods
+    - kind: changed
+      description: use named port for service

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.3
+version: 2.40.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.4
+version: 2.40.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:

--- a/charts/argo-rollouts/templates/dashboard/service.yaml
+++ b/charts/argo-rollouts/templates/dashboard/service.yaml
@@ -37,7 +37,7 @@ spec:
   - name: {{ .Values.dashboard.service.portName }}
     protocol: TCP
     port: {{ .Values.dashboard.service.port }}
-    targetPort: {{ .Values.dashboard.service.targetPort }}
+    targetPort: dashboard
     {{- if and (eq .Values.dashboard.service.type "NodePort") .Values.dashboard.service.nodePort }}
     nodePort: {{ .Values.dashboard.service.nodePort }}
     {{- end }}


### PR DESCRIPTION
Signed-off-by: drfaust92 <ilia.lazebnik@gmail.com>

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
