### PR TITLE
 feat(argo-rollouts): add automountServiceAccountToken for controller and dashboard

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.3
+version: 2.40.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: added
+      description: add automountServiceAccountToken toggles for controller and dashboard pods and service accounts
     - kind: added
       description: support dnsConfig for controller and dashboard pods

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -86,6 +86,7 @@ For full list of changes please check ArtifactHub [changelog].
 |-----|------|---------|-------------|
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context to set on container level |
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
+| controller.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account into the controller pod. |
 | controller.component | string | `"rollouts-controller"` | Value of label `app.kubernetes.io/component` |
 | controller.containerPorts.healthz | int | `8080` | Healthz container port |
 | controller.containerPorts.metrics | int | `8090` | Metrics container port |
@@ -139,6 +140,7 @@ For full list of changes please check ArtifactHub [changelog].
 | podLabels | object | `{}` | Labels to be added to the Rollout pods |
 | podSecurityContext | object | `{"runAsNonRoot":true}` | Security Context to set on pod level |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the controller Service Account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceAnnotations | object | `{}` | Annotations to be added to the Rollout service |
@@ -148,6 +150,7 @@ For full list of changes please check ArtifactHub [changelog].
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | dashboard.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
+| dashboard.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account into the dashboard pod. |
 | dashboard.component | string | `"rollouts-dashboard"` | Value of label `app.kubernetes.io/component` |
 | dashboard.containerSecurityContext | object | `{}` | Security Context to set on container level |
 | dashboard.createClusterRole | bool | `true` | flag to enable creation of dashbord cluster role (requires cluster RBAC) |
@@ -196,6 +199,7 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.service.targetPort | int | `3100` | Service target port |
 | dashboard.service.type | string | `"ClusterIP"` | Sets the type of the Service |
 | dashboard.serviceAccount.annotations | object | `{}` | Annotations to add to the dashboard service account |
+| dashboard.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the dashboard Service Account |
 | dashboard.serviceAccount.create | bool | `true` | Specifies whether a dashboard service account should be created |
 | dashboard.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | dashboard.tolerations | list | `[]` | [Tolerations] for use with node taints |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
       containers:
       - image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
         args:

--- a/charts/argo-rollouts/templates/controller/serviceaccount.yaml
+++ b/charts/argo-rollouts/templates/controller/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "argo-rollouts.serviceAccountName" . }}
   namespace: {{ include "argo-rollouts.namespace" . | quote }}

--- a/charts/argo-rollouts/templates/dashboard/deployment.yaml
+++ b/charts/argo-rollouts/templates/dashboard/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "argo-rollouts.serviceAccountName" . }}-dashboard
+      automountServiceAccountToken: {{ .Values.dashboard.automountServiceAccountToken }}
       containers:
       - image: "{{ .Values.dashboard.image.registry }}/{{ .Values.dashboard.image.repository }}:{{ default .Chart.AppVersion .Values.dashboard.image.tag }}"
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}

--- a/charts/argo-rollouts/templates/dashboard/serviceaccount.yaml
+++ b/charts/argo-rollouts/templates/dashboard/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.dashboard.enabled .Values.dashboard.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.dashboard.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "argo-rollouts.serviceAccountName" . }}-dashboard
   namespace: {{ include "argo-rollouts.namespace" . | quote }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -65,6 +65,8 @@ global:
 controller:
   # -- Value of label `app.kubernetes.io/component`
   component: rollouts-controller
+  # -- Automount API credentials for the Service Account into the controller pod.
+  automountServiceAccountToken: true
   # -- Annotations to be added to the controller deployment
   deploymentAnnotations: {}
   # -- Labels to be added to the controller deployment
@@ -253,6 +255,8 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # -- Automount API credentials for the controller Service Account
+  automountServiceAccountToken: true
 
 # -- Annotations to be added to all CRDs
 crdAnnotations: {}
@@ -315,6 +319,8 @@ providerRBAC:
 dashboard:
   # -- Deploy dashboard server
   enabled: false
+  # -- Automount API credentials for the Service Account into the dashboard pod.
+  automountServiceAccountToken: true
   # -- Set cluster role to readonly
   readonly: false
   # -- Value of label `app.kubernetes.io/component`
@@ -408,6 +414,8 @@ dashboard:
     # -- The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+    # -- Automount API credentials for the dashboard Service Account
+    automountServiceAccountToken: true
 
   ## Configure Pod Disruption Budget for the dashboard
   pdb:


### PR DESCRIPTION

Add enforcements to disable automatic mounting of a service account token for argo-rollouts

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
