### PR TITLE
fix(argocd-image-updater): Change default value of `.Values.ingress.enabled` to `false`

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: v0.17.0
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Upgrade argocd-image-updater to v0.17.0
+    - kind: fixed
+      description: Change default value of `.Values.ingress.enabled` to `false`

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -105,7 +105,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | ImagePullSecrets for the image updater deployment |
 | ingress.annotations | object | `{}` | Additional ingress annotations |
-| ingress.enabled | bool | `true` | Enable an ingress resource for the deployment |
+| ingress.enabled | bool | `false` | Enable an ingress resource for the deployment |
 | ingress.extraHosts | list | `[]` (See [values.yaml]) | The list of additional hostnames to be covered by ingress record |
 | ingress.extraPaths | list | `[]` (See [values.yaml]) | Additional ingress paths |
 | ingress.hostname | string | `""` (defaults to global.domain) | deployment hostname |

--- a/charts/argocd-image-updater/templates/service.yaml
+++ b/charts/argocd-image-updater/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -49,3 +50,4 @@ spec:
     {{- end }}
   selector:
     {{- include "argocd-image-updater.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -351,7 +351,7 @@ service:
 # Ingress for the deployment
 ingress:
   # -- Enable an ingress resource for the deployment
-  enabled: true
+  enabled: false
   # -- Additional ingress labels
   labels: {}
   # -- Additional ingress annotations


### PR DESCRIPTION
Ref: https://github.com/argoproj/argo-helm/pull/3511#issuecomment-3425553960
Ingress (and service for it) is supposed to be opt-in instead of opt-out. In order to align to other argoproj's projetcs (e.g. argo-cd), I changed the default value from `true` to `false` .

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
