### PR TITLE
feat(argo-workflows): make server service targetPort configurable

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.7.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.46.00
+version: 0.46.1
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v3.7.4
+    - kind: added
+      description: Add server.serviceTargetPort parameter to allow custom target ports for TLS sidecars

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -407,6 +407,7 @@ Fields to note:
 | server.serviceNodePort | string | `nil` | Service node port |
 | server.servicePort | int | `2746` | Service port for server |
 | server.servicePortName | string | `""` | Service port name |
+| server.serviceTargetPort | int | `2746` | Service target port for server |
 | server.serviceType | string | `"ClusterIP"` | Service type for server pods |
 | server.sso.clientId.key | string | `"client-id"` | Key of secret to retrieve the app OIDC client ID |
 | server.sso.clientId.name | string | `"argo-server-sso"` | Name of secret to retrieve the app OIDC client ID |

--- a/charts/argo-workflows/templates/server/server-service.yaml
+++ b/charts/argo-workflows/templates/server/server-service.yaml
@@ -20,7 +20,7 @@ spec:
     {{- with .Values.server.servicePortName }}
     name: {{ . }}
     {{- end }}
-    targetPort: 2746
+    targetPort: {{ .Values.server.serviceTargetPort }}
     {{- if and (eq .Values.server.serviceType "NodePort") .Values.server.serviceNodePort }}
     nodePort: {{ .Values.server.serviceNodePort }}
     {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -548,6 +548,8 @@ server:
   serviceType: ClusterIP
   # -- Service port for server
   servicePort: 2746
+  # -- Service target port for server
+  serviceTargetPort: 2746
   # -- Service node port
   serviceNodePort: # 32746
   # -- Service port name


### PR DESCRIPTION
  Adds server.serviceTargetPort parameter to allow routing to custom ports.
  This enables TLS termination sidecars (e.g., nginx) listening on port 443.

  Defaults to 2746 for backward compatibility.

  Fixes: #3558

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
