### PR TITLE
feat(argo-rollouts): update all crds

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.5
+version: 2.41.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: use named port for service
+      description: upgrade all argo rollouts crds

--- a/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-run-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - ar
     singular: analysisrun
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -273,6 +272,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -340,17 +341,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -391,11 +410,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -407,11 +428,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -422,6 +445,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -438,11 +462,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -454,14 +480,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -487,11 +516,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -521,11 +552,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -536,6 +569,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -549,6 +583,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -565,11 +600,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -599,11 +636,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -614,12 +653,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -641,11 +682,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -675,11 +718,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -690,6 +735,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -703,6 +749,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -719,11 +766,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -753,11 +802,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -768,12 +819,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -785,10 +838,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -803,6 +858,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -818,6 +874,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -841,6 +914,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -853,12 +927,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -869,6 +947,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -876,6 +955,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -890,6 +970,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -907,6 +988,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -948,6 +1030,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -965,6 +1048,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -998,6 +1082,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1007,6 +1093,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1017,6 +1104,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1037,6 +1125,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1111,6 +1200,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1121,6 +1211,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1141,6 +1232,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1201,6 +1293,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1215,20 +1309,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1284,6 +1412,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1294,6 +1423,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1314,6 +1444,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1376,6 +1507,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1387,6 +1521,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1396,18 +1532,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1417,10 +1560,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1433,10 +1578,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1451,6 +1598,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1466,6 +1614,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1489,6 +1654,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1501,12 +1667,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1517,6 +1687,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1524,6 +1695,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1538,6 +1710,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1555,6 +1728,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1596,6 +1770,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1613,6 +1788,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1646,6 +1822,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1655,6 +1833,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1665,6 +1844,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1685,6 +1865,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1759,6 +1940,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1769,6 +1951,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1789,6 +1972,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1849,6 +2033,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1863,20 +2049,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1932,6 +2152,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1942,6 +2163,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1962,6 +2184,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2026,6 +2249,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2037,6 +2263,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2046,12 +2274,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2059,10 +2293,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2073,14 +2313,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2088,10 +2334,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2106,6 +2354,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2121,6 +2370,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2144,6 +2410,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2156,12 +2423,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2172,6 +2443,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2179,6 +2451,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2193,6 +2466,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2210,6 +2484,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2251,6 +2526,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2268,6 +2544,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2301,6 +2578,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2310,6 +2589,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2320,6 +2600,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2340,6 +2621,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2414,6 +2696,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2424,6 +2707,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2444,6 +2728,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2504,6 +2789,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2518,20 +2805,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2587,6 +2908,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2597,6 +2919,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2617,6 +2940,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2679,6 +3003,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2690,6 +3017,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2699,12 +3028,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2743,18 +3078,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2762,6 +3095,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2782,6 +3148,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2795,6 +3170,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2820,6 +3197,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2832,6 +3212,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2873,6 +3254,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2889,11 +3271,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2954,6 +3338,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2973,10 +3359,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2993,10 +3377,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/analysis-template-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - at
     singular: analysistemplate
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -269,6 +268,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -336,17 +337,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -387,11 +406,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -403,11 +424,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -418,6 +441,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -434,11 +458,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -450,14 +476,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -483,11 +512,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -517,11 +548,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -532,6 +565,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -545,6 +579,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -561,11 +596,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -595,11 +632,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -610,12 +649,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -637,11 +678,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -671,11 +714,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -686,6 +731,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -699,6 +745,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -715,11 +762,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -749,11 +798,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -764,12 +815,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -781,10 +834,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -799,6 +854,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -814,6 +870,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -837,6 +910,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -849,12 +923,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -865,6 +943,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -872,6 +951,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -886,6 +966,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -903,6 +984,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -944,6 +1026,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -961,6 +1044,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -994,6 +1078,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1003,6 +1089,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1013,6 +1100,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1033,6 +1121,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1107,6 +1196,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1117,6 +1207,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1137,6 +1228,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1197,6 +1289,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1211,20 +1305,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1280,6 +1408,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1290,6 +1419,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1310,6 +1440,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1372,6 +1503,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1383,6 +1517,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1392,18 +1528,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1413,10 +1556,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1429,10 +1574,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1447,6 +1594,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1462,6 +1610,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1485,6 +1650,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1497,12 +1663,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1513,6 +1683,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1520,6 +1691,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1534,6 +1706,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1551,6 +1724,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1592,6 +1766,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1609,6 +1784,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1642,6 +1818,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1651,6 +1829,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1661,6 +1840,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1681,6 +1861,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1755,6 +1936,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1765,6 +1947,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1785,6 +1968,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1845,6 +2029,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1859,20 +2045,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1928,6 +2148,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1938,6 +2159,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1958,6 +2180,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2022,6 +2245,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2033,6 +2259,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2042,12 +2270,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2055,10 +2289,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2069,14 +2309,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2084,10 +2330,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2102,6 +2350,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2117,6 +2366,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2140,6 +2406,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2152,12 +2419,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2168,6 +2439,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2175,6 +2447,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2189,6 +2462,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2206,6 +2480,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2247,6 +2522,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2264,6 +2540,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2297,6 +2574,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2306,6 +2585,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2316,6 +2596,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2336,6 +2617,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2410,6 +2692,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2420,6 +2703,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2440,6 +2724,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2500,6 +2785,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2514,20 +2801,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2583,6 +2904,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2593,6 +2915,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2613,6 +2936,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2675,6 +2999,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2686,6 +3013,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2695,12 +3024,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2739,18 +3074,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2758,6 +3091,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2778,6 +3144,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2791,6 +3166,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2816,6 +3193,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2828,6 +3208,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2869,6 +3250,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2885,11 +3267,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2950,6 +3334,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2969,10 +3355,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2989,10 +3373,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/cluster-analysis-template-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - cat
     singular: clusteranalysistemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -269,6 +268,8 @@ spec:
                                 completions:
                                   format: int32
                                   type: integer
