### PR TITLE
feat(argo-cd): add additional annotation support for redis-secret-init RBAC resources

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.6
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.4.17
+version: 9.4.18
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: added
+      description: Add additional annotations support for redis-secret-init Role and RoleBinding
     - kind: changed
       description: Bump argo-cd to v3.3.6

--- a/charts/argo-cd/templates/redis-secret-init/role.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/role.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+    {{- range $key, $value := .Values.redisSecretInit.roleAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redisSecretInit.name "name" .Values.redisSecretInit.name) | nindent 4 }}
   name: {{ include "argo-cd.redisSecretInit.fullname" . }}

--- a/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/rolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+    {{- range $key, $value := .Values.redisSecretInit.roleBindingAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redisSecretInit.name "name" .Values.redisSecretInit.name) | nindent 4 }}
   name: {{ include "argo-cd.redisSecretInit.fullname" . }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1891,6 +1891,12 @@ redisSecretInit:
   # @default -- `""` (defaults to global.runtimeClassName)
   runtimeClassName: ""
 
+  # -- Annotations to be added to the Redis secret-init Role
+  roleAnnotations: {}
+
+  # -- Annotations to be added to the Redis secret-init RoleBinding
+  roleBindingAnnotations: {}
+
   # -- Annotations to be added to the Redis secret-init Job
   jobAnnotations: {}
 


### PR DESCRIPTION
When using Argo CD to manage the argo-cd helm chart, the redis-secret-init job and its associated RBAC resources (Role, RoleBinding, ServiceAccount) are managed as Helm hooks.

The current default helm.sh/hook-delete-policy: before-hook-creation can lead to timing issues. Specifically, Argocd is running is managing itself in Argocd this results in stuck in waiting for completion of hook batch/Job/argocd-redis-secret-init from [#2887](https://github.com/argoproj/argo-helm/issues/2887).

I have added support for adding additional annotations on the Role and RoleBinding resources for redis-secret-init. This allows users to overwrite the default hook delete policy with argocd.argoproj.io/hook-delete-policy: HookSucceeded (or other values), ensuring that the RBAC resources persist until the job has successfully completed and let argocd manage itself successfully.

Checklist:
* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).