### PR TITLE
fix(argo-cd): revert "Remove Redis references when redis.enabled=false"

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.2.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.3.1
+version: 9.3.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.2.4
+    - kind: fixed
+      description: Revert Remove Redis references when redis.enabled=false (#3643)

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -232,9 +232,7 @@ NOTE: Configuration keys must be stored as dict because YAML treats dot as separ
 {{- $presets := dict -}}
 {{- $_ := set $presets "repo.server" (printf "%s:%s" (include "argo-cd.repoServer.fullname" .) (.Values.repoServer.service.port | toString)) -}}
 {{- $_ := set $presets "server.repo.server.strict.tls" (.Values.repoServer.certificateSecret.enabled | toString ) -}}
-{{- if or .Values.redis.enabled .Values.externalRedis.host -}}
 {{- $_ := set $presets "redis.server" (include "argo-cd.redis.server" .) -}}
-{{- end -}}
 {{- $_ := set $presets "applicationsetcontroller.enable.leader.election" (gt ((.Values.applicationSet.replicas | default .Values.applicationSet.replicaCount) | int64) 1) -}}
 {{- if .Values.dex.enabled -}}
 {{- $_ := set $presets "server.dex.server" (include "argo-cd.dex.server" .) -}}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -226,7 +226,6 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.app.state.cache.expiration
                 optional: true
-          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -265,7 +264,6 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
-          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -222,7 +222,6 @@ spec:
                 name: argocd-cmd-params-cm
                 key: controller.app.state.cache.expiration
                 optional: true
-          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -261,7 +260,6 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
-          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -166,7 +166,6 @@ spec:
                 name: argocd-cmd-params-cm
                 key: reposerver.repo.cache.expiration
                 optional: true
-          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -205,7 +204,6 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
-          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -222,7 +222,6 @@ spec:
                 name: argocd-cmd-params-cm
                 key: server.app.state.cache.expiration
                 optional: true
-          {{- if or .Values.redis.enabled .Values.externalRedis.host }}
           - name: REDIS_SERVER
             valueFrom:
               configMapKeyRef:
@@ -261,7 +260,6 @@ spec:
                 name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
                 key: redis-sentinel-password
                 optional: true
-          {{- end }}
           - name: ARGOCD_DEFAULT_CACHE_EXPIRATION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/redis-secret-init/job.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/role.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (or .Values.redis.enabled (index .Values "redis-ha" "enabled")) (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (not .Values.externalRedis.host) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redisSecretInit.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-helm/issues/3657

Reverts https://github.com/argoproj/argo-helm/pull/3643

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
