### PR TITLE
feat(argocd-image-updater): Add missing config values, webhook support, and controller flags

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -19,12 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add missing config values (log.format, interval, max_concurrent_apps, max_concurrent_reconciles, argocd.namespace)
-    - kind: added
-      description: Add webhook configuration values (webhook.enable, webhook.port, webhook.ratelimit-allowed)
-    - kind: added
-      description: Add Aliyun ACR and CloudEvents webhook secret env vars to deployment
-    - kind: added
-      description: Add metricsSecure and enableHTTP2 values as first-class controller args
-    - kind: added
-      description: Wire health-probe-bind-address arg to containerPorts.health value
+      description: Add missing config values, webhook support, and controller flags

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add first-class values for missing config keys (log.format, interval, concurrency), webhook support (enable, port, rate-limit, ACR/CloudEvents secrets), controller flags (metricsSecure, enableHTTP2), and health-probe-bind-address wiring
+      description: Wire ALIYUN_ACR_WEBHOOK_SECRET and CLOUDEVENTS_WEBHOOK_SECRET env vars, add metricsSecure and enableHTTP2 controller flags, and bind --health-probe-bind-address to containerPorts.health

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 1.1.3
+version: 1.2.0
 appVersion: v1.1.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,13 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Remove command override in deployment to allow Dockerfile ENTRYPOINT with tini init process to prevent zombie processes
+    - kind: added
+      description: Add missing config values (log.format, interval, max_concurrent_apps, max_concurrent_reconciles, argocd.namespace)
+    - kind: added
+      description: Add webhook configuration values (webhook.enable, webhook.port, webhook.ratelimit-allowed)
+    - kind: added
+      description: Add Aliyun ACR and CloudEvents webhook secret env vars to deployment
+    - kind: added
+      description: Add metricsSecure and enableHTTP2 values as first-class controller args
+    - kind: added
+      description: Wire health-probe-bind-address arg to containerPorts.health value

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add missing config values, webhook support, and controller flags
+      description: Add first-class values for missing config keys (log.format, interval, concurrency), webhook support (enable, port, rate-limit, ACR/CloudEvents secrets), controller flags (metricsSecure, enableHTTP2), and health-probe-bind-address wiring

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: v1.2.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-image-updater to v1.2.1
+    - kind: added
+      description: Wire ALIYUN_ACR_WEBHOOK_SECRET and CLOUDEVENTS_WEBHOOK_SECRET env vars, add metricsSecure and enableHTTP2 controller flags, and bind --health-probe-bind-address to containerPorts.health

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -82,7 +82,6 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | authScripts.enabled | bool | `false` | Whether to mount the defined scripts that can be used to authenticate with a registry, the scripts will be mounted at `/scripts` |
 | authScripts.name | string | `"argocd-image-updater-authscripts"` | Name of the authentication scripts ConfigMap |
 | authScripts.scripts | object | `{}` | Map of key-value pairs where the key consists of the name of the script and the value the contents. |
-| config."argocd.namespace" | string | `""` | Namespace where ArgoCD runs in (defaults to the controller namespace) |
 | config."git.commit-message-template" | string | `""` | Changing the Git commit message |
 | config."git.commit-sign-off" | bool | `false` | Enables sign off on commits |
 | config."git.commit-signing-key" | string | `""` | Path to public SSH key mounted in container, or GPG key ID used to sign commits |
@@ -90,14 +89,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | config."git.email" | string | `""` | E-Mail address to use for Git commits |
 | config."git.user" | string | `""` | Username to use for Git commits |
 | config."kube.events" | bool | `false` | Disable kubernetes events |
-| config."log.format" | string | `""` | Argo CD Image Updater log format (`text` or `json`) |
 | config."log.level" | string | `"info"` | Argo CD Image Update log level |
