### PR TITLE
docs(argo-cd): Correct Changelog in README for v9.0.0

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.1.9
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.0.1
+version: 9.0.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.1.9
+    - kind: fixed
+      description: Correct Changelog in README for v9.0.0

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -397,7 +397,7 @@ For full list of changes please check ArtifactHub [changelog].
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
 ### 9.0.0
-We have removed all parameters under `.Values.configs.cm.params` in this release, with the exception of `create` and `annotations`.
+We have removed all parameters under `.Values.configs.params` in this release, with the exception of `create` and `annotations`.
 This is to ensure better alignment with the upstream project, as tracking changes to their default values within the Helm chart has become challenging.
 
 **Breaking change**
@@ -409,9 +409,8 @@ To restore the previous setting, you can override the argocd-cmd-params-cm Confi
 
 ```yaml
 configs:
-  cm:
-    params:
-      applicationsetcontroller.policy: 'sync'
+  params:
+    applicationsetcontroller.policy: 'sync'
 ```
 
 ### 8.0.0

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -397,7 +397,7 @@ For full list of changes please check ArtifactHub [changelog].
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
 ### 9.0.0
-We have removed all parameters under `.Values.configs.cm.params` in this release, with the exception of `create` and `annotations`.
+We have removed all parameters under `.Values.configs.params` in this release, with the exception of `create` and `annotations`.
 This is to ensure better alignment with the upstream project, as tracking changes to their default values within the Helm chart has become challenging.
 
 **Breaking change**
@@ -409,9 +409,8 @@ To restore the previous setting, you can override the argocd-cmd-params-cm Confi
 
 ```yaml
 configs:
-  cm:
-    params:
-      applicationsetcontroller.policy: 'sync'
+  params:
+    applicationsetcontroller.policy: 'sync'
 ```
 
 ### 8.0.0


### PR DESCRIPTION
Thanks to @tgdfool2 ( https://github.com/argoproj/argo-helm/pull/3545  ) , I realized the wrong doc in changelog. Thank you so much. In order to deliver faster, please forgive me to make new PR for it.
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
