### PR TITLE
fix(argo-workflows): Allow controller to edit workflowartifactgctask's finalizers

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.7.10
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 0.47.4
+version: 0.47.5
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v3.7.10
+    - kind: fixed
+      description: Allow controller to edit workflowartifactgctask's finalizers

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -59,6 +59,7 @@ rules:
   - workflowtasksets/finalizers
   - workflowtasksets/status
   - workflowartifactgctasks
+  - workflowartifactgctasks/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION
Reason: I wanted to use `ArtifactGC` but opperation was failing with
```
time="2026-02-20T20:01:48.730Z" level=error msg="failed to GC artifacts" error="failed to create pod: pods \"...\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>" namespace=... workflow=...
```
I locally tested adding the mentioned permission, and it looks it fix the issue.

-----

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