-| config."webhook.enable" | string | `""` | Enable webhook server for receiving registry events |
-| config."webhook.port" | string | `""` | Port to listen on for webhook events |
-| config."webhook.ratelimit-allowed" | string | `""` | The number of allowed requests per hour for webhook rate limiting (0 disables) |
-| config.interval | string | `""` | Interval for how often to check for updates (e.g. `2m`, `5m`) |
-| config.max_concurrent_apps | string | `""` | Maximum number of ArgoCD applications that can be updated concurrently |
-| config.max_concurrent_reconciles | string | `""` | Maximum number of concurrent Reconciles which can be run |
 | config.name | string | `"argocd-image-updater-config"` | Name of the ConfigMap |
 | config.registries | list | `[]` | Argo CD Image Updater registries list configuration. More information [here](https://argocd-image-updater.readthedocs.io/en/stable/configuration/registries/). |
 | config.sshConfig.config | string | `""` | Argo CD Image Updater ssh client parameter configuration |

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -112,7 +112,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | createClusterRoles | bool | `true` | Create cluster roles for cluster-wide installation. |
 | dualStack.ipFamilies | list | `[]` | IP families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |
 | dualStack.ipFamilyPolicy | string | `""` | IP family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) |
-| enableHTTP2 | bool | `false` | Enable HTTP/2 for the metrics and webhook servers |
+| enableHTTP2 | bool | `nil` | Enable HTTP/2 for the metrics and webhook servers. Upstream default is `false`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely. |
 | extraArgs | list | `[]` | Extra arguments for argocd-image-updater not defined in `config.argocd`. If a flag contains both key and value, they need to be split to a new entry. |
 | extraEnv | list | `[]` | Extra environment variables for argocd-image-updater. |
 | extraEnvFrom | list | `[]` | Extra envFrom to pass to argocd-image-updater |
@@ -144,7 +144,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
 | metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
-| metricsSecure | bool | `true` | Serve metrics endpoint securely via HTTPS (default `true`). Set to `false` to use HTTP |
+| metricsSecure | bool | `nil` | Serve metrics endpoint securely via HTTPS. Upstream default is `true`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely. |
 | nameOverride | string | `""` | Global name (argocd-image-updater.name in _helpers.tpl) override |
 | namespaceOverride | string | `""` | Global namespace (argocd-image-updater.namespace in _helpers.tpl) override |
 | nodeSelector | object | `{}` | Kubernetes nodeSelector settings for the deployment |

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -82,6 +82,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | authScripts.enabled | bool | `false` | Whether to mount the defined scripts that can be used to authenticate with a registry, the scripts will be mounted at `/scripts` |
 | authScripts.name | string | `"argocd-image-updater-authscripts"` | Name of the authentication scripts ConfigMap |
 | authScripts.scripts | object | `{}` | Map of key-value pairs where the key consists of the name of the script and the value the contents. |
+| config."argocd.namespace" | string | `""` | Namespace where ArgoCD runs in (defaults to the controller namespace) |
 | config."git.commit-message-template" | string | `""` | Changing the Git commit message |
 | config."git.commit-sign-off" | bool | `false` | Enables sign off on commits |
 | config."git.commit-signing-key" | string | `""` | Path to public SSH key mounted in container, or GPG key ID used to sign commits |
@@ -89,7 +90,14 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | config."git.email" | string | `""` | E-Mail address to use for Git commits |
 | config."git.user" | string | `""` | Username to use for Git commits |
 | config."kube.events" | bool | `false` | Disable kubernetes events |
+| config."log.format" | string | `""` | Argo CD Image Updater log format (`text` or `json`) |
 | config."log.level" | string | `"info"` | Argo CD Image Update log level |
