### PR TITLE
chore(github): pin artifacthub container image to digest SHA

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,7 +9,7 @@ jobs:
   linter-artifacthub:
     runs-on: ubuntu-latest
     container:
-      image: ecr-public.aws.com/artifacthub/ah:v1.14.0
+      image: ecr-public.aws.com/artifacthub/ah:v1.14.0@sha256:3773afcdeb5662c31576f1a9a0ee10bced7af2e80842ca06a186a50497e149a5
       options: --user 1001
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## What

Pin the ArtifactHub linter container image in lint-and-test.yml from a
mutable version tag to an immutable digest SHA, verified using crane.
Dependabot will update the digest in the future for us.

## Why

Mutable tags can be overwritten at the registry level, meaning the image
pulled during CI could silently change without any code change. Pinning
to a digest ensures the exact image layer content is always used.

## Notes

- Digest was resolved using `crane digest ecr-public.aws.com/artifacthub/ah:v1.14.0`
- `ghcr.io/renovatebot/renovate` in renovate.yaml uses `renovate-version`
  as a parameter passed to renovatebot/github-action, which appends it as
  a tag via string concatenation. Pinning that image by digest would
  require upstream support in the action and would break Renovate's
  auto-update directive. Left as a known gap.