+                                managedBy:
+                                  type: string
                                 manualSelector:
                                   type: boolean
                                 maxFailedIndexes:
@@ -336,17 +337,35 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                         - key
                                         - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
                                 suspend:
                                   type: boolean
                                 template:
@@ -387,11 +406,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -403,11 +424,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       weight:
@@ -418,6 +441,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   properties:
                                                     nodeSelectorTerms:
@@ -434,11 +458,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchFields:
                                                             items:
                                                               properties:
@@ -450,14 +476,17 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - nodeSelectorTerms
                                                   type: object
@@ -483,11 +512,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -517,11 +548,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -532,6 +565,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -545,6 +579,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -561,11 +596,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -595,11 +632,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -610,12 +649,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                             podAntiAffinity:
                                               properties:
@@ -637,11 +678,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -671,11 +714,13 @@ spec:
                                                                       items:
                                                                         type: string
                                                                       type: array
+                                                                      x-kubernetes-list-type: atomic
                                                                   required:
                                                                   - key
                                                                   - operator
                                                                   type: object
                                                                 type: array
+                                                                x-kubernetes-list-type: atomic
                                                               matchLabels:
                                                                 additionalProperties:
                                                                   type: string
@@ -686,6 +731,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           topologyKey:
                                                             type: string
                                                         required:
@@ -699,6 +745,7 @@ spec:
                                                     - weight
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 requiredDuringSchedulingIgnoredDuringExecution:
                                                   items:
                                                     properties:
@@ -715,11 +762,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -749,11 +798,13 @@ spec:
                                                                   items:
                                                                     type: string
                                                                   type: array
+                                                                  x-kubernetes-list-type: atomic
                                                               required:
                                                               - key
                                                               - operator
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           matchLabels:
                                                             additionalProperties:
                                                               type: string
@@ -764,12 +815,14 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         type: string
                                                     required:
                                                     - topologyKey
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               type: object
                                           type: object
                                         automountServiceAccountToken:
