### PR TITLE
fix(argo-rollouts): Remove deprecated preserveUnknownFields field from CRDs

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.5
+version: 2.40.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: use named port for service
+    - kind: fixed
+      description: Remove deprecated preserveUnknownFields field from CRDs

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - exp
     singular: experiment
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - ro
     singular: rollout
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
## Summary

Removes the deprecated `preserveUnknownFields` field from all argo-rollouts CRDs. This field has been deprecated in Kubernetes API and should be removed from CRD specifications.

## Details

The `preserveUnknownFields` field at the CRD spec level was deprecated in favor of the more granular `x-kubernetes-preserve-unknown-fields` field within OpenAPI schemas. This change:

- Removes `preserveUnknownFields: false` from all 5 argo-rollouts CRDs
- The modern `x-kubernetes-preserve-unknown-fields` field is already correctly placed in the OpenAPI schema definitions where needed
- No functional changes to CRD behavior

## Affected CRDs
- rollout-crd.yaml
- analysis-run-crd.yaml  
- analysis-template-crd.yaml
- cluster-analysis-template-crd.yaml
- experiment-crd.yaml

## Testing

The CRDs maintain their existing validation behavior as `x-kubernetes-preserve-unknown-fields` is already properly set in the schema definitions.

## Checklist

- [x] Chart version bumped (2.40.5 -> 2.40.6)
- [x] Changelog added to Chart.yaml annotations
- [x] Follows conventional commits format
- [x] Single chart modification (argo-rollouts only)