+| config."webhook.enable" | string | `""` | Enable webhook server for receiving registry events |
+| config."webhook.port" | string | `""` | Port to listen on for webhook events |
+| config."webhook.ratelimit-allowed" | string | `""` | The number of allowed requests per hour for webhook rate limiting (0 disables) |
+| config.interval | string | `""` | Interval for how often to check for updates (e.g. `2m`, `5m`) |
+| config.max_concurrent_apps | string | `""` | Maximum number of ArgoCD applications that can be updated concurrently |
+| config.max_concurrent_reconciles | string | `""` | Maximum number of concurrent Reconciles which can be run |
 | config.name | string | `"argocd-image-updater-config"` | Name of the ConfigMap |
 | config.registries | list | `[]` | Argo CD Image Updater registries list configuration. More information [here](https://argocd-image-updater.readthedocs.io/en/stable/configuration/registries/). |
 | config.sshConfig.config | string | `""` | Argo CD Image Updater ssh client parameter configuration |
@@ -104,6 +112,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | createClusterRoles | bool | `true` | Create cluster roles for cluster-wide installation. |
 | dualStack.ipFamilies | list | `[]` | IP families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |
 | dualStack.ipFamilyPolicy | string | `""` | IP family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) |
+| enableHTTP2 | bool | `false` | Enable HTTP/2 for the metrics and webhook servers |
 | extraArgs | list | `[]` | Extra arguments for argocd-image-updater not defined in `config.argocd`. If a flag contains both key and value, they need to be split to a new entry. |
 | extraEnv | list | `[]` | Extra environment variables for argocd-image-updater. |
 | extraEnvFrom | list | `[]` | Extra envFrom to pass to argocd-image-updater |
@@ -135,6 +144,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
 | metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| metricsSecure | bool | `true` | Serve metrics endpoint securely via HTTPS (default `true`). Set to `false` to use HTTP |
 | nameOverride | string | `""` | Global name (argocd-image-updater.name in _helpers.tpl) override |
 | namespaceOverride | string | `""` | Global namespace (argocd-image-updater.namespace in _helpers.tpl) override |
 | nodeSelector | object | `{}` | Kubernetes nodeSelector settings for the deployment |

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -121,6 +121,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | createClusterRoles | bool | `true` | Create cluster roles for cluster-wide installation. |
 | dualStack.ipFamilies | list | `[]` | IP families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |
 | dualStack.ipFamilyPolicy | string | `""` | IP family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) |
+| enableHTTP2 | bool | `nil` | Enable HTTP/2 for the metrics and webhook servers. Upstream default is `false`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely. |
 | extraArgs | list | `[]` | Extra arguments for argocd-image-updater not defined in `config.argocd`. If a flag contains both key and value, they need to be split to a new entry. |
 | extraEnv | list | `[]` | Extra environment variables for argocd-image-updater. |
 | extraEnvFrom | list | `[]` | Extra envFrom to pass to argocd-image-updater |
@@ -152,6 +153,7 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
 | metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| metricsSecure | bool | `nil` | Serve metrics endpoint securely via HTTPS. Upstream default is `true`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely. |
 | nameOverride | string | `""` | Global name (argocd-image-updater.name in _helpers.tpl) override |
 | namespaceOverride | string | `""` | Global namespace (argocd-image-updater.namespace in _helpers.tpl) override |
 | nodeSelector | object | `{}` | Kubernetes nodeSelector settings for the deployment |

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -37,11 +37,11 @@ spec:
           args:
             - --metrics-bind-address=:{{ .Values.containerPorts.metrics }}
             - --health-probe-bind-address=:{{ .Values.containerPorts.health }}
-            {{- if not .Values.metricsSecure }}
-            - --metrics-secure=false
+            {{- if kindIs "bool" .Values.metricsSecure }}
+            - --metrics-secure={{ .Values.metricsSecure }}
             {{- end }}
-            {{- if .Values.enableHTTP2 }}
-            - --enable-http2
+            {{- if kindIs "bool" .Values.enableHTTP2 }}
+            - --enable-http2={{ .Values.enableHTTP2 }}
             {{- end }}
             - run
             {{- with .Values.extraArgs }}

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -36,6 +36,13 @@ spec:
         - name: {{ include "argocd-image-updater.fullname" . }}-controller
           args:
             - --metrics-bind-address=:{{ .Values.containerPorts.metrics }}