@@ -781,10 +834,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -799,6 +854,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -814,6 +870,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -837,6 +910,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -849,12 +923,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -865,6 +943,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -872,6 +951,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -886,6 +966,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -903,6 +984,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -944,6 +1026,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -961,6 +1044,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -994,6 +1078,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1003,6 +1089,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1013,6 +1100,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1033,6 +1121,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1107,6 +1196,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1117,6 +1207,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1137,6 +1228,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1197,6 +1289,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1211,20 +1305,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1280,6 +1408,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1290,6 +1419,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1310,6 +1440,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1372,6 +1503,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -1383,6 +1517,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -1392,18 +1528,25 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         dnsConfig:
                                           properties:
                                             nameservers:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             options:
                                               items:
                                                 properties:
@@ -1413,10 +1556,12 @@ spec:
                                                     type: string
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             searches:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         dnsPolicy:
                                           type: string
@@ -1429,10 +1574,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -1447,6 +1594,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1462,6 +1610,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -1485,6 +1650,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -1497,12 +1663,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1513,6 +1683,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -1520,6 +1691,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -1534,6 +1706,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1551,6 +1724,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1592,6 +1766,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -1609,6 +1784,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -1642,6 +1818,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -1651,6 +1829,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1661,6 +1840,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1681,6 +1861,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1755,6 +1936,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1765,6 +1947,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1785,6 +1968,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -1845,6 +2029,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -1859,20 +2045,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -1928,6 +2148,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -1938,6 +2159,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -1958,6 +2180,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2022,6 +2245,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2033,6 +2259,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2042,12 +2270,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         hostAliases:
                                           items:
                                             properties:
@@ -2055,10 +2289,16 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               ip:
                                                 type: string
+                                            required:
+                                            - ip
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
                                         hostIPC:
                                           type: boolean
                                         hostNetwork:
@@ -2069,14 +2309,20 @@ spec:
                                           type: boolean
                                         hostname:
                                           type: string
+                                        hostnameOverride:
+                                          type: string
                                         imagePullSecrets:
                                           items:
                                             properties:
                                               name:
+                                                default: ""
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         initContainers:
                                           items:
                                             properties:
@@ -2084,10 +2330,12 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               command:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               env:
                                                 items:
                                                   properties:
@@ -2102,6 +2350,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2117,6 +2366,23 @@ spec:
                                                               type: string
                                                           required:
                                                           - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         resourceFieldRef:
@@ -2140,6 +2406,7 @@ spec:
                                                             key:
                                                               type: string
                                                             name:
+                                                              default: ""
                                                               type: string
                                                             optional:
                                                               type: boolean
@@ -2152,12 +2419,16 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
                                               envFrom:
                                                 items:
                                                   properties:
                                                     configMapRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2168,6 +2439,7 @@ spec:
                                                     secretRef:
                                                       properties:
                                                         name:
+                                                          default: ""
                                                           type: string
                                                         optional:
                                                           type: boolean
@@ -2175,6 +2447,7 @@ spec:
                                                       x-kubernetes-map-type: atomic
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               image:
                                                 type: string
                                               imagePullPolicy:
@@ -2189,6 +2462,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2206,6 +2480,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2247,6 +2522,7 @@ spec:
                                                             items:
                                                               type: string
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                         type: object
                                                       httpGet:
                                                         properties:
@@ -2264,6 +2540,7 @@ spec:
                                                               - value
                                                               type: object
                                                             type: array
+                                                            x-kubernetes-list-type: atomic
                                                           path:
                                                             type: string
                                                           port:
@@ -2297,6 +2574,8 @@ spec:
                                                         - port
                                                         type: object
                                                     type: object
+                                                  stopSignal:
+                                                    type: string
                                                 type: object
                                               livenessProbe:
                                                 properties:
@@ -2306,6 +2585,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2316,6 +2596,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2336,6 +2617,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2410,6 +2692,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2420,6 +2703,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2440,6 +2724,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2500,6 +2785,8 @@ spec:
                                                       properties:
                                                         name:
                                                           type: string
