### PR TITLE
feat(argo-cd): add custom roleRules support for application-controller

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.1.6
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.5.2
+version: 8.5.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.1.6
+    - kind: added
+      description: Add custom roleRules support for application-controller Role resource

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -941,6 +941,8 @@ NAME: my-release
 | controller.replicas | int | `1` | The number of application controller pods to run. Additional replicas will cause sharding of managed clusters across number of replicas. |
 | controller.resources | object | `{}` | Resource limits and requests for the application controller pods |
 | controller.revisionHistoryLimit | int | `5` | Maximum number of controller revisions that will be maintained in StatefulSet history |
+| controller.roleRules.enabled | bool | `false` | Enable custom rules for the application controller's Role resource |
+| controller.roleRules.rules | list | `[]` | List of custom rules for the application controller's Role resource |
 | controller.runtimeClassName | string | `""` (defaults to global.runtimeClassName) | Runtime class name for the application controller |
 | controller.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | controller.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -941,8 +941,7 @@ NAME: my-release
 | controller.replicas | int | `1` | The number of application controller pods to run. Additional replicas will cause sharding of managed clusters across number of replicas. |
 | controller.resources | object | `{}` | Resource limits and requests for the application controller pods |
 | controller.revisionHistoryLimit | int | `5` | Maximum number of controller revisions that will be maintained in StatefulSet history |
-| controller.roleRules.enabled | bool | `false` | Enable custom rules for the application controller's Role resource |
-| controller.roleRules.rules | list | `[]` | List of custom rules for the application controller's Role resource |
+| controller.roleRules | list | `[]` | List of custom rules for the application controller's Role resource |
 | controller.runtimeClassName | string | `""` (defaults to global.runtimeClassName) | Runtime class name for the application controller |
 | controller.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |
 | controller.serviceAccount.automountServiceAccountToken | bool | `true` | Automount API credentials for the Service Account |

--- a/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:
-{{- if .Values.controller.roleRules.enabled }}
-  {{- toYaml .Values.controller.roleRules.rules | nindent 2 }}
+{{- with .Values.controller.roleRules }}
+{{- toYaml . | nindent 0 }}
 {{- else }}
 - apiGroups:
   - ""

--- a/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:
 {{- with .Values.controller.roleRules }}
-{{- toYaml . | nindent 0 }}
+{{- toYaml . | nindent 2 }}
 {{- else }}
 - apiGroups:
   - ""

--- a/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 rules:
+{{- if .Values.controller.roleRules.enabled }}
+  {{- toYaml .Values.controller.roleRules.rules | nindent 2 }}
+{{- else }}
 - apiGroups:
   - ""
   resources:
@@ -57,4 +60,5 @@ rules:
   - watch
   - create
   - update
+{{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1142,11 +1142,8 @@ controller:
 
   ## Enable this and set the rules: to whatever custom rules you want for the Role resource.
   ## Defaults to off
-  roleRules:
-    # -- Enable custom rules for the application controller's Role resource
-    enabled: false
-    # -- List of custom rules for the application controller's Role resource
-    rules: []
+  # -- List of custom rules for the application controller's Role resource
+  roleRules: []
 
   # Default application controller's network policy
   networkPolicy:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1140,6 +1140,14 @@ controller:
     # -- List of custom rules for the application controller's ClusterRole resource
     rules: []
 
+  ## Enable this and set the rules: to whatever custom rules you want for the Role resource.
+  ## Defaults to off
+  roleRules:
+    # -- Enable custom rules for the application controller's Role resource
+    enabled: false
+    # -- List of custom rules for the application controller's Role resource
+    rules: []
+
   # Default application controller's network policy
   networkPolicy:
     # -- Default network policy rules used by application controller


### PR DESCRIPTION
## Description

Fixes #3414 - Add possibility to customize Role rules for application-controller when running in namespace-scoped environments with security constraints. This follows the same pattern as the existing `clusterRoleRules` feature and addresses the need for custom RBAC rules in namespace-scoped deployments.

## Changes

- Add `controller.roleRules` array for custom RBAC rules
- Update Role template to use `with` pattern for conditional rules
- Maintain backward compatibility with existing default rules
- Follow same pattern as existing `clusterRoleRules` feature

## Usage

```yaml
controller:
  roleRules:
    - apiGroups:
      - ""
      resources:
      - pods
      verbs:
      - get
      - list
      - watch
    - apiGroups:
      - apps
      resources:
      - replicasets
      verbs:
      - get
      - list
```

## Testing

- [x] Tested with default configuration (existing behavior preserved)
- [x] Tested with custom roleRules enabled
- [x] Helm template rendering verified for both scenarios



---

**Checklist:**

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).