### PR TITLE
feat(argo-cd): Allow configuring external redis endpoint from secret

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.4.5
+version: 9.4.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add support for configuring HTTPRoute timeouts
+      description: Allow configuring external redis endpoint from secret

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1603,6 +1603,7 @@ If you want to use an existing Redis (eg. a managed service from a cloud provide
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | externalRedis.existingSecret | string | `""` | The name of an existing secret with Redis (must contain key `redis-password`. And should contain `redis-username` if username is not `default`) and Sentinel credentials. When it's set, the `externalRedis.username` and `externalRedis.password` parameters are ignored |
+| externalRedis.existingSecretServerKey | string | `""` | When set, the Redis server endpoint (host:port) is read from the existing secret under this key (e.g. `redis-server`). When it's set, `externalRedis.host` and `externalRedis.port` are ignored for the endpoint. The secret value must be in "host:port" format. |
 | externalRedis.host | string | `""` | External Redis server host |
 | externalRedis.password | string | `""` | External Redis password |
 | externalRedis.port | int | `6379` | External Redis server port |

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -64,14 +64,40 @@ Create redis name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Return Redis server endpoint
+Return Redis server endpoint (empty when endpoint is read from existingSecret via existingSecretServerKey)
 */}}
 {{- define "argo-cd.redis.server" -}}
 {{- $redisHa := (index .Values "redis-ha") -}}
 {{- if or (and .Values.redis.enabled (not $redisHa.enabled)) (and $redisHa.enabled $redisHa.haproxy.enabled) }}
     {{- printf "%s:%s" (include "argo-cd.redis.fullname" .)  (toString .Values.redis.servicePort) }}
+{{- else if and .Values.externalRedis.existingSecret .Values.externalRedis.existingSecretServerKey }}
+    {{- /* Endpoint from secret; do not output here */ -}}
 {{- else if and .Values.externalRedis.host .Values.externalRedis.port }}
     {{- printf "%s:%s" .Values.externalRedis.host (toString .Values.externalRedis.port) }}
+{{- end }}
+{{- end -}}
+
+{{/*
+True when external Redis is in use (host set or endpoint from existingSecret)
+*/}}
+{{- define "argo-cd.externalRedis.inUse" -}}
+{{- or .Values.externalRedis.host (and .Values.externalRedis.existingSecret .Values.externalRedis.existingSecretServerKey) -}}
+{{- end -}}
+
+{{/*
+valueFrom block for REDIS_SERVER env: secretKeyRef when endpoint comes from existingSecret, else configMapKeyRef
+*/}}
+{{- define "argo-cd.redisServerEnvRef" -}}
+{{- if and .Values.externalRedis.existingSecret .Values.externalRedis.existingSecretServerKey }}
+secretKeyRef:
+  name: {{ .Values.externalRedis.existingSecret }}
+  key: {{ .Values.externalRedis.existingSecretServerKey }}
+  optional: false
+{{- else }}
+configMapKeyRef:
+  name: argocd-cmd-params-cm
+  key: redis.server
+  optional: true
 {{- end }}
 {{- end -}}
 

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -228,10 +228,7 @@ spec:
                 optional: true
           - name: REDIS_SERVER
             valueFrom:
-              configMapKeyRef:
-                name: argocd-cmd-params-cm
-                key: redis.server
-                optional: true
+              {{- include "argo-cd.redisServerEnvRef" . | nindent 14 }}
           - name: REDIS_COMPRESSION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -224,10 +224,7 @@ spec:
                 optional: true
           - name: REDIS_SERVER
             valueFrom:
-              configMapKeyRef:
-                name: argocd-cmd-params-cm
-                key: redis.server
-                optional: true
+              {{- include "argo-cd.redisServerEnvRef" . | nindent 14 }}
           - name: REDIS_COMPRESSION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -168,10 +168,7 @@ spec:
                 optional: true
           - name: REDIS_SERVER
             valueFrom:
-              configMapKeyRef:
-                name: argocd-cmd-params-cm
-                key: redis.server
-                optional: true
+              {{- include "argo-cd.redisServerEnvRef" . | nindent 14 }}
           - name: REDIS_COMPRESSION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -224,10 +224,7 @@ spec:
                 optional: true
           - name: REDIS_SERVER
             valueFrom:
-              configMapKeyRef:
-                name: argocd-cmd-params-cm
-                key: redis.server
-                optional: true
+              {{- include "argo-cd.redisServerEnvRef" . | nindent 14 }}
           - name: REDIS_COMPRESSION
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/redis-secret-init/job.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (not (include "argo-cd.externalRedis.inUse" .)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/role.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (not (include "argo-cd.externalRedis.inUse" .)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled (not (include "argo-cd.externalRedis.inUse" .)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (not .Values.externalRedis.host) }}
+{{- if and .Values.redisSecretInit.enabled .Values.redisSecretInit.serviceAccount.create (not (include "argo-cd.externalRedis.inUse" .)) }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.redisSecretInit.serviceAccount.automountServiceAccountToken }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1849,6 +1849,9 @@ externalRedis:
   # -- The name of an existing secret with Redis (must contain key `redis-password`. And should contain `redis-username` if username is not `default`) and Sentinel credentials.
   # When it's set, the `externalRedis.username` and `externalRedis.password` parameters are ignored
   existingSecret: ""
+  # -- When set, the Redis server endpoint (host:port) is read from the existing secret under this key (e.g. `redis-server`).
+  # When it's set, `externalRedis.host` and `externalRedis.port` are ignored for the endpoint. The secret value must be in "host:port" format.
+  existingSecretServerKey: ""
   # -- External Redis Secret annotations
   secretAnnotations: {}
 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Description:
We are using Argo CD with AWS Elasticache, our Elasticache is provisioned via crossplane alongside the chart.
To be able to correctly point Argo we need to do two installs, or have Elasticache created separately because of the endpoint.
With this change we allow the redis endpoint when using `externalRedis` to be passed from the secret, it will be up to the user to ensure it is in `host:port`  format

Fixes #3735

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