+                                                        request:
+                                                          type: string
                                                       required:
                                                       - name
                                                       type: object
@@ -2514,20 +2801,54 @@ spec:
                                                 type: object
                                               restartPolicy:
                                                 type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               securityContext:
                                                 properties:
                                                   allowPrivilegeEscalation:
                                                     type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
                                                   capabilities:
                                                     properties:
                                                       add:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       drop:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   privileged:
                                                     type: boolean
@@ -2583,6 +2904,7 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     type: object
                                                   failureThreshold:
                                                     format: int32
@@ -2593,6 +2915,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       service:
+                                                        default: ""
                                                         type: string
                                                     required:
                                                     - port
@@ -2613,6 +2936,7 @@ spec:
                                                           - value
                                                           type: object
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                       path:
                                                         type: string
                                                       port:
@@ -2675,6 +2999,9 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
                                               volumeMounts:
                                                 items:
                                                   properties:
@@ -2686,6 +3013,8 @@ spec:
                                                       type: string
                                                     readOnly:
                                                       type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
                                                     subPath:
                                                       type: string
                                                     subPathExpr:
@@ -2695,12 +3024,18 @@ spec:
                                                   - name
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
                                               workingDir:
                                                 type: string
                                             required:
                                             - name
                                             type: object
                                           type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
                                         nodeName:
                                           type: string
                                         nodeSelector:
@@ -2739,18 +3074,16 @@ spec:
                                             - conditionType
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         resourceClaims:
                                           items:
                                             properties:
                                               name:
                                                 type: string
-                                              source:
-                                                properties:
-                                                  resourceClaimName:
-                                                    type: string
-                                                  resourceClaimTemplateName:
-                                                    type: string
-                                                type: object
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
                                             required:
                                             - name
                                             type: object
@@ -2758,6 +3091,39 @@ spec:
                                           x-kubernetes-list-map-keys:
                                           - name
                                           x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
                                         restartPolicy:
                                           type: string
                                         runtimeClassName:
@@ -2778,6 +3144,15 @@ spec:
                                           x-kubernetes-list-type: map
                                         securityContext:
                                           properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
                                             fsGroup:
                                               format: int64
                                               type: integer
@@ -2791,6 +3166,8 @@ spec:
                                             runAsUser:
                                               format: int64
                                               type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
                                             seLinuxOptions:
                                               properties:
                                                 level:
@@ -2816,6 +3193,9 @@ spec:
                                                 format: int64
                                                 type: integer
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
                                             sysctls:
                                               items:
                                                 properties:
@@ -2828,6 +3208,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             windowsOptions:
                                               properties:
                                                 gmsaCredentialSpec:
@@ -2869,6 +3250,7 @@ spec:
                                                 type: string
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologySpreadConstraints:
                                           items:
                                             properties:
@@ -2885,11 +3267,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -2950,6 +3334,8 @@ spec:
                               type: string
                             configurationAccountName:
                               type: string
+                            lookback:
+                              type: boolean
                             metricsAccountName:
                               type: string
                             scopes:
@@ -2969,10 +3355,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   experimentScope:
@@ -2989,10 +3373,8 @@ spec:
                                         format: int64
                                         type: integer
                                     required:
-                                    - end
                                     - region
                                     - scope
-                                    - start
                                     - step
                                     type: object
                                   name:

--- a/charts/argo-rollouts/templates/crds/experiment-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/experiment-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - exp
     singular: experiment
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -159,11 +158,13 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
@@ -213,11 +214,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 items:
                                                   properties:
@@ -229,11 +232,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           weight:
@@ -244,6 +249,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       properties:
                                         nodeSelectorTerms:
@@ -260,11 +266,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchFields:
                                                 items:
                                                   properties:
@@ -276,14 +284,17 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                       - nodeSelectorTerms
                                       type: object
@@ -309,11 +320,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -343,11 +356,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -358,6 +373,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
                                                 type: string
                                             required:
