### PR TITLE
fix: remove preserveUnknownFields to avoid OutOfSync in ArgoCD

### DIFF
--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - ro
     singular: rollout
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
# fix(argo-rollouts): remove `spec.preserveUnknownFields` from CRDs to avoid Argo CD OutOfSync

## What

Remove the `spec.preserveUnknownFields: false` key from all Argo Rollouts CRD templates.

## Why

* In CRD `apiextensions.k8s.io/v1`, `spec.preserveUnknownFields` is **deprecated/invalid** and the behavior must be expressed with the OpenAPI extension `x-kubernetes-preserve-unknown-fields` inside the schema. Using the top-level field causes drift between desired and live objects. ([[Kubernetes](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)][1])
* Argo CD 3.0+ explicitly calls out that CRDs containing `spec.preserveUnknownFields: false` will show as **OutOfSync** and recommends removing the field. ([[Argo CD](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.14-3.0/)][2])
* This aligns the chart with Helm/Argo CD guidance for managing CRDs (and avoids unnecessary diff noise during syncs). ([[Argo Project](https://argoproj.github.io/argo-helm/)][3])

## Impact

* No functional change to the CRDs themselves—the field is ignored by modern API servers—but it **eliminates false OutOfSync** reports for users deploying this chart with [Argo CD](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.14-3.0/). ([Argo CD][2])

## How I validated

* Reproduced OutOfSync on CRDs that included `spec.preserveUnknownFields: false`; removing the key restored a clean sync. (There’s also active community demand to drop the field.) ([[GitHub](https://github.com/argoproj/argo-helm/issues/3301)][4])

## Notes for Maintainers

I have **not completed the checklist** (version bump, docs, changelog, etc.). I’m short on time to go through the full contribution process, but this is a minimal, safe fix that prevents avoidable OutOfSync states for everyone using Argo CD. Please apply the change on your side and handle versioning/changelog as you see fit.