### PR TITLE
fix:allow argo rollout controller service monitor to use tlsconfig

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.3
+version: 2.40.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: support dnsConfig for controller and dashboard pods
+      description: support tlsConfig configuration for controller serviceMonitor endpoint

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -116,6 +116,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.metrics.serviceMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
 | controller.metrics.serviceMonitor.namespace | string | `""` | Namespace to be used for the ServiceMonitor |
 | controller.metrics.serviceMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping |
+| controller.metrics.serviceMonitor.tlsConfig | object | `{}` | TLS configuration for the ServiceMonitor. When set, scheme will be https |
 | controller.nodeSelector | object | `{}` | [Node selector] |
 | controller.pdb.annotations | object | `{}` | Annotations to be added to controller [Pod Disruption Budget] |
 | controller.pdb.enabled | bool | `false` | Deploy a [Pod Disruption Budget] for the controller |

--- a/charts/argo-rollouts/templates/controller/servicemonitor.yaml
+++ b/charts/argo-rollouts/templates/controller/servicemonitor.yaml
@@ -17,6 +17,11 @@ metadata:
 spec:
   endpoints:
   - port: {{ .Values.controller.metrics.service.portName }}
+    {{- if .Values.controller.metrics.serviceMonitor.tlsConfig }}
+    scheme: https
+    tlsConfig:
+      {{- toYaml .Values.controller.metrics.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     {{- with .Values.controller.metrics.serviceMonitor.relabelings }}
     relabelings:
       {{- toYaml . | nindent 6 }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -178,6 +178,12 @@ controller:
       relabelings: []
       # -- MetricRelabelConfigs to apply to samples before ingestion
       metricRelabelings: []
+      # -- TLS configuration for the ServiceMonitor. When set, scheme will be https
+      tlsConfig: {}
+        # caFile: /etc/istio-certs/root-cert.pem
+        # certFile: /etc/istio-certs/cert-chain.pem
+        # insecureSkipVerify: true
+        # keyFile: /etc/istio-certs/key.pem
 
   # -- Configure liveness [probe] for the controller
   # @default -- See [values.yaml]


### PR DESCRIPTION
Allow argo rollout controller service monitor to use `tlsconfig` this feature is mandatory when using `istio` or `mTLS` 

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
