### PR TITLE
fix(argo-cd): Remove Redis references when redis.enabled=false

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.2.3
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.2.3
+version: 9.2.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: add 'enabled' value, to true, for liveness and readiness for default server and Repo server to restore the default behaviour before 9.2.2
+      description: Remove Redis references when redis.enabled=false to prevent CreateContainerConfigError

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -232,7 +232,9 @@ NOTE: Configuration keys must be stored as dict because YAML treats dot as separ
 {{- $presets := dict -}}
 {{- $_ := set $presets "repo.server" (printf "%s:%s" (include "argo-cd.repoServer.fullname" .) (.Values.repoServer.service.port | toString)) -}}
 {{- $_ := set $presets "server.repo.server.strict.tls" (.Values.repoServer.certificateSecret.enabled | toString ) -}}
+{{- if or .Values.redis.enabled .Values.externalRedis.host -}}
 {{- $_ := set $presets "redis.server" (include "argo-cd.redis.server" .) -}}
+{{- end -}}
 {{- $_ := set $presets "applicationsetcontroller.enable.leader.election" (gt ((.Values.applicationSet.replicas | default .Values.applicationSet.replicaCount) | int64) 1) -}}
 {{- if .Values.dex.enabled -}}
 {{- $_ := set $presets "server.dex.server" (include "argo-cd.dex.server" .) -}}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -226,6 +226,7 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.app.state.cache.expiration
                 optional: true
+          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -264,6 +265,7 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
+          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -222,6 +222,7 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.app.state.cache.expiration
                 optional: true
+          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -260,6 +261,7 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
+          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -166,6 +166,7 @@ spec:
                 name: argocd-cmd-params-cm
                 key: reposerver.repo.cache.expiration
                 optional: true
+          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -204,6 +205,7 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
+          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -222,6 +222,7 @@ spec:
                 name: argocd-cmd-params-cm
                 key: server.app.state.cache.expiration
                 optional: true
+          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -260,6 +261,7 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
+          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/redis-secret-init/job.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/role.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redisSecretInit.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
## Summary

When deploying ArgoCD with `redis.enabled=false`, the rendered manifests still contain Redis-related environment variables, ConfigMap entries, and the redis-secret-init Job/RBAC resources. This PR removes all Redis references when Redis is disabled, resulting in cleaner manifests.

## Problem

With `redis.enabled=false`, the following Redis references are still rendered:

**In Deployments/StatefulSets:**
- `REDIS_SERVER`, `REDIS_COMPRESSION`, `REDISDB` environment variables

**In ConfigMap (`argocd-cmd-params-cm`):**
- `redis.server: ""` (empty value)

**Redis Secret Init resources:**
- Job, Role, RoleBinding, and ServiceAccount are created even when Redis is disabled

## Solution

1. Wrap Redis environment variables in conditional blocks:
```yaml
{{- if or .Values.redis.enabled .Values.externalRedis.host }}
```

2. Add `redis.enabled` or `redis-ha.enabled` check to redis-secret-init resources:
```yaml
{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
```

## Verification

```bash
# After fix - Zero Redis references when disabled
helm template argocd ./charts/argo-cd --set redis.enabled=false | grep -i redis
# Output: (empty - no matches)

# Redis enabled still works normally
helm template argocd ./charts/argo-cd --set redis.enabled=true | grep -c redis
# Output: 83 references (expected behavior)
```

---

## Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).