+            - --health-probe-bind-address=:{{ .Values.containerPorts.health }}
+            {{- if not .Values.metricsSecure }}
+            - --metrics-secure=false
+            {{- end }}
+            {{- if .Values.enableHTTP2 }}
+            - --enable-http2
+            {{- end }}
             - run
             {{- with .Values.extraArgs }}
               {{- toYaml . | nindent 12 }}
@@ -148,6 +155,18 @@ spec:
               secretKeyRef:
                 name: argocd-image-updater-secret
                 key: webhook.harbor-secret
+                optional: true
+          - name: ALIYUN_ACR_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: argocd-image-updater-secret
+                key: webhook.aliyun-acr-secret
+                optional: true
+          - name: CLOUDEVENTS_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: argocd-image-updater-secret
+                key: webhook.cloudevents-secret
                 optional: true
           - name: WEBHOOK_RATELIMIT_ALLOWED
             valueFrom:

--- a/charts/argocd-image-updater/templates/deployment.yaml
+++ b/charts/argocd-image-updater/templates/deployment.yaml
@@ -36,6 +36,13 @@ spec:
         - name: {{ include "argocd-image-updater.fullname" . }}-controller
           args:
             - --metrics-bind-address=:{{ .Values.containerPorts.metrics }}
+            - --health-probe-bind-address=:{{ .Values.containerPorts.health }}
+            {{- if kindIs "bool" .Values.metricsSecure }}
+            - --metrics-secure={{ .Values.metricsSecure }}
+            {{- end }}
+            {{- if kindIs "bool" .Values.enableHTTP2 }}
+            - --enable-http2={{ .Values.enableHTTP2 }}
+            {{- end }}
             - run
             {{- with .Values.extraArgs }}
               {{- toYaml . | nindent 12 }}
@@ -160,6 +167,12 @@ spec:
               secretKeyRef:
                 name: argocd-image-updater-secret
                 key: webhook.aliyun-acr-secret
+                optional: true
+          - name: CLOUDEVENTS_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: argocd-image-updater-secret
+                key: webhook.cloudevents-secret
                 optional: true
           - name: WEBHOOK_RATELIMIT_ALLOWED
             valueFrom:

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -36,6 +36,12 @@ namespaceOverride: ""
 ## If you want to use this, please set `.Values.rbac.enabled` true as well.
 createClusterRoles: true
 
+# -- Serve metrics endpoint securely via HTTPS (default `true`). Set to `false` to use HTTP
+metricsSecure: true
+
+# -- Enable HTTP/2 for the metrics and webhook servers
+enableHTTP2: false
+
 # -- Extra arguments for argocd-image-updater not defined in `config.argocd`.
 # If a flag contains both key and value, they need to be split to a new entry.
 extraArgs: []
@@ -153,8 +159,33 @@ config:
   # -- Method used to sign Git commits. `openpgp` or `ssh`
   git.commit-signing-method: ""
 
+  # -- Argo CD Image Updater log format (`text` or `json`)
+  log.format: ""
+
   # -- Argo CD Image Update log level
   log.level: "info"
+
+  # -- Interval for how often to check for updates (e.g. `2m`, `5m`)
+  interval: ""
+
+  # -- Maximum number of ArgoCD applications that can be updated concurrently
+  max_concurrent_apps: ""
+
+  # -- Maximum number of concurrent Reconciles which can be run
+  max_concurrent_reconciles: ""
+
+  # -- Namespace where ArgoCD runs in (defaults to the controller namespace)
+  argocd.namespace: ""
+
+  # -- Enable webhook server for receiving registry events
+  webhook.enable: ""
+
+  # -- Port to listen on for webhook events
+  webhook.port: ""
+
+  # -- The number of allowed requests per hour for webhook rate limiting (0 disables)
+  webhook.ratelimit-allowed: ""
+
 
   # -- Argo CD Image Updater registries list configuration. More information [here](https://argocd-image-updater.readthedocs.io/en/stable/configuration/registries/).
   registries: []

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -36,11 +36,11 @@ namespaceOverride: ""
 ## If you want to use this, please set `.Values.rbac.enabled` true as well.
 createClusterRoles: true
 
