### PR TITLE
chore(github): update CRDs if renovate finds an argo workflows version bump

### DIFF
--- a/scripts/renovate-bump-version.sh
+++ b/scripts/renovate-bump-version.sh
@@ -39,3 +39,8 @@ sed -i -e '/^  artifacthub.io\/changes: |/,$ d' "${chart_yaml_path}"
   echo "      description: Bump ${dependency_name} to ${dependency_version}"
 } >> "${chart_yaml_path}"
 cat "${chart_yaml_path}"
+
+# If the dependency is argo-workflows, also update CRDs
+if [[ "$dependency_name" == "argo-workflows" ]]; then
+  "$(dirname "$0")/update-argo-workflows-crds.sh" "$dependency_version"
+fi


### PR DESCRIPTION
Building on #3606 this PR automatically runs the script when renovate does its thing of finding new versions.