### PR TITLE
feat(argo-cd): add AWS Gateway API support for gRPC backend routing

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.5
+version: 9.5.6
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix ArgoAppNotSynced PrometheusRule example annotations to use plain Prometheus template syntax instead of Helm raw-string escaping, which caused alertmanager to receive unrendered template expressions.
+    - kind: added
+      description: Adds AWS Load Balancer Controller Gateway API support for Argo CD server gRPC traffic.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1246,10 +1246,10 @@ NAME: my-release
 | server.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
 | server.httproute.aws.enabled | bool | `false` | Enable AWS Application Load Balancer options for the HTTPRoute |
 | server.httproute.aws.rules | list | `[]` (See [values.yaml]) | HTTPRoute rules configuration |
-| server.httproute.aws.targetGroupConfiguration | object | `{"annotations":{},"labels":{},"routeConfigurations":[{"routeIdentifier":{"kind":"HTTPRoute","name":"{{ template \"argo-cd.server.fullname\" . }}-grpc","namespace":"{{ .Release.Namespace }}"},"targetGroupProps":{"protocolVersion":"GRPC"}},{"routeIdentifier":{"kind":"HTTPRoute"},"targetGroupProps":{"protocolVersion":"HTTP1"}},{"routeIdentifier":{"kind":"GRPCRoute"},"targetGroupProps":{"protocolVersion":"GRPC"}}]}` | ALB target group configuration Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/ for details |
+| server.httproute.aws.targetGroupConfiguration | object | `{}` (See [values.yaml]) | ALB target group configuration Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/ for details |
 | server.httproute.aws.targetGroupConfiguration.annotations | object | `{}` | Additional HTTPRoute annotations |
 | server.httproute.aws.targetGroupConfiguration.labels | object | `{}` | Additional HTTPRoute labels |
-| server.httproute.aws.targetGroupConfiguration.routeConfigurations | list | `[{"routeIdentifier":{"kind":"HTTPRoute","name":"{{ template \"argo-cd.server.fullname\" . }}-grpc","namespace":"{{ .Release.Namespace }}"},"targetGroupProps":{"protocolVersion":"GRPC"}},{"routeIdentifier":{"kind":"HTTPRoute"},"targetGroupProps":{"protocolVersion":"HTTP1"}},{"routeIdentifier":{"kind":"GRPCRoute"},"targetGroupProps":{"protocolVersion":"GRPC"}}]` | Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/#route-matching-logic |
+| server.httproute.aws.targetGroupConfiguration.routeConfigurations | list | `[]` (See [values.yaml]) | Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/#route-matching-logic |
 | server.httproute.enabled | bool | `false` | Enable HTTPRoute resource for Argo CD server (Gateway API) |
 | server.httproute.hostnames | list | `[]` (See [values.yaml]) | List of hostnames for the HTTPRoute |
 | server.httproute.labels | object | `{}` | Additional HTTPRoute labels |

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1244,6 +1244,12 @@ NAME: my-release
 | server.grpcroute.rules | list | `[]` (See [values.yaml]) | GRPCRoute rules configuration |
 | server.hostNetwork | bool | `false` | Host Network for Server pods |
 | server.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| server.httproute.aws.enabled | bool | `false` | Enable AWS Application Load Balancer options for the HTTPRoute |
+| server.httproute.aws.rules | list | `[]` (See [values.yaml]) | HTTPRoute rules configuration |
+| server.httproute.aws.targetGroupConfiguration | object | `{"annotations":{},"labels":{},"routeConfigurations":[{"routeIdentifier":{"kind":"HTTPRoute","name":"{{ template \"argo-cd.server.fullname\" . }}-grpc","namespace":"{{ .Release.Namespace }}"},"targetGroupProps":{"protocolVersion":"GRPC"}},{"routeIdentifier":{"kind":"HTTPRoute"},"targetGroupProps":{"protocolVersion":"HTTP1"}},{"routeIdentifier":{"kind":"GRPCRoute"},"targetGroupProps":{"protocolVersion":"GRPC"}}]}` | ALB target group configuration Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/ for details |
+| server.httproute.aws.targetGroupConfiguration.annotations | object | `{}` | Additional HTTPRoute annotations |
+| server.httproute.aws.targetGroupConfiguration.labels | object | `{}` | Additional HTTPRoute labels |
+| server.httproute.aws.targetGroupConfiguration.routeConfigurations | list | `[{"routeIdentifier":{"kind":"HTTPRoute","name":"{{ template \"argo-cd.server.fullname\" . }}-grpc","namespace":"{{ .Release.Namespace }}"},"targetGroupProps":{"protocolVersion":"GRPC"}},{"routeIdentifier":{"kind":"HTTPRoute"},"targetGroupProps":{"protocolVersion":"HTTP1"}},{"routeIdentifier":{"kind":"GRPCRoute"},"targetGroupProps":{"protocolVersion":"GRPC"}}]` | Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/#route-matching-logic |
 | server.httproute.enabled | bool | `false` | Enable HTTPRoute resource for Argo CD server (Gateway API) |
 | server.httproute.hostnames | list | `[]` (See [values.yaml]) | List of hostnames for the HTTPRoute |
 | server.httproute.labels | object | `{}` | Additional HTTPRoute labels |

