### PR TITLE
fix(argo-workflows): Updating argo-workflow CM generation to allow disabling built-in prometheus exporter

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.13
+version: 1.0.14
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,6 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Use Recreate deployment strategy when controller replicas is 1 to prevent two controllers running during rollout
+    - kind: fixed
+      description: Fix controller configmap generation so it disable argo-workflow built-in prometheus exporter when metricsConfig is set to false
+

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -18,4 +18,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: Fix controller configmap generation so it disable argo-workflow built-in prometheus exporter when metricsConfig is set to false
-

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -118,17 +118,17 @@ data:
       {{- toYaml .Values.customArtifactRepository | nindent 6 }}
       {{- end }}
     {{- end }}
-    {{- if .Values.controller.metricsConfig.enabled }}
+    {{- with .Values.controller.metricsConfig }}
     metricsConfig:
-      enabled: {{ .Values.controller.metricsConfig.enabled }}
-      path: {{ .Values.controller.metricsConfig.path }}
-      port: {{ .Values.controller.metricsConfig.port }}
-      {{- if .Values.controller.metricsConfig.metricsTTL }}
-      metricsTTL: {{ .Values.controller.metricsConfig.metricsTTL }}
+      enabled: {{ .enabled }}
+      path: {{ .path }}
+      port: {{ .port }}
+      {{- if .metricsTTL }}
+      metricsTTL: {{ .metricsTTL }}
       {{- end }}
-      ignoreErrors: {{ .Values.controller.metricsConfig.ignoreErrors }}
-      secure: {{ .Values.controller.metricsConfig.secure }}
-      {{- with .Values.controller.metricsConfig.modifiers }}
+      ignoreErrors: {{ .ignoreErrors }}
+      secure: {{ .secure }}
+      {{- with .modifiers }}
       modifiers:
         {{- toYaml . | nindent 8 }} 
       {{- end }}  


### PR DESCRIPTION
Hi,

This PR fixes #3751.

Let me know what you think,

rurod

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
