### PR TITLE
fix(argo-cd): quote VPA updateMode to prevent YAML boolean coercion

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.4.14
+version: 9.4.15
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Omit runAsUser for dex when deployed on OpenShift
+      description: Quote VPA updateMode to prevent YAML boolean coercion of Off to false and fix annotations typo

--- a/charts/argo-cd/templates/argocd-application-controller/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/vpa.yaml
@@ -10,7 +10,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with .Values.controller.vpa.annotations }}
-  annnotaions:
+  annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -23,7 +23,7 @@ spec:
     {{- end }}
     name: {{ template "argo-cd.controller.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.controller.vpa.updateMode }}
+    updateMode: {{ .Values.controller.vpa.updateMode | quote }}
   resourcePolicy:
     containerPolicies:
     - containerName: {{ .Values.controller.name }}


### PR DESCRIPTION
## Summary

- Quote `updateMode` in the VPA template to prevent YAML from interpreting `Off` as boolean `false`
- Fix `annnotaions` typo (3 n's) to `annotations`

## Problem

`charts/argo-cd/templates/argocd-application-controller/vpa.yaml` line 26 renders `updateMode` without quoting:

```yaml
updateMode: {{ .Values.controller.vpa.updateMode }}
```

When set to `"Off"`, Helm outputs `updateMode: Off` which YAML interprets as boolean `false`. The valid VPA updateMode values are strings: `Off`, `Initial`, `Recreate`, `Auto`.

## Fix

```yaml
updateMode: {{ .Values.controller.vpa.updateMode | quote }}
```

Fixes #3789

## Checklist

- [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning) (9.4.14 -> 9.4.15)
- [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) (ran helm-docs, no README changes needed)
- [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog)
- [x] Any new values are backwards compatible and/or have sensible default.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
- [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
- [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/))