### PR TITLE
fix(argo-cd): make gateway API backend protocol selection work for server

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.2.0
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.1.3
+version: 9.1.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Add documentation about breaking changes when upgrading to 9.1.0 for redis-ha dependency
+    - kind: fixed
+      description: Make gateway API backend protocol selection work for server.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1328,8 +1328,12 @@ NAME: my-release
 | server.service.loadBalancerIP | string | `""` | LoadBalancer will get created with the IP specified in this field |
 | server.service.loadBalancerSourceRanges | list | `[]` | Source IP ranges to allow access to service from |
 | server.service.nodePortHttp | int | `30080` | Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort") |
+| server.service.nodePortHttp2 | int | `38008` | Server service http2 port for NodePort service type (only if `server.service.type` is set to "NodePort") |
 | server.service.nodePortHttps | int | `30443` | Server service https port for NodePort service type (only if `server.service.type` is set to "NodePort") |
 | server.service.servicePortHttp | int | `80` | Server service http port |
+| server.service.servicePortHttp2 | int | `8008` | Server service http2 port |
+| server.service.servicePortHttp2AppProtocol | string | `"kubernetes.io/h2c"` | Server service http2 port appProtocol |
+| server.service.servicePortHttp2Name | string | `"http2"` | Server service http2 port name, can be used to route traffic via istio |
 | server.service.servicePortHttpName | string | `"http"` | Server service http port name, can be used to route traffic via istio |
 | server.service.servicePortHttps | int | `443` | Server service https port |
 | server.service.servicePortHttpsAppProtocol | string | `""` | Server service https port appProtocol |

--- a/charts/argo-cd/templates/argocd-server/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-server/httproute.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.server.httproute.enabled -}}
 {{- $fullName := include "argo-cd.server.fullname" . -}}
 {{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
-{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
+{{- $servicePortHttp := .Values.server.service.servicePortHttp -}}
+{{- $servicePortHttps := .Values.server.service.servicePortHttps -}}
+{{- $servicePortHttp2 := .Values.server.service.servicePortHttp2 -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -26,20 +28,24 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    {{- range .Values.server.httproute.rules }}
-    {{- with .matches }}
-    - matches:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .filters }}
-      filters:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-      backendRefs:
+    {{- range $servicePort := eq $insecure "true" | ternary (list $servicePortHttp $servicePortHttp2) (list $servicePortHttps) -}}
+    {{- range $.Values.server.httproute.rules | default (list dict) }}
+    - backendRefs:
         - group: ''
           kind: Service
           name: {{ $fullName }}
           port: {{ $servicePort }}
           weight: 1
+    {{- with .matches | default (eq $servicePort $servicePortHttp2 | ternary (list dict) list) }}
+      matches:
+      {{- range . }}
+        - {{ eq $servicePort $servicePortHttp2 | ternary (set (deepCopy .) "headers" (prepend (index . "headers" | default list) (dict "name" "Content-Type" "value" "application/grpc"))) . | toYaml | indent 10 | trim }}
+      {{- end }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/service.yaml
@@ -44,6 +44,14 @@ spec:
     {{- if eq .Values.server.service.type "NodePort" }}
     nodePort: {{ .Values.server.service.nodePortHttp }}
     {{- end }}
+  - name: {{ .Values.server.service.servicePortHttp2Name }}
+    protocol: TCP
+    appProtocol: {{ .Values.server.service.servicePortHttp2AppProtocol}}
+    port: {{ .Values.server.service.servicePortHttp2 }}
+    targetPort: {{ .Values.server.containerPorts.server }}
+    {{- if eq .Values.server.service.type "NodePort" }}
+    nodePort: {{ .Values.server.service.nodePortHttp2 }}
+    {{- end }}
   - name: {{ .Values.server.service.servicePortHttpsName }}
     protocol: TCP
     port: {{ .Values.server.service.servicePortHttps }}
@@ -56,4 +64,3 @@ spec:
     {{- end }}
   selector:
     {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 4 }}
-

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2297,16 +2297,25 @@ server:
     type: ClusterIP
     # -- Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort")
     nodePortHttp: 30080
+    # -- Server service http2 port for NodePort service type (only if `server.service.type` is set to "NodePort")
+    nodePortHttp2: 38008
     # -- Server service https port for NodePort service type (only if `server.service.type` is set to "NodePort")
     nodePortHttps: 30443
     # -- Server service http port
     servicePortHttp: 80
+    # -- Server service http2 port
+    servicePortHttp2: 8008
     # -- Server service https port
     servicePortHttps: 443
     # -- Server service http port name, can be used to route traffic via istio
     servicePortHttpName: http
+    # -- Server service http2 port name, can be used to route traffic via istio
+    servicePortHttp2Name: http2
     # -- Server service https port name, can be used to route traffic via istio
     servicePortHttpsName: https
+    # -- Server service http2 port appProtocol
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
+    servicePortHttp2AppProtocol: "kubernetes.io/h2c"
     # -- Server service https port appProtocol
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
     servicePortHttpsAppProtocol: ""


### PR DESCRIPTION
When using gateway API (https://gateway-api.sigs.k8s.io/) to configure a Gateway and an HTTPRoute to access Argo CD server, backend protocol selection (https://gateway-api.sigs.k8s.io/guides/backend-protocol/) relies on the appProtocol field of the backend service port (https://gateway-api.sigs.k8s.io/reference/spec/#backendref). Valid values for this field are described in KEP-3726
(https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols).

Since Argo CD server serves web UI using HTTP 1 and GRPC using HTTP 2, both on the same port, two ports redirecting to the same pod port are needed on the service.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
