### PR TITLE
fix(argo-cd): support empty matches in GRPCRoute and HTTPRoute rules

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.7
+version: 9.5.8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Make PrometheusRule API version field overridable like it is in ServiceMonitor objects.
+    - kind: fixed
+      description: Support empty matches in GRPCRoute and HTTPRoute rules.

--- a/charts/argo-cd/ci/grpcroute-empty-matches.yaml
+++ b/charts/argo-cd/ci/grpcroute-empty-matches.yaml
@@ -1,0 +1,5 @@
+server:
+  grpcroute:
+    enabled: true
+    rules:
+      - matches: []

--- a/charts/argo-cd/ci/httproute-empty-matches.yaml
+++ b/charts/argo-cd/ci/httproute-empty-matches.yaml
@@ -1,0 +1,5 @@
+server:
+  httproute:
+    enabled: true
+    rules:
+      - matches: []

--- a/charts/argo-cd/templates/argocd-server/grpcroute.yaml
+++ b/charts/argo-cd/templates/argocd-server/grpcroute.yaml
@@ -26,18 +26,18 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    {{- range .Values.server.grpcroute.rules }}
-    {{- with .matches }}
-    - matches:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .filters }}
-      filters:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-      backendRefs:
+  {{- range .Values.server.grpcroute.rules }}
+    - backendRefs:
         - name: {{ $fullName }}
           port: {{ $servicePort }}
           weight: 1
+    {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-server/httproute.yaml
@@ -26,24 +26,24 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    {{- range .Values.server.httproute.rules }}
-    {{- with .matches }}
-    - matches:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .filters }}
-      filters:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .timeouts }}
-      timeouts:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-      backendRefs:
+  {{- range .Values.server.httproute.rules }}
+    - backendRefs:
         - group: ''
           kind: Service
           name: {{ $fullName }}
           port: {{ $servicePort }}
           weight: 1
+    {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Prior to this PR, the following values would result in invalid YAML.

```yaml
# charts/argo-cd/ci/grpcroute-empty-matches.yaml
server:
  grpcroute:
    enabled: true
    rules:
      - matches: []
```

```yaml
# Source: argo-cd/templates/argocd-server/grpcroute.yaml
spec:
  rules:
      backendRefs:
        - name: release-name-argocd-server
          port: 443
          weight: 1
```

The same goes for the HTTPRoute template.

```yaml
# charts/argo-cd/ci/httproute-empty-matches.yaml
server:
  httproute:
    enabled: true
    rules:
      - matches: []
```

```yaml
# Source: argo-cd/templates/argocd-server/httproute.yaml
spec:
  rules:
      backendRefs:
        - group: ''
          kind: Service
          name: release-name-argocd-server
          port: 443
          weight: 1
```

With this PR, the results are as follows, which is valid YAML.

```yaml
---
# Source: argo-cd/templates/argocd-server/grpcroute.yaml
spec:
  rules:
    - backendRefs:
        - name: release-name-argocd-server
          port: 443
          weight: 1
---
# Source: argo-cd/templates/argocd-server/httproute.yaml
spec:
  rules:
    - backendRefs:
        - group: ''
          kind: Service
          name: release-name-argocd-server
          port: 443
          weight: 1
```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Close #3847.

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
