### PR TITLE
feat(argocd-apps): Add goTemplateOptions support for ApplicationSet

### DIFF
--- a/charts/argocd-apps/Chart.yaml
+++ b/charts/argocd-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-apps
 description: A Helm chart for managing additional Argo CD Applications and Projects
 type: application
-version: 2.0.2
+version: 2.0.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 keywords:
@@ -18,4 +18,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: allow setting applicationset finalizers
+      description: support goTemplateOptions for ApplicationSet

--- a/charts/argocd-apps/templates/applicationsets.yaml
+++ b/charts/argocd-apps/templates/applicationsets.yaml
@@ -25,6 +25,10 @@ spec:
   {{- if hasKey $appSetData "goTemplate" }}
   goTemplate: {{ $appSetData.goTemplate }}
   {{- end }}
+  {{- with $appSetData.goTemplateOptions }}
+  goTemplateOptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $appSetData.generators }}
   generators:
     {{- toYaml . | nindent 4 }}

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -101,6 +101,7 @@ applicationsets: {}
 #    - resources-finalizer.argocd.argoproj.io
 #    # See PR #10026 (ArgoCD v2.5 or later)
 #    # goTemplate: false
+#    # goTemplateOptions: ["missingkey=error"]
 #    generators:
 #    - git:
 #        repoURL: https://github.com/argoproj/argocd-example-apps.git


### PR DESCRIPTION
Allow configuring [Go template](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/GoTemplate/#go-template) options like "missingkey=error" when using goTemplate in ApplicationSet resources.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
