### PR TITLE
feat(argo-workflows): add deploymentStrategy values for controller and server

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.5
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.13
+version: 1.0.14
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Use Recreate deployment strategy when controller replicas is 1 to prevent two controllers running during rollout
+    - kind: added
+      description: Add `controller.deploymentStrategy` and `server.deploymentStrategy` values so operators running 2+ replicas can opt into a zero-downtime rolling update strategy

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -262,6 +262,7 @@ Fields to note:
 | controller.configMap.name | string | `""` | ConfigMap name |
 | controller.cronWorkflowWorkers | string | `nil` | Number of cron workflow workers Only valid for 3.5+ |
 | controller.deploymentAnnotations | object | `{}` | deploymentAnnotations is an optional map of annotations to be applied to the controller Deployment |
+| controller.deploymentStrategy | object | `{}` | Deployment strategy for the workflow-controller. When set, it takes precedence over the chart's default of `type: Recreate` for `replicas: 1`, allowing operators with `replicas: 2+` to opt into a zero-downtime rolling strategy (e.g. `maxUnavailable: 0, maxSurge: 1`). |
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
@@ -408,6 +409,7 @@ Fields to note:
 | server.clusterWorkflowTemplates.enableEditing | bool | `true` | Give the server permissions to edit ClusterWorkflowTemplates. |
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |
 | server.deploymentAnnotations | object | `{}` | optional map of annotations to be applied to the ui Deployment |
+| server.deploymentStrategy | object | `{}` | Deployment strategy for the argo server. When unset, Kubernetes uses the default RollingUpdate (25%/25%); set this to opt into zero-downtime rolls (e.g. `maxUnavailable: 0, maxSurge: 1`) when running 2+ replicas. |
 | server.enabled | bool | `true` | Deploy the Argo Server |
 | server.extraArgs | list | `[]` | Extra arguments to provide to the Argo server binary. |
 | server.extraContainers | list | `[]` | Extra containers to be added to the server deployment |

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -13,7 +13,10 @@ metadata:
 spec:
   replicas: {{ .Values.controller.replicas }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
-  {{- if eq (int .Values.controller.replicas) 1 }}
+  {{- if .Values.controller.deploymentStrategy }}
+  strategy:
+    {{- toYaml .Values.controller.deploymentStrategy | nindent 4 }}
+  {{- else if eq (int .Values.controller.replicas) 1 }}
   strategy:
     type: Recreate
   {{- end }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: {{ .Values.server.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.server.revisionHistoryLimit }}
+  {{- with .Values.server.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-workflows.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 6 }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -387,6 +387,16 @@ controller:
   # -- The number of revisions to keep.
   revisionHistoryLimit: 10
 
+  # -- Deployment strategy for the workflow-controller. When set, it takes
+  # precedence over the chart's default of `type: Recreate` for `replicas: 1`,
+  # allowing operators with `replicas: 2+` to opt into a zero-downtime rolling
+  # strategy (e.g. `maxUnavailable: 0, maxSurge: 1`).
+  deploymentStrategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 0
+    #   maxSurge: 1
+
   pdb:
     # -- Configure [Pod Disruption Budget] for the controller pods
     enabled: false
@@ -628,6 +638,16 @@ server:
   replicas: 1
   # -- The number of revisions to keep.
   revisionHistoryLimit: 10
+
+  # -- Deployment strategy for the argo server. When unset, Kubernetes uses
+  # the default RollingUpdate (25%/25%); set this to opt into zero-downtime
+  # rolls (e.g. `maxUnavailable: 0, maxSurge: 1`) when running 2+ replicas.
+  deploymentStrategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 0
+    #   maxSurge: 1
+
   ## Argo Server Horizontal Pod Autoscaler
   autoscaling:
     # -- Enable Horizontal Pod Autoscaler ([HPA]) for the Argo Server


### PR DESCRIPTION
## Why

The `workflow-controller` Deployment and the `argo-server` Deployment didn't expose a way to set `spec.strategy`. The controller template only set `type: Recreate` when `replicas == 1`; otherwise no strategy was rendered on either Deployment, so Kubernetes fell back to the default `RollingUpdate { maxUnavailable: 25%, maxSurge: 25% }`.

For operators running 2 replicas, that default allows an old pod to terminate before its replacement is Ready, producing a brief gap that surfaces to users as a white screen during chart upgrades. A PDB doesn't help here — PDBs only govern voluntary disruptions (drains), not rolling updates. The argo-cd chart already exposes `deploymentStrategy` per component for exactly this reason; this PR brings argo-workflows in line.

## What

Adds `controller.deploymentStrategy` and `server.deploymentStrategy` values (default `{}`). When set, the value is rendered into `spec.strategy` on the corresponding Deployment.

**Backwards compatible:**
- `controller.deploymentStrategy: {}` (default) + `controller.replicas: 1` → unchanged: `type: Recreate` is rendered (preserves the behavior added in https://github.com/argoproj/argo-helm/blob/main/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml).
- `controller.deploymentStrategy: {}` + `controller.replicas >= 2` → unchanged: no strategy rendered, K8s default applies.
- `server.deploymentStrategy: {}` (default) → unchanged: no strategy rendered.

**New capability:** operators running 2+ replicas can now opt into zero-downtime rolls:

```yaml
controller:
  replicas: 2
  deploymentStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 1
server:
  replicas: 2
  deploymentStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 1
```

Verified locally with `helm template`:

| Scenario | Controller strategy | Server strategy |
|---|---|---|
| Defaults (replicas=1, no override) | `type: Recreate` | (none) |
| replicas=2, no override | (none) | (none) |
| replicas=2 + override | RollingUpdate maxUnavailable=0 | RollingUpdate maxUnavailable=0 |

## Checklist

* [x] Bumped chart version: 1.0.13 → 1.0.14
* [x] Updated README.md via `./scripts/helm-docs.sh`
* [x] Updated `artifacthub.io/changes` annotation in `Chart.yaml`
* [x] New values are backwards compatible with sensible defaults (`{}`)
* [x] Commits are DCO signed
* [x] Single chart in this PR (argo-workflows only)