### PR TITLE
fix(github): skip draft lifecycle workflows for bot-authored PRs

### DIFF
--- a/.github/workflows/default-pr-to-draft.yaml
+++ b/.github/workflows/default-pr-to-draft.yaml
@@ -2,18 +2,19 @@ name: Default PR to Draft
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  cancel-in-progress: true
 
 jobs:
   default-to-draft:
     name: Convert PR to draft and add label
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     permissions:
       pull-requests: write # Convert PR to draft and add "Mark Ready When Ready" label
     steps:

--- a/.github/workflows/mark-ready-when-ready.yaml
+++ b/.github/workflows/mark-ready-when-ready.yaml
@@ -8,7 +8,7 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  cancel-in-progress: true
 
 jobs:
   mark-ready:
@@ -20,6 +20,8 @@ jobs:
       pull-requests: write # Mark the draft PR as ready for review
       statuses: read      # Read commit statuses to determine if PR is ready
     if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
       github.event.pull_request.draft == true
     steps:


### PR DESCRIPTION
## What

Skip the default-to-draft and mark-ready-when-ready workflows when the PR author is dependabot or renovate. Also add the `reopened` trigger to default-to-draft and simplify the `cancel-in-progress` expressions.

## Why

GitHub blocks the `convertPullRequestToDraft` GraphQL mutation for bot-authored PRs, causing the default-to-draft workflow to fail with "Resource not accessible by integration" on every Dependabot and Renovate PR.

## Notes

- Bot exclusion uses `github.actor`, which reflects the PR author at event time. The job is skipped cleanly rather than failing.
- `reopened` trigger closes the close-then-reopen bypass for draft enforcement (carry-over fix from the previous PR that couldn't be force-pushed after review).
- `cancel-in-progress` simplified to `true` -- both workflows only fire on `pull_request_target` so the conditional expression was always evaluating to `true`.
- The root cause of the failure was not a missing permission. The token had `pull-requests: write`. GitHub simply does not allow `convertPullRequestToDraft` on bot-authored PRs regardless of token scope.

## Testing

- Verified against the failing run [#24927359479](https://github.com/argoproj/argo-helm/actions/runs/24927359479/job/72999439953) -- the Dependabot PR that triggered the failure was authored by `dependabot[bot]`, which now matches the skip condition.
- Manual verification: open a PR as a human author to confirm the workflow still runs as expected.

Checklist:

* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).