### PR TITLE
feat(argo-cd): Allow configuring resource requests/limits for copyutil initContainer in repo-server pod

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.1.7
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.5.6
+version: 8.5.7
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Add missing environment variable for v3.1.7
+    - kind: added
+      description: Allow configuring resource requests/limits for copyutil initContainer in repo-server pod

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -984,6 +984,7 @@ NAME: my-release
 | repoServer.containerPorts.metrics | int | `8084` | Metrics container port |
 | repoServer.containerPorts.server | int | `8081` | Repo server container port |
 | repoServer.containerSecurityContext | object | See [values.yaml] | Repo server container-level security context |
+| repoServer.copyutil | object | `{"resources":{}}` | Resource limits and requests for the copyutil initContainer |
 | repoServer.deploymentAnnotations | object | `{}` | Annotations to be added to repo server Deployment |
 | repoServer.deploymentLabels | object | `{}` | Labels for the repo server Deployment |
 | repoServer.deploymentStrategy | object | `{}` | Deployment strategy to be added to the repo server Deployment |
@@ -1001,8 +1002,6 @@ NAME: my-release
 | repoServer.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the repo server |
 | repoServer.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | repoServer.initContainers | list | `[]` | Init containers to add to the repo server pods |
-| repoServer.initContainers | object | `{"copyutil":{"resources":{}}}` | Init containers for the repo server pods |
-| repoServer.initContainers.copyutil | object | `{"resources":{}}` | Resource limits and requests for the copyutil initContainer |
 | repoServer.lifecycle | object | `{}` | Specify postStart and preStop lifecycle hooks for your argo-repo-server container |
 | repoServer.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | repoServer.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1001,6 +1001,8 @@ NAME: my-release
 | repoServer.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the repo server |
 | repoServer.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | repoServer.initContainers | list | `[]` | Init containers to add to the repo server pods |
+| repoServer.initContainers | object | `{"copyutil":{"resources":{}}}` | Init containers for the repo server pods |
+| repoServer.initContainers.copyutil | object | `{"resources":{}}` | Resource limits and requests for the copyutil initContainer |
 | repoServer.lifecycle | object | `{}` | Specify postStart and preStop lifecycle hooks for your argo-repo-server container |
 | repoServer.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | repoServer.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -984,7 +984,7 @@ NAME: my-release
 | repoServer.containerPorts.metrics | int | `8084` | Metrics container port |
 | repoServer.containerPorts.server | int | `8081` | Repo server container port |
 | repoServer.containerSecurityContext | object | See [values.yaml] | Repo server container-level security context |
-| repoServer.copyutil | object | `{"resources":{}}` | Resource limits and requests for the copyutil initContainer |
+| repoServer.copyutil.resources | object | `{}` | Resource limits and requests for the repo server copyutil initContainer |
 | repoServer.deploymentAnnotations | object | `{}` | Annotations to be added to repo server Deployment |
 | repoServer.deploymentLabels | object | `{}` | Labels for the repo server Deployment |
 | repoServer.deploymentStrategy | object | `{}` | Deployment strategy to be added to the repo server Deployment |

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -412,11 +412,7 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
         name: copyutil
         resources:
-          {{- if .Values.repoServer.copyutil.resources }}
-          {{- toYaml .Values.repoServer.copyutil.resources | nindent 10 }}
-          {{- else }}
-          {{- toYaml .Values.repoServer.resources | nindent 10 }}
-          {{- end }}
+          {{- toYaml (default .Values.repoServer.resources .Values.repoServer.copyutil.resources) | nindent 10 }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -412,8 +412,8 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
         name: copyutil
         resources:
-          {{- if .Values.repoServer.initContainers.copyutil.resources }}
-          {{- toYaml .Values.repoServer.initContainers.copyutil.resources | nindent 10 }}
+          {{- if .Values.repoServer.copyutil.resources }}
+          {{- toYaml .Values.repoServer.copyutil.resources | nindent 10 }}
           {{- else }}
           {{- toYaml .Values.repoServer.resources | nindent 10 }}
           {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -412,7 +412,11 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.repoServer.image.imagePullPolicy }}
         name: copyutil
         resources:
+          {{- if .Values.repoServer.initContainers.copyutil.resources }}
+          {{- toYaml .Values.repoServer.initContainers.copyutil.resources | nindent 10 }}
+          {{- else }}
           {{- toYaml .Values.repoServer.resources | nindent 10 }}
+          {{- end }}
         {{- with .Values.repoServer.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2853,6 +2853,18 @@ repoServer:
   #    cpu: 10m
   #    memory: 64Mi
 
+  # -- Init containers for the repo server pods
+  initContainers:
+    # -- Resource limits and requests for the copyutil initContainer
+    copyutil:
+      resources: {}
+      #  limits:
+      #    cpu: 100m
+      #    memory: 128Mi
+      #  requests:
+      #    cpu: 50m
+      #    memory: 64Mi
+
   # Repo server container ports
   containerPorts:
     # -- Repo server container port

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2793,8 +2793,8 @@ repoServer:
   # -- Init containers to add to the repo server pods
   initContainers: []
 
-  # -- Resource limits and requests for the copyutil initContainer
   copyutil:
+    # -- Resource limits and requests for the repo server copyutil initContainer
     resources: {}
     #  limits:
     #    cpu: 100m

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2793,6 +2793,16 @@ repoServer:
   # -- Init containers to add to the repo server pods
   initContainers: []
 
+  # -- Resource limits and requests for the copyutil initContainer
+  copyutil:
+    resources: {}
+    #  limits:
+    #    cpu: 100m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 50m
+    #    memory: 64Mi
+
   # -- Additional volumeMounts to the repo server main container
   volumeMounts: []
 
@@ -2852,18 +2862,6 @@ repoServer:
   #  requests:
   #    cpu: 10m
   #    memory: 64Mi
-
-  # -- Init containers for the repo server pods
-  initContainers:
-    # -- Resource limits and requests for the copyutil initContainer
-    copyutil:
-      resources: {}
-      #  limits:
-      #    cpu: 100m
-      #    memory: 128Mi
-      #  requests:
-      #    cpu: 50m
-      #    memory: 64Mi
 
   # Repo server container ports
   containerPorts:


### PR DESCRIPTION
## Description
This PR adds the ability to configure separate resource requests and limits for the `copyutil` initContainer in the repo-server pod, addressing issue #3504.

## Changes
- Added `repoServer.initContainers.copyutil.resources` configuration option in values.yaml
- Updated deployment template to use separate resources for copyutil initContainer
- Maintains backward compatibility by falling back to `repoServer.resources` if not specified
- Bumped chart version from 8.5.6 to 8.5.7
- Updated changelog in Chart.yaml

## Testing
```bash
# Test with separate copyutil resources
helm template argocd charts/argo-cd \
 --set repoServer.initContainers.copyutil.resources.requests.memory=64Mi \
 --set repoServer.initContainers.copyutil.resources.requests.cpu=50m \
 --set repoServer.initContainers.copyutil.resources.limits.memory=128Mi \
 --set repoServer.initContainers.copyutil.resources.limits.cpu=100m \
 -s templates/argocd-repo-server/deployment.yaml
```

Fixes #3504

## Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
