### PR TITLE
fix(argo-cd): fix ArgoAppNotSynced PrometheusRule annotation template syntax

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.4
+version: 9.5.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Set argo-cd parent repo as first source in Chart.yaml, so renovate can pull changelogs from parent repo.
+    - kind: fixed
+      description: Fix ArgoAppNotSynced PrometheusRule example annotations to use plain Prometheus template syntax instead of Helm raw-string escaping, which caused alertmanager to receive unrendered template expressions.

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1089,9 +1089,9 @@ controller:
       #   labels:
       #     severity: warning
       #   annotations:
-      #     summary: "[{{`{{$labels.name}}`}}] Application not synchronized"
+      #     summary: "[{{ $labels.name }}] Application not synchronized"
       #     description: >
-      #       The application [{{`{{$labels.name}}`}} has not been synchronized for over
+      #       The application {{ $labels.name }} has not been synchronized for over
       #       12 hours which means that the state of this cloud has drifted away from the
       #       state inside Git.
 


### PR DESCRIPTION
Fixes ArgoAppNotSynced PrometheusRule example annotations that use incorrect Helm raw-string escaping, which causes alertmanager template rendering failures (starting in Alertmanager v0.30.0). Also fixes an unclosed `[` bracket in the description annotation.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).