@@ -371,6 +387,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
                                         properties:
@@ -387,11 +404,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -421,11 +440,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -436,12 +457,14 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 podAntiAffinity:
                                   properties:
@@ -463,11 +486,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -497,11 +522,13 @@ spec:
                                                           items:
                                                             type: string
                                                           type: array
+                                                          x-kubernetes-list-type: atomic
                                                       required:
                                                       - key
                                                       - operator
                                                       type: object
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
@@ -512,6 +539,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               topologyKey:
                                                 type: string
                                             required:
@@ -525,6 +553,7 @@ spec:
                                         - weight
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     requiredDuringSchedulingIgnoredDuringExecution:
                                       items:
                                         properties:
@@ -541,11 +570,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -575,11 +606,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                   - key
                                                   - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -590,12 +623,14 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             type: string
                                         required:
                                         - topologyKey
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                               type: object
                             automountServiceAccountToken:
@@ -607,10 +642,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -625,6 +662,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -640,6 +678,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -663,6 +718,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -675,12 +731,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -691,6 +751,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -698,6 +759,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -712,6 +774,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -729,6 +792,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -770,6 +834,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -787,6 +852,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -820,6 +886,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -829,6 +897,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -839,6 +908,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -859,6 +929,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -933,6 +1004,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -943,6 +1015,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -963,6 +1036,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1023,6 +1097,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -1037,20 +1113,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -1106,6 +1216,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1116,6 +1227,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1136,6 +1248,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1198,6 +1311,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -1209,6 +1325,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -1218,18 +1336,25 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             dnsConfig:
                               properties:
                                 nameservers:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 options:
                                   items:
                                     properties:
@@ -1239,10 +1364,12 @@ spec:
                                         type: string
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 searches:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             dnsPolicy:
                               type: string
@@ -1255,10 +1382,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -1273,6 +1402,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1288,6 +1418,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -1311,6 +1458,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1323,12 +1471,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1339,6 +1491,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1346,6 +1499,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -1360,6 +1514,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -1377,6 +1532,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -1418,6 +1574,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -1435,6 +1592,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -1468,6 +1626,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -1477,6 +1637,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1487,6 +1648,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1507,6 +1669,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1581,6 +1744,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1591,6 +1755,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1611,6 +1776,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1671,6 +1837,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -1685,20 +1853,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -1754,6 +1956,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -1764,6 +1967,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -1784,6 +1988,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -1848,6 +2053,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -1859,6 +2067,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -1868,12 +2078,18 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             hostAliases:
                               items:
                                 properties:
@@ -1881,10 +2097,16 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   ip:
                                     type: string
+                                required:
+                                - ip
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - ip
+                              x-kubernetes-list-type: map
                             hostIPC:
                               type: boolean
                             hostNetwork:
@@ -1895,14 +2117,20 @@ spec:
                               type: boolean
                             hostname:
                               type: string
+                            hostnameOverride:
+                              type: string
                             imagePullSecrets:
                               items:
                                 properties:
                                   name:
+                                    default: ""
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             initContainers:
                               items:
                                 properties:
@@ -1910,10 +2138,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   command:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   env:
                                     items:
                                       properties:
@@ -1928,6 +2158,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1943,6 +2174,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -1966,6 +2214,7 @@ spec:
                                                 key:
                                                   type: string
                                                 name:
+                                                  default: ""
                                                   type: string
                                                 optional:
                                                   type: boolean
@@ -1978,12 +2227,16 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   envFrom:
                                     items:
                                       properties:
                                         configMapRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -1994,6 +2247,7 @@ spec:
                                         secretRef:
                                           properties:
                                             name:
+                                              default: ""
                                               type: string
                                             optional:
                                               type: boolean
@@ -2001,6 +2255,7 @@ spec:
                                           x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   image:
                                     type: string
                                   imagePullPolicy:
@@ -2015,6 +2270,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -2032,6 +2288,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -2073,6 +2330,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           httpGet:
                                             properties:
