### PR TITLE
fix(argocd-image-updater): Fix zombie process accumulation

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: v1.1.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-image-updater to v1.1.1
+    - kind: fixed
+      description: Remove command override in deployment to allow Dockerfile ENTRYPOINT with tini init process to prevent zombie processes

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -34,8 +34,6 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ include "argocd-image-updater.fullname" . }}-controller
-          command:
-            - /manager
           args:
             - --metrics-bind-address=:{{ .Values.containerPorts.metrics }}
             - run


### PR DESCRIPTION
The Helm chart's deployment template explicitly sets `command: ["/manager"]`, which overrides the Dockerfile's `ENTRYPOINT` that uses tini as an init process. Without tini acting as PID 1, zombie processes accumulate because there is no init system to reap terminated child processes.

As can be seen in the [upstream Dockerfile](https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/refs/heads/master/Dockerfile), tini is explicitly installed and used as the entrypoint:

```dockerfile
RUN apk add ca-certificates git openssh-client aws-cli tini gpg gpg-agent
...
ENTRYPOINT ["/sbin/tini", "--", "/manager"]
```

Removing the `command` override from the chart's deployment template allows the Dockerfile's `ENTRYPOINT` with tini to function as intended.

**Before:**
```yaml
command: ["/manager"]
```

**After:**
```yaml
# command override removed
```

**Testing:**
Verified on a live cluster that zombie processes no longer accumulate after removing the command override and allowing tini to act as PID 1.