--- a/charts/argo-cd/templates/argocd-server/aws/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/httproute.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.server.httproute.enabled .Values.server.httproute.aws.enabled }}
+{{- $fullName := include "argo-cd.server.fullname" . -}}
+{{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
+{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "argo-cd.server.fullname" . }}-grpc
+  namespace: {{ include  "argo-cd.namespace" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    {{- with .Values.server.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.server.httproute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.server.httproute.aws.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $servicePort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/aws/targetgroupconfiguration.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/targetgroupconfiguration.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.server.httproute.enabled .Values.server.httproute.aws.enabled }}
+{{- $fullName := include "argo-cd.server.fullname" . -}}
+{{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
+{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
+apiVersion: gateway.k8s.aws/v1beta1
+kind: TargetGroupConfiguration
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include  "argo-cd.namespace" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    {{- with .Values.server.httproute.aws.targetGroupConfiguration.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.httproute.aws.targetGroupConfiguration.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetReferences:
+    - group: ''
+      kind: Service
+      name: {{ $fullName }}
+  {{- with .Values.server.httproute.aws.targetGroupConfiguration.routeConfigurations }}
+  routeConfigurations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2730,6 +2730,56 @@ server:
         #   request: 10s
         #   backendRequest: 2s
 
+    # AWS specific options for Application Load Balancer with Gateway API
+    aws:
+      # -- Enable AWS Application Load Balancer options for the HTTPRoute
+      enabled: false
+      # -- ALB target group configuration
+      # Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/ for details
+      targetGroupConfiguration:
+        # -- Additional HTTPRoute labels
+        labels: {}
+        # -- Additional HTTPRoute annotations
+        annotations: {}
+        # -- Route configuration
+        # -- Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/#route-matching-logic
+        routeConfigurations:
+          - routeIdentifier:
+              kind: HTTPRoute
+              name: |-
+                {{ template "argo-cd.server.fullname" . }}-grpc
+              namespace: "{{ .Release.Namespace }}"
+            targetGroupProps:
+              protocolVersion: GRPC
+          - routeIdentifier:
+              kind: HTTPRoute
+            targetGroupProps:
+              protocolVersion: HTTP1
+          - routeIdentifier:
+              kind: GRPCRoute
+            targetGroupProps:
+              protocolVersion: GRPC
+      # -- HTTPRoute rules configuration
+      # @default -- `[]` (See [values.yaml])
+      rules:
+        - matches:
+            - headers:
+                - name: Content-Type
+                  type: RegularExpression
+                  value: ^application/grpc.*
+              path:
+                type: PathPrefix
+                value: /
+          # filters: []
+          #   - type: RequestHeaderModifier
+          #     requestHeaderModifier:
+          #       add:
+          #         - name: X-Custom-Header
+          #           value: custom-value
+          # timeouts:
+          #   request: 10s
+          #   backendRequest: 2s
+
   # Gateway API GRPCRoute configuration
   # NOTE: Gateway API support is in EXPERIMENTAL status
   # Support depends on your Gateway controller implementation

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2736,6 +2736,7 @@ server:
       enabled: false
       # -- ALB target group configuration
       # Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/ for details
+      # @default -- `{}` (See [values.yaml])
       targetGroupConfiguration:
         # -- Additional HTTPRoute labels
         labels: {}
@@ -2743,6 +2744,7 @@ server:
         annotations: {}
         # -- Route configuration
         # -- Refer to https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/gateway/targetgroupconfig/#route-matching-logic
+        # @default -- `[]` (See [values.yaml])
         routeConfigurations:
           - routeIdentifier:
               kind: HTTPRoute


### PR DESCRIPTION
Description:

Adds AWS Load Balancer Controller Gateway API support for Argo CD server gRPC traffic.

Summary:
  - Adds an AWS-specific HTTPRoute for gRPC requests, matching Content-Type: application/grpc*.
  - Adds a TargetGroupConfiguration template for AWS ALB target group protocol settings.
  - Introduces server.httproute.aws values for enabling the feature, customizing route rules, labels, annotations, and target group route  configuration.
  - Defaults the gRPC route target group to protocolVersion: GRPC while preserving HTTP/1 behavior for non-gRPC HTTPRoute traffic.

References:

- https://github.com/argoproj/argo-helm/issues/3550#issuecomment-4332481448

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
