### PR TITLE
ci(github): add draft PR lifecycle workflows

### DIFF
--- a/.github/workflows/default-pr-to-draft.yaml
+++ b/.github/workflows/default-pr-to-draft.yaml
@@ -1,0 +1,37 @@
+name: Default PR to Draft
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+jobs:
+  default-to-draft:
+    name: Convert PR to draft and add label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Convert PR to draft and add "Mark Ready When Ready" label
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Convert to draft
+        if: github.event.pull_request.draft == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr ready --undo ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+
+      - name: Add Mark Ready When Ready label
+        if: "!contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "Mark Ready When Ready" --repo ${{ github.repository }}

--- a/.github/workflows/mark-ready-when-ready.yaml
+++ b/.github/workflows/mark-ready-when-ready.yaml
@@ -1,0 +1,34 @@
+name: Mark PR Ready When Ready
+
+on:
+  pull_request_target:
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+jobs:
+  mark-ready:
+    name: Mark as ready after successful checks
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read        # Read CI check results to determine if PR is ready
+      contents: write     # Required by kenyonj/mark-ready-when-ready action
+      pull-requests: write # Mark the draft PR as ready for review
+      statuses: read      # Read commit statuses to determine if PR is ready
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
+      github.event.pull_request.draft == true
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Mark ready when ready
+        uses: kenyonj/mark-ready-when-ready@0ef6176fc2ddef5bab6cb4ab9517a37f0c153ba4 # v1.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ Argo Helm is a collection of **community maintained** charts. Therefore we rely 
 All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests. See the above stated requirements for PR on this project.
 
 > **Note**
-> Please create a separate Pull Request for each chart.
-> e.g: If your changes involve both argo-cd and argo-rollouts, please submit one PR for argo-cd and another separate.
+> Please start your pull request in draft mode and add the `Mark Ready When Ready` label to your PR. This will transition your PR automatically to ready when all of the checks have passed. This allows you to iterate on your PR if failures occur without notifying maintainers to review it until it is ready. Thank you for your understanding and cooperation.
 
 ### Pull Request Title Linting
 


### PR DESCRIPTION
## What

Add two GitHub Actions workflows to enforce a draft-first PR lifecycle. All newly opened PRs are automatically converted to draft and labeled with `Mark Ready When Ready`. Once all checks pass, the label triggers automatic promotion to ready for review.

## Why

Reduces manual toil for contributors -- no need to remember to open as draft or manually mark ready after CI passes. The automation handles the full lifecycle by default.

## Notes

- Both workflows use `pull_request_target` instead of `pull_request` so the `GITHUB_TOKEN` retains write permissions for PRs from forks. GitHub caps fork PR tokens at read-only on `pull_request` events regardless of the `permissions` block.
- `pull_request_target` is safe here because neither workflow checks out or executes code from the PR branch -- they only invoke pinned-SHA actions.
- `default-pr-to-draft.yaml` triggers only on `opened` to avoid fighting with `mark-ready-when-ready.yaml` when a PR is promoted -- no re-draft loop possible.
- `mark-ready-when-ready.yaml` renamed from `.yml` and updated to comply with GHA standards: `permissions: {}` at workflow level, job-level permissions with comments, corrected concurrency group key.
- `contents: write` on the mark-ready job is retained -- required internally by the `kenyonj/mark-ready-when-ready` action.
- The `Mark Ready When Ready` label must exist in the repo (already created).