### PR TITLE
fix(argo-cd): add missing ARGOCD_SYNC_WAVE_DELAY configuration

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.1.5
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.3.7
+version: 8.3.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis_exporter to v1.77.0
+    - kind: added
+      description: support for controller.sync.wave.delay.seconds configuration

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -824,6 +824,7 @@ NOTE: Any values you put under `.Values.configs.cm` are passed to argocd-cm Conf
 | configs.params."controller.self.heal.timeout.seconds" | int | `5` | Specifies timeout between application self heal attempts |
 | configs.params."controller.status.processors" | int | `20` | Number of application status processors |
 | configs.params."controller.sync.timeout.seconds" | int | `0` | Specifies the timeout after which a sync would be terminated. 0 means no timeout |
+| configs.params."controller.sync.wave.delay.seconds" | int | `2` | Delay in seconds between sync waves |
 | configs.params."hydrator.enabled" | bool | `false` | Enable the hydrator feature (hydrator is in Alpha phase) |
 | configs.params."otlp.address" | string | `""` | Open-Telemetry collector address: (e.g. "otel-collector:4317") |
 | configs.params."reposerver.parallelism.limit" | int | `0` | Limit on number of concurrent manifests generate requests. Any value less the 1 means no limit. |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -196,6 +196,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.sync.timeout.seconds
                 optional: true
+          - name: ARGOCD_SYNC_WAVE_DELAY
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: controller.sync.wave.delay.seconds
+                optional: true
           - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_PLAINTEXT
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -192,6 +192,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.sync.timeout.seconds
                 optional: true
+          - name: ARGOCD_SYNC_WAVE_DELAY
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: controller.sync.wave.delay.seconds
+                optional: true
           - name: ARGOCD_APPLICATION_CONTROLLER_REPO_SERVER_PLAINTEXT
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -405,6 +405,8 @@ configs:
     controller.repo.server.timeout.seconds: 60
     # -- Specifies the timeout after which a sync would be terminated. 0 means no timeout
     controller.sync.timeout.seconds: 0
+    # -- Delay in seconds between sync waves
+    controller.sync.wave.delay.seconds: 2
 
     ## Server properties
     # -- Run server without TLS


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Summary

Add missing `ARGOCD_SYNC_WAVE_DELAY` environment variable and `controller.sync.wave.delay.seconds` parameter support to the argo-cd Helm chart. 
This configuration was added to Argo CD upstream in [argoproj/argo-cd#24536](https://github.com/argoproj/argo-cd/pull/24536) but was not exposed in the Helm chart configuration.
  
## Changes

- Added `ARGOCD_SYNC_WAVE_DELAY` environment variable to both StatefulSet and Deployment templates
- Added `controller.sync.wave.delay.seconds: 2` parameter to values.yaml with default value
- Bumped chart version from `8.3.7` to `8.3.8`
- Updated changelog in Chart.yaml annotations


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