@@ -2090,6 +2348,7 @@ spec:
                                                   - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               path:
                                                 type: string
                                               port:
@@ -2123,6 +2382,8 @@ spec:
                                             - port
                                             type: object
                                         type: object
+                                      stopSignal:
+                                        type: string
                                     type: object
                                   livenessProbe:
                                     properties:
@@ -2132,6 +2393,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2142,6 +2404,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2162,6 +2425,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2236,6 +2500,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2246,6 +2511,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2266,6 +2532,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2326,6 +2593,8 @@ spec:
                                           properties:
                                             name:
                                               type: string
+                                            request:
+                                              type: string
                                           required:
                                           - name
                                           type: object
@@ -2340,20 +2609,54 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
                                         type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
                                       capabilities:
                                         properties:
                                           add:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           drop:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       privileged:
                                         type: boolean
@@ -2409,6 +2712,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       failureThreshold:
                                         format: int32
@@ -2419,6 +2723,7 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
+                                            default: ""
                                             type: string
                                         required:
                                         - port
@@ -2439,6 +2744,7 @@ spec:
                                               - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             type: string
                                           port:
@@ -2501,6 +2807,9 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
                                   volumeMounts:
                                     items:
                                       properties:
@@ -2512,6 +2821,8 @@ spec:
                                           type: string
                                         readOnly:
                                           type: boolean
+                                        recursiveReadOnly:
+                                          type: string
                                         subPath:
                                           type: string
                                         subPathExpr:
@@ -2521,12 +2832,18 @@ spec:
                                       - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
                                   workingDir:
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             nodeName:
                               type: string
                             nodeSelector:
@@ -2565,18 +2882,16 @@ spec:
                                 - conditionType
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             resourceClaims:
                               items:
                                 properties:
                                   name:
                                     type: string
-                                  source:
-                                    properties:
-                                      resourceClaimName:
-                                        type: string
-                                      resourceClaimTemplateName:
-                                        type: string
-                                    type: object
+                                  resourceClaimName:
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    type: string
                                 required:
                                 - name
                                 type: object
@@ -2584,6 +2899,39 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
                             restartPolicy:
                               type: string
                             runtimeClassName:
@@ -2604,6 +2952,15 @@ spec:
                               x-kubernetes-list-type: map
                             securityContext:
                               properties:
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 fsGroup:
                                   format: int64
                                   type: integer
@@ -2617,6 +2974,8 @@ spec:
                                 runAsUser:
                                   format: int64
                                   type: integer
+                                seLinuxChangePolicy:
+                                  type: string
                                 seLinuxOptions:
                                   properties:
                                     level:
@@ -2642,6 +3001,9 @@ spec:
                                     format: int64
                                     type: integer
                                   type: array
+                                  x-kubernetes-list-type: atomic
+                                supplementalGroupsPolicy:
+                                  type: string
                                 sysctls:
                                   items:
                                     properties:
@@ -2654,6 +3016,7 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 windowsOptions:
                                   properties:
                                     gmsaCredentialSpec:
@@ -2695,6 +3058,7 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             topologySpreadConstraints:
                               items:
                                 properties:
@@ -2711,11 +3075,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                           - key
                                           - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string

--- a/charts/argo-rollouts/templates/crds/rollout-crd.yaml
+++ b/charts/argo-rollouts/templates/crds/rollout-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     {{- if .Values.keepCRDs }}
     "helm.sh/resource-policy": keep
     {{- end }}
@@ -23,7 +23,6 @@ spec:
     shortNames:
     - ro
     singular: rollout
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -108,17 +107,22 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: .spec.selector is immutable
+                  rule: self == oldSelf
               strategy:
                 properties:
                   blueGreen:
@@ -450,6 +454,17 @@ spec:
                         - pingService
                         - pongService
                         type: object
+                      replicaProgressThreshold:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            format: int32
+                            type: integer
+                        required:
+                        - type
+                        - value
+                        type: object
                       scaleDownDelayRevisionLimit:
                         format: int32
                         type: integer
