### PR TITLE
docs(argo-cd): Add context to Changelog in README for v9.0.0

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.1.9
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.0.2
+version: 9.0.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Correct Changelog in README for v9.0.0
+      description: Add context to Changelog in README for v9.0.0

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -400,6 +400,8 @@ Highlighted versions provide information about additional steps that should be p
 We have removed all parameters under `.Values.configs.params` in this release, with the exception of `create` and `annotations`.
 This is to ensure better alignment with the upstream project, as tracking changes to their default values within the Helm chart has become challenging.
 
+**Though we removed the parameters from values.yaml in argo-helm, we keep providing the interface to override `.Values.configs.params` as the same way. **
+
 **Breaking change**
 
 Please be aware that the default value for `applicationsetcontroller.policy` has been updated to match the upstream default. The chart's default was previously `'sync'`, while the upstream default is `""` (an empty string).

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -400,6 +400,8 @@ Highlighted versions provide information about additional steps that should be p
 We have removed all parameters under `.Values.configs.params` in this release, with the exception of `create` and `annotations`.
 This is to ensure better alignment with the upstream project, as tracking changes to their default values within the Helm chart has become challenging.
 
+**Though we removed the parameters from values.yaml in argo-helm, we keep providing the interface to override `.Values.configs.params` as the same way. **
+
 **Breaking change**
 
 Please be aware that the default value for `applicationsetcontroller.policy` has been updated to match the upstream default. The chart's default was previously `'sync'`, while the upstream default is `""` (an empty string).


### PR DESCRIPTION
* We removed `configs.params.xxxx` from values.yaml in v9.0.0 but users can still override them, it was confusing for users to recognize the update, so I wonder it is better to add more context in changelog. 🤔 🙇 
* Ref
  * https://github.com/argoproj/argo-helm/pull/3546
  * https://github.com/argoproj/argo-helm/pull/3540

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
