### PR TITLE
fix(github): correct renovate bot actor name in draft lifecycle workflows

### DIFF
--- a/.github/workflows/default-pr-to-draft.yaml
+++ b/.github/workflows/default-pr-to-draft.yaml
@@ -14,7 +14,7 @@ jobs:
   default-to-draft:
     name: Convert PR to draft and add label
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'argoproj-renovate[bot]'
     permissions:
       pull-requests: write # Convert PR to draft and add "Mark Ready When Ready" label
     steps:

--- a/.github/workflows/mark-ready-when-ready.yaml
+++ b/.github/workflows/mark-ready-when-ready.yaml
@@ -21,7 +21,7 @@ jobs:
       statuses: read      # Read commit statuses to determine if PR is ready
     if: |
       github.actor != 'dependabot[bot]' &&
-      github.actor != 'renovate[bot]' &&
+      github.actor != 'argoproj-renovate[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
       github.event.pull_request.draft == true
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ output
 .idea
 **/*.tgz
 **/charts/*/charts
+.worktrees


### PR DESCRIPTION
## What

Updates the bot actor check from `renovate[bot]` to `argoproj-renovate[bot]` in both the default-pr-to-draft and mark-ready-when-ready workflows, and adds `.worktrees` to `.gitignore`.

## Why

This repo uses a custom renovate bot (`argoproj-renovate[bot]`) rather than the generic `renovate[bot]`, so the skip conditions were not matching and renovate PRs were being incorrectly converted to draft.

## Notes

- The `.gitignore` entry for `.worktrees` is unrelated to the bot name fix but included as a prerequisite for local git worktree usage.

## Testing

Verified by checking the failing "Default PR to Draft" check on PR #3854 -- `github.actor` is `argoproj-renovate[bot]`, which did not match the previous `renovate[bot]` condition.

---

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).