### PR TITLE
feat(argo-cd): Add HTTPRoute support for Gateway API

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.1.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.5.8
+version: 8.6.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.1.8
+    - kind: added
+      description: Add HTTPRoute support for Gateway API

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1120,6 +1120,15 @@ NAME: my-release
 | server.extraArgs | list | `[]` | Additional command line arguments to pass to Argo CD server |
 | server.extraContainers | list | `[]` | Additional containers to be added to the server pod |
 | server.hostNetwork | bool | `false` | Host Network for Server pods |
+| server.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| server.httproute.enabled | bool | `false` | Enable HTTPRoute resource for Argo CD server (Gateway API) |
+| server.httproute.extraHosts | list | `[]` (See [values.yaml]) | The list of additional hostnames to be covered by HTTPRoute |
+| server.httproute.extraRules | list | `[]` (See [values.yaml]) | Additional HTTPRoute rules |
+| server.httproute.hostname | string | `""` (defaults to global.domain) | Argo CD server hostname |
+| server.httproute.labels | object | `{}` | Additional HTTPRoute labels |
+| server.httproute.parentRefs | list | `[]` (See [values.yaml]) | Gateway API parentRefs for the HTTPRoute |
+| server.httproute.path | string | `"/"` | The path to Argo CD server |
+| server.httproute.pathType | string | `"PathPrefix"` | HTTPRoute path type. One of `Exact`, `PathPrefix` or `RegularExpression` |
 | server.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Argo CD server |
 | server.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the Argo CD server |
 | server.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the Argo CD server |

--- a/charts/argo-cd/templates/argocd-server/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-server/httproute.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.server.httproute.enabled -}}
+{{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
+{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "argo-cd.server.fullname" . }}
+  namespace: {{ include  "argo-cd.namespace" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    {{- with .Values.server.httproute.labels }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.httproute.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl (toString $value) $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.server.httproute.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.server.httproute.hostname .Values.global.domain }}
+  hostnames:
+    - {{ tpl (.Values.server.httproute.hostname) $ | default .Values.global.domain }}
+    {{- range .Values.server.httproute.extraHosts }}
+    - {{ tpl .name $ }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.server.httproute.pathType }}
+            value: {{ .Values.server.httproute.path }}
+      backendRefs:
+        - name: {{ include "argo-cd.server.fullname" . }}
+          port: {{ $servicePort }}
+    {{- with .Values.server.httproute.extraRules }}
+      {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2640,6 +2640,38 @@ server:
     # -- Termination policy of Openshift Route
     termination_policy: None
 
+  # Gateway API HTTPRoute configuration
+  httproute:
+    # -- Enable HTTPRoute resource for Argo CD server (Gateway API)
+    enabled: false
+    # -- Additional HTTPRoute labels
+    labels: {}
+    # -- Additional HTTPRoute annotations
+    annotations: {}
+    # -- Gateway API parentRefs for the HTTPRoute
+    ## Must reference an existing Gateway
+    # @default -- `[]` (See [values.yaml])
+    ## Note: Supports use of custom Helm templates
+    parentRefs: []
+      # - name: example-gateway
+      #   namespace: example-gateway-namespace
+      #   sectionName: https
+    # -- Argo CD server hostname
+    # @default -- `""` (defaults to global.domain)
+    hostname: ""
+    # -- The path to Argo CD server
+    path: /
+    # -- HTTPRoute path type. One of `Exact`, `PathPrefix` or `RegularExpression`
+    pathType: PathPrefix
+    # -- The list of additional hostnames to be covered by HTTPRoute
+    # @default -- `[]` (See [values.yaml])
+    extraHosts: []
+      # - name: argocd.example.com
+    # -- Additional HTTPRoute rules
+    # @default -- `[]` (See [values.yaml])
+    ## Note: Supports use of custom Helm templates
+    extraRules: []
+
   ## Enable this and set the rules: to whatever custom rules you want for the Cluster Role resource.
   ## Defaults to off
   clusterRoleRules:


### PR DESCRIPTION
## Summary

This PR adds support for Kubernetes Gateway API HTTPRoute resource to the Argo CD Helm chart, enabling users to expose Argo CD server using Gateway API instead of traditional Ingress or OpenShift Route.

## Changes

- **New template**: `argocd-server/httproute.yaml` - HTTPRoute resource template following Gateway API v1 specification
- **Configuration**: Added `server.httproute` section in `values.yaml` with support for:
  - `enabled` flag (default: false)
  - `labels` and `annotations` for custom metadata
  - `parentRefs` for Gateway binding (required)
  - `hostname` (defaults to `global.domain`)
  - `path` and `pathType` (default: `/` with `PathPrefix`)
  - `extraHosts` and `extraRules` for advanced routing scenarios
- **Smart port selection**: Automatically selects HTTP or HTTPS port based on `server.insecure` configuration
- **Documentation**: Updated README.md via helm-docs

## Motivation

Gateway API is the successor to Ingress and is becoming the standard for traffic management in Kubernetes. This addition provides users with a modern, vendor-neutral way to expose Argo CD, aligning with the evolving Kubernetes ecosystem.

## Testing

- ✅ Helm lint passed
- ✅ Template rendering verified with sample values
- ✅ Documentation generated successfully
- ✅ Backwards compatible (disabled by default)

## Notes

**AI Disclosure**: This code was developed with assistance from Claude (Anthropic AI assistant) but has been carefully reviewed, tested, and validated by the PR author.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to main. They are not published on branches. -->