-# -- Serve metrics endpoint securely via HTTPS (default `true`). Set to `false` to use HTTP
-metricsSecure: true
+# -- (bool) Serve metrics endpoint securely via HTTPS. Upstream default is `true`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely.
+metricsSecure:
 
-# -- Enable HTTP/2 for the metrics and webhook servers
-enableHTTP2: false
+# -- (bool) Enable HTTP/2 for the metrics and webhook servers. Upstream default is `false`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely.
+enableHTTP2:
 
 # -- Extra arguments for argocd-image-updater not defined in `config.argocd`.
 # If a flag contains both key and value, they need to be split to a new entry.

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -159,33 +159,8 @@ config:
   # -- Method used to sign Git commits. `openpgp` or `ssh`
   git.commit-signing-method: ""
 
-  # -- Argo CD Image Updater log format (`text` or `json`)
-  log.format: ""
-
   # -- Argo CD Image Update log level
   log.level: "info"
-
-  # -- Interval for how often to check for updates (e.g. `2m`, `5m`)
-  interval: ""
-
-  # -- Maximum number of ArgoCD applications that can be updated concurrently
-  max_concurrent_apps: ""
-
-  # -- Maximum number of concurrent Reconciles which can be run
-  max_concurrent_reconciles: ""
-
-  # -- Namespace where ArgoCD runs in (defaults to the controller namespace)
-  argocd.namespace: ""
-
-  # -- Enable webhook server for receiving registry events
-  webhook.enable: ""
-
-  # -- Port to listen on for webhook events
-  webhook.port: ""
-
-  # -- The number of allowed requests per hour for webhook rate limiting (0 disables)
-  webhook.ratelimit-allowed: ""
-
 
   # -- Argo CD Image Updater registries list configuration. More information [here](https://argocd-image-updater.readthedocs.io/en/stable/configuration/registries/).
   registries: []

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -36,6 +36,12 @@ namespaceOverride: ""
 ## If you want to use this, please set `.Values.rbac.enabled` true as well.
 createClusterRoles: true
 
+# -- (bool) Serve metrics endpoint securely via HTTPS. Upstream default is `true`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely.
+metricsSecure:
+
+# -- (bool) Enable HTTP/2 for the metrics and webhook servers. Upstream default is `false`. Only applies to the new `run` command (controller-runtime based). Leave unset to omit the flag entirely.
+enableHTTP2:
+
 # -- Extra arguments for argocd-image-updater not defined in `config.argocd`.
 # If a flag contains both key and value, they need to be split to a new entry.
 extraArgs: []


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

## Summary

This PR adds (per maintainer review, the `config:` value additions were dropped — only template wiring remains):

- **New webhook secrets** — `ALIYUN_ACR_WEBHOOK_SECRET` and `CLOUDEVENTS_WEBHOOK_SECRET` (new in v1.1.0 for ECR CloudEvents support) are now wired in the deployment template
- **Controller flags** — `metricsSecure` and `enableHTTP2` are now first-class values instead of requiring `extraArgs`
- **Health probe** — `--health-probe-bind-address` is now wired to `containerPorts.health` instead of being hardcoded

Boolean flags default to `nil`, so the CLI args are omitted entirely unless explicitly set — fully backwards compatible.

## Test plan

- [x] `helm template` with defaults renders correctly (no extra args)
- [x] `helm template` with `metricsSecure=false` and `enableHTTP2=true` renders correct CLI args
- [x] New env vars (ALIYUN_ACR_WEBHOOK_SECRET, CLOUDEVENTS_WEBHOOK_SECRET) appear in deployment
- [ ] Deploy with webhook enabled and verify CloudEvents webhook receives ECR events
