### PR TITLE
fix(argo-cd): fixed externally managed redis secret marked as optional (#2836)

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.9
+version: 9.5.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix an issue with the applicationset webhook service port in the HTTPRoute
+      description: Fixed externally-managed Redis secret always defined as optional (#2836)

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -852,6 +852,9 @@ NAME: my-release
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apiVersionOverrides | object | `{}` |  |
+| configRefOptionality | object | `{"redisPasswordSecret":true,"redisUsernameSecret":true}` | Resources that reference other resources, e.g. env-vars injection from ConfigMaps or Secrets can be optional or required |
+| configRefOptionality.redisPasswordSecret | bool | `true` | Secret ref in argo-cd.redisPasswordSecretRef |
+| configRefOptionality.redisUsernameSecret | bool | `true` | Secret ref in argo-cd.redisUsernameSecretRef |
 | crds.additionalLabels | object | `{}` | Additional labels to be added to all CRDs |
 | crds.annotations | object | `{"argocd.argoproj.io/sync-options":"ServerSideApply=true"}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -291,7 +291,7 @@ optional: {{ if .Values.externalRedis.username }}false{{ else }}true{{ end }}
     {{- else -}}
 name: "argocd-redis"
 key: redis-username
-optional: true
+optional: {{ .Values.configRefOptionality.redisUsernameSecret }}
     {{- end -}}
 {{- end -}}
 
@@ -316,7 +316,7 @@ optional: false # Secret is not optional in this case !
     {{- /* All other use cases (e.g. disabled pre-install Job) */ -}}
 name: "argocd-redis"
 key: auth
-optional: true
+optional: {{ .Values.configRefOptionality.redisPasswordSecret }}
     {{- end -}}
 {{- end -}}
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -4511,3 +4511,10 @@ commitServer:
       # maxAllowed:
       #   cpu: 1
       #   memory: 1Gi
+
+# -- Resources that reference other resources, e.g. env-vars injection from ConfigMaps or Secrets can be optional or required
+configRefOptionality:
+  # -- Secret ref in argo-cd.redisUsernameSecretRef
+  redisUsernameSecret: true
+  # -- Secret ref in argo-cd.redisPasswordSecretRef
+  redisPasswordSecret: true


### PR DESCRIPTION
Fixes #2836 

Note, the settings for Redis in this chart is a little complicated. Generally the options are:

1. External redis (`.Values.externalRedis.host`)
   - `.Values.externalRedis.existingSecret` allow naming an external Redis secret
2. Internal redis (if not .Values.externalRedis.host` given)
   - Redis secret hardcoded to `argocd-redis`
   - If `.Values.redisSecretInit.enabled`, then Helm chart generates a secret
   - else an externally managed secret is assumed and reference is given with `optional: true`

The questionable part of this PR is how to make the `optional` be configurable - especially since there is no good section of the `values.yaml` file where an option could fit in - the "internal Redis with externally managed secret" does not have a section of its own. Since there are several other references that similarly are given with `optional: true` my thinking was to create a separate section for 'reference optinality' where other refences could be added in the future. The default values ensures that the change is backward compatible,

Hence, anyone using an externally managed Redis secret will need to add:

```
configRefOptionality:
  redisUsernameSecret: false
  redisPasswordSecret: false
```

with this, e.g. the application controller pod will have the following env-var settings:
```
        - name: REDIS_USERNAME
          valueFrom:
            secretKeyRef:
              name: "argocd-redis"
              key: redis-username
              optional: false.   # <-- note
        - name: REDIS_PASSWORD
          valueFrom:
            secretKeyRef:
              name: "argocd-redis"
              key: auth
              optional: false.   # <--- note
```

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
