### PR TITLE
fix(argo-cd): fix RBAC condition for shard-cm when dynamicClusterDistribution is enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.3.9
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.11
+version: 9.5.12
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Fix RBAC condition for argocd-app-controller-shard-cm when controller.dynamicClusterDistribution is enabled
     - kind: changed
       description: Bump argo-cd to v3.3.9

--- a/charts/argo-cd/ci/dynamic-sharding-values.yaml
+++ b/charts/argo-cd/ci/dynamic-sharding-values.yaml
@@ -2,5 +2,7 @@
 crds:
   keep: false
 
+createClusterRoles: true
+
 controller:
   dynamicClusterDistribution: true

--- a/charts/argo-cd/templates/argocd-application-controller/role.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/role.yaml
@@ -47,7 +47,7 @@ rules:
   - get
   - list
   - watch
-{{- if and (not .Values.createClusterRoles) .Values.controller.dynamicClusterDistribution }}
+{{- if .Values.controller.dynamicClusterDistribution }}
 - apiGroups:
   - ""
   resources:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -769,6 +769,7 @@ controller:
   replicas: 1
 
   # -- Enable dynamic cluster distribution (alpha)
+  # Enabling this grants the application controller RBAC access to the argocd-app-controller-shard-cm ConfigMap.
   # Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/dynamic-cluster-distribution
   ## This is done using a deployment instead of a statefulSet
   ## When replicas are added or removed, the sharding algorithm is re-run to ensure that the


### PR DESCRIPTION
## What this fixes

Fixes the RBAC condition in `charts/argo-cd/templates/argocd-application-controller/role.yaml` that prevented `argocd-app-controller-shard-cm` permissions from being granted in standard installations.

**Root cause:** The condition was:
```yaml
{{- if and (not .Values.createClusterRoles) .Values.controller.dynamicClusterDistribution }}
```

Since `createClusterRoles` defaults to `true`, `(not .Values.createClusterRoles)` always evaluates to `false`, short-circuiting the entire block. The application controller never received permission to read or write the shard mapping ConfigMap, causing conflict retries and zombie controllers stuck at `shard=-1`.

**Fix:** Change the condition to:
```yaml
{{- if .Values.controller.dynamicClusterDistribution }}
```

The shard-CM permission should be gated only on whether dynamic cluster distribution is enabled — it has no dependency on `createClusterRoles`.

## Verification

Reproduced with `helm template` before the fix:
```bash
# Before fix — shard-cm permission absent (the bug)
helm template argocd charts/argo-cd \
  --set controller.dynamicClusterDistribution=true \
  --set createClusterRoles=true \
  | grep "argocd-app-controller-shard-cm"
# Output: (empty)
```

After the fix:
```bash
# After fix — shard-cm permission present ✅
helm template argocd charts/argo-cd \
  --set controller.dynamicClusterDistribution=true \
  --set createClusterRoles=true \
  | grep "argocd-app-controller-shard-cm"
# Output:   - argocd-app-controller-shard-cm

# Feature off — no permission added ✅
helm template argocd charts/argo-cd \
  --set controller.dynamicClusterDistribution=false \
  --set createClusterRoles=true \
  | grep "argocd-app-controller-shard-cm"
# Output: (empty)
```

## Changes

- `role.yaml` — fix the broken RBAC condition (1 line)
- `ci/dynamic-sharding-values.yaml` — add `createClusterRoles: true` to actually test the standard install path in CI
- `values.yaml` — document that enabling `dynamicClusterDistribution` grants shard-cm RBAC access
- `Chart.yaml` — version bump 9.5.11 → 9.5.12 + changelog entry

## Related

Reported in argoproj/argo-cd#21181

## Checklist

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog)
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md)
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/))
