### PR TITLE
feat(argo-workflows): add timeouts support to server HTTPRoute

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.4
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.8
+version: 1.0.9
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,8 +16,8 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix missing service account secrets
+    - kind: added
+      description: Add timeouts support to server HTTPRoute
       links:
         - name: GitHub Issue
-          url: https://github.com/argoproj/argo-helm/issues/3236
+          url: https://github.com/argoproj/argo-helm/issues/3832

--- a/charts/argo-workflows/templates/server/server-httproute.yaml
+++ b/charts/argo-workflows/templates/server/server-httproute.yaml
@@ -34,6 +34,10 @@ spec:
       filters:
       {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
       backendRefs:
         - group: ''
           kind: Service

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -834,6 +834,9 @@ server:
         #       add:
         #         - name: X-Custom-Header
         #           value: custom-value
+        # timeouts:
+        #   request: 10s
+        #   backendRequest: 2s
 
   # Gateway API BackendTLSPolicy configuration
   # NOTE: BackendTLSPolicy support is in EXPERIMENTAL status


### PR DESCRIPTION
close: https://github.com/argoproj/argo-helm/issues/3832

Thank you to the maintainers for your work.

Based on the following PR, I have implemented a change to allow configuring timeouts for the HTTPRoute in argo-workflows.
ref: https://github.com/argoproj/argo-helm/pull/3755

---

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
