### PR TITLE
feat(argo-cd): Add TLSRoute configuration for Argo CD server

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -112,6 +112,12 @@ jobs:
           ## VPA CRDs not available in kind cluster
           rm charts/argo-cd/ci/vpa-values.yaml
 
+      - name: Skip Gateway API tests of ArgoCD
+        if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')
+        run: |
+          ## Gateway API CRDs not available in kind cluster
+          rm charts/argo-cd/ci/gateway-api-values.yaml
+
       - name: Create an external redis for ArgoCD externalRedis feature
         if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')
         run: |

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.14
+version: 9.5.15
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.4.2
+    - kind: added
+      description: Add Gateway API TLSRoute support for Argo CD server

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -305,6 +305,26 @@ server:
         sectionName: grpc
 ```
 
+#### Gateway API with TLS passthrough
+
+For end-to-end TLS where the Argo CD server keeps handling TLS, use TLSRoute to route traffic based on SNI:
+
+```yaml
+configs:
+  params:
+    server.insecure: false  # HTTPS backend
+
+server:
+  tlsroute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+        sectionName: tls-passthrough
+    hostnames:
+      - argocd.example.com
+```
+
 #### Gateway API with TLS backend
 
 For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy (experimental, v1alpha3):

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1359,6 +1359,12 @@ NAME: my-release
 | server.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | server.serviceAccount.name | string | `"argocd-server"` | Server service account name |
 | server.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
+| server.tlsroute.annotations | object | `{}` | Additional TLSRoute annotations |
+| server.tlsroute.enabled | bool | `false` | Enable TLSRoute resource for Argo CD server (Gateway API) |
+| server.tlsroute.hostnames | list | `[]` (See [values.yaml]) | List of hostnames to match against SNI |
+| server.tlsroute.labels | object | `{}` | Additional TLSRoute labels |
+| server.tlsroute.parentRefs | list | `[]` (See [values.yaml]) | Gateway API parentRefs for the TLSRoute |
+| server.tlsroute.rules | list | `[]` (See [values.yaml]) | TLSRoute rules configuration If not specified, a default rule routing to the server service is created |
 | server.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | server.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the Argo CD server |
 | server.volumeMounts | list | `[]` | Additional volumeMounts to the server main container |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -304,6 +304,26 @@ server:
         sectionName: grpc
 ```
 
+#### Gateway API with TLS passthrough
+
+For end-to-end TLS where the Argo CD server keeps handling TLS, use TLSRoute to route traffic based on SNI:
+
+```yaml
+configs:
+  params:
+    server.insecure: false  # HTTPS backend
+
+server:
+  tlsroute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+        sectionName: tls-passthrough
+    hostnames:
+      - argocd.example.com
+```
+
 #### Gateway API with TLS backend
 
 For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy (experimental, v1alpha3):

--- a/charts/argo-cd/ci/gateway-api-values.yaml
+++ b/charts/argo-cd/ci/gateway-api-values.yaml
@@ -1,0 +1,12 @@
+# Test Gateway API TLSRoute for Argo CD server
+crds:
+  keep: false
+server:
+  tlsroute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: example-gateway-namespace
+        sectionName: tls-passthrough
+    hostnames:
+      - argocd.example.com

--- a/charts/argo-cd/templates/argocd-server/tlsroute.yaml
+++ b/charts/argo-cd/templates/argocd-server/tlsroute.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.server.tlsroute.enabled -}}
+{{- $fullName := include "argo-cd.server.fullname" . -}}
+{{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
+{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include  "argo-cd.namespace" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    {{- with .Values.server.tlsroute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.tlsroute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.server.tlsroute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.tlsroute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with .Values.server.tlsroute.rules }}
+      {{- toYaml . | nindent 4 }}
+    {{- else }}
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $servicePort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2765,6 +2765,39 @@ server:
         #         - name: X-Custom-Header
         #           value: custom-value
 
+  # Gateway API TLSRoute configuration
+  # NOTE: Gateway API support is in EXPERIMENTAL status
+  # Support depends on your Gateway controller implementation
+  # Refer to https://gateway-api.sigs.k8s.io/implementations/ for controller-specific details
+  tlsroute:
+    # -- Enable TLSRoute resource for Argo CD server (Gateway API)
+    enabled: false
+    # -- Additional TLSRoute labels
+    labels: {}
+    # -- Additional TLSRoute annotations
+    annotations: {}
+    # -- Gateway API parentRefs for the TLSRoute
+    ## Must reference an existing Gateway
+    # @default -- `[]` (See [values.yaml])
+    parentRefs: []
+      # - name: example-gateway
+      #   namespace: example-gateway-namespace
+      #   sectionName: tls-passthrough
+    # -- List of hostnames to match against SNI
+    # @default -- `[]` (See [values.yaml])
+    hostnames: []
+      # - argocd.example.com
+    # -- TLSRoute rules configuration
+    # If not specified, a default rule routing to the server service is created
+    # @default -- `[]` (See [values.yaml])
+    rules: []
+      # - backendRefs:
+      #     - group: ""
+      #       kind: Service
+      #       name: argocd-server
+      #       port: 443
+      #       weight: 1
+
   # Gateway API BackendTLSPolicy configuration
   # NOTE: BackendTLSPolicy support is in EXPERIMENTAL status
   # Required for HTTPS backends when using Gateway API


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->


**Motivation**

Sometimes we want to have end-to-end tls encryption. Argocd server has already a https listener, so if we are using [gateway api](https://gateway-api.sigs.k8s.io/guides/getting-started/simple-gateway) (recommended after [ingress nginx retirement](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)), we need a [TLSRoute](https://gateway-api.sigs.k8s.io/api-types/tlsroute) to route tls traffic up to the argocd endpoint.


**What this PR does / why we need it**:

This PR adds support for [Gateway API TLSRoute](https://gateway-api.sigs.k8s.io/api-types/tlsroute/) resource to the Argo CD Helm chart. TLSRoute enables TLS passthrough or termination at the Gateway level, allowing traffic routing based on the hostname (= SNI = Server Name Indication) without requiring the Gateway to decrypt the traffic. This is particularly useful for scenarios where:

- TLS termination needs to happen at the backend service (passthrough mode)
- Gateway-based routing is required for TLS traffic
- Integration with Gateway API-compatible ingress controllers like Envoy Gateway, Istio, or Cilium

**Special notes**:

- TLSRoute support is marked as **EXPERIMENTAL** (like HTTPRoute and GRPCRoute)
- Requires Gateway API CRDs to be installed in the cluster
- The API version used is `gateway.networking.k8s.io/v1` (standard for TLSRoute)
- The implementation dynamically selects the correct service port (HTTP 80 or HTTPS 443) based on the `server.insecure` configuration
- If no custom rules are specified, a sensible default rule is created that routes to the argocd-server service

**Release notes**:

```markdown
- Add Gateway API TLSRoute support for Argo CD server with configurable parentRefs, hostnames, and routing rules
```

**Tests**:

- Manual template rendering verification with various configurations

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->