### PR TITLE
feat(argo-cd): Make PrometheusRule API version field overridable like it is in ServiceMonitor manifests.

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.4
+version: 9.5.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Set argo-cd parent repo as first source in Chart.yaml, so renovate can pull changelogs from parent repo.
+    - kind: changed
+      description: Make PrometheusRule API version field overridable like it is in ServiceMonitor objects.

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,6 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Set argo-cd parent repo as first source in Chart.yaml, so renovate can pull changelogs from parent repo.
-    - kind: changed
       description: Make PrometheusRule API version field overridable like it is in ServiceMonitor objects.

--- a/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/prometheusrule.yaml
@@ -1,5 +1,6 @@
+{{- $apiVersion := include "argo-cd.apiVersions.monitoring" . }}
 {{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.controller.metrics.enabled .Values.controller.metrics.rules.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ $apiVersion }}
 kind: PrometheusRule
 metadata:
   name: {{ template "argo-cd.controller.fullname" . }}


### PR DESCRIPTION
Hi,

This PR fixes #3856.

It makes PrometheusRule API Version overridable by the Helm Chart user.

Let me know what you think,

Thanks

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