@@ -603,6 +618,9 @@ spec:
                                   type: array
                                 duration:
                                   type: string
+                                scaleDownDelaySeconds:
+                                  format: int32
+                                  type: integer
                                 templates:
                                   items:
                                     properties:
@@ -635,11 +653,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                               - key
                                               - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -858,6 +878,10 @@ spec:
                             properties:
                               destinationRule:
                                 properties:
+                                  additionalSubsetNames:
+                                    items:
+                                      type: string
+                                    type: array
                                   canarySubsetName:
                                     type: string
                                   name:
@@ -1023,11 +1047,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
                                           items:
                                             properties:
@@ -1039,11 +1065,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     weight:
@@ -1054,6 +1082,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 properties:
                                   nodeSelectorTerms:
@@ -1070,11 +1099,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchFields:
                                           items:
                                             properties:
@@ -1086,14 +1117,17 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - nodeSelectorTerms
                                 type: object
@@ -1119,11 +1153,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1153,11 +1189,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1168,6 +1206,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
                                           type: string
                                       required:
@@ -1181,6 +1220,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
@@ -1197,11 +1237,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1231,11 +1273,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1246,12 +1290,14 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                           podAntiAffinity:
                             properties:
@@ -1273,11 +1319,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1307,11 +1355,13 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                    x-kubernetes-list-type: atomic
                                                 required:
                                                 - key
                                                 - operator
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
@@ -1322,6 +1372,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         topologyKey:
                                           type: string
                                       required:
@@ -1335,6 +1386,7 @@ spec:
                                   - weight
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
                                 items:
                                   properties:
@@ -1351,11 +1403,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1385,11 +1439,13 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             required:
                                             - key
                                             - operator
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         matchLabels:
                                           additionalProperties:
                                             type: string
@@ -1400,12 +1456,14 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     topologyKey:
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                         type: object
                       automountServiceAccountToken:
@@ -1417,10 +1475,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -1435,6 +1495,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1450,6 +1511,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -1473,6 +1551,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1485,12 +1564,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1501,6 +1584,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1508,6 +1592,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -1522,6 +1607,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -1539,6 +1625,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -1580,6 +1667,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -1597,6 +1685,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -1630,6 +1719,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -1639,6 +1730,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1649,6 +1741,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1669,6 +1762,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1743,6 +1837,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1753,6 +1848,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1773,6 +1869,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -1833,6 +1930,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -1847,20 +1946,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -1916,6 +2049,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -1926,6 +2060,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1946,6 +2081,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2008,6 +2144,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -2019,6 +2158,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -2028,18 +2169,25 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       dnsConfig:
                         properties:
                           nameservers:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           options:
                             items:
                               properties:
@@ -2049,10 +2197,12 @@ spec:
                                   type: string
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           searches:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                       dnsPolicy:
                         type: string
@@ -2065,10 +2215,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -2083,6 +2235,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2098,6 +2251,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2121,6 +2291,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2133,12 +2304,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2149,6 +2324,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2156,6 +2332,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -2170,6 +2347,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2187,6 +2365,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2228,6 +2407,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2245,6 +2425,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2278,6 +2459,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -2287,6 +2470,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2297,6 +2481,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2317,6 +2502,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2391,6 +2577,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2401,6 +2588,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2421,6 +2609,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2481,6 +2670,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -2495,20 +2686,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -2564,6 +2789,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2574,6 +2800,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2594,6 +2821,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -2658,6 +2886,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -2669,6 +2900,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -2678,12 +2911,18 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       hostAliases:
                         items:
                           properties:
@@ -2691,10 +2930,16 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ip:
                               type: string
+                          required:
+                          - ip
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
                       hostIPC:
                         type: boolean
                       hostNetwork:
@@ -2705,14 +2950,20 @@ spec:
                         type: boolean
                       hostname:
                         type: string
+                      hostnameOverride:
+                        type: string
                       imagePullSecrets:
                         items:
                           properties:
                             name:
+                              default: ""
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       initContainers:
                         items:
                           properties:
@@ -2720,10 +2971,12 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             command:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             env:
                               items:
                                 properties:
@@ -2738,6 +2991,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2753,6 +3007,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2776,6 +3047,7 @@ spec:
                                           key:
                                             type: string
                                           name:
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2788,12 +3060,16 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             envFrom:
                               items:
                                 properties:
                                   configMapRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2804,6 +3080,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2811,6 +3088,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             image:
                               type: string
                             imagePullPolicy:
@@ -2825,6 +3103,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2842,6 +3121,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2883,6 +3163,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
                                       properties:
@@ -2900,6 +3181,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         path:
                                           type: string
                                         port:
@@ -2933,6 +3215,8 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  type: string
                               type: object
                             livenessProbe:
                               properties:
@@ -2942,6 +3226,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -2952,6 +3237,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2972,6 +3258,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3046,6 +3333,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -3056,6 +3344,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3076,6 +3365,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3136,6 +3426,8 @@ spec:
                                     properties:
                                       name:
                                         type: string
+                                      request:
+                                        type: string
                                     required:
                                     - name
                                     type: object
@@ -3150,20 +3442,54 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
                                   type: boolean
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
                                 capabilities:
                                   properties:
                                     add:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     drop:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
                                   type: boolean
@@ -3219,6 +3545,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
                                   format: int32
@@ -3229,6 +3556,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3249,6 +3577,7 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     path:
                                       type: string
                                     port:
@@ -3311,6 +3640,9 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
                             volumeMounts:
                               items:
                                 properties:
@@ -3322,6 +3654,8 @@ spec:
                                     type: string
                                   readOnly:
                                     type: boolean
+                                  recursiveReadOnly:
+                                    type: string
                                   subPath:
                                     type: string
                                   subPathExpr:
@@ -3331,12 +3665,18 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
                             workingDir:
                               type: string
                           required:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       nodeName:
                         type: string
                       nodeSelector:
@@ -3375,18 +3715,16 @@ spec:
                           - conditionType
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       resourceClaims:
                         items:
                           properties:
                             name:
                               type: string
-                            source:
-                              properties:
-                                resourceClaimName:
-                                  type: string
-                                resourceClaimTemplateName:
-                                  type: string
-                              type: object
+                            resourceClaimName:
+                              type: string
+                            resourceClaimTemplateName:
+                              type: string
                           required:
                           - name
                           type: object
@@ -3394,6 +3732,39 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       restartPolicy:
                         type: string
                       runtimeClassName:
@@ -3414,6 +3785,15 @@ spec:
                         x-kubernetes-list-type: map
                       securityContext:
                         properties:
+                          appArmorProfile:
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            type: object
                           fsGroup:
                             format: int64
                             type: integer
@@ -3427,6 +3807,8 @@ spec:
                           runAsUser:
                             format: int64
                             type: integer
+                          seLinuxChangePolicy:
+                            type: string
                           seLinuxOptions:
                             properties:
                               level:
@@ -3452,6 +3834,9 @@ spec:
                               format: int64
                               type: integer
                             type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            type: string
                           sysctls:
                             items:
                               properties:
@@ -3464,6 +3849,7 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           windowsOptions:
                             properties:
                               gmsaCredentialSpec:
@@ -3505,6 +3891,7 @@ spec:
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       topologySpreadConstraints:
                         items:
                           properties:
@@ -3521,11 +3908,13 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
@@ -3562,9 +3951,7 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        items:
-                          x-kubernetes-preserve-unknown-fields: true
-                        type: array
+                        x-kubernetes-preserve-unknown-fields: true
                     required:
                     - containers
                     type: object


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

---

## Purpose

I was debugging an orphaned replicaset issue and realized the CRDs don't include making `spec.labels`  immutable like they do for the standard Kubernetes Deployment. 

After researching more I realized the CRDs in this repository are not up to date in the argo-rollouts source code repo.
