### PR TITLE
fix(argocd-image-updater): Add ServiceMonitor TLS and authorization options

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 1.1.5
+version: 1.1.6
 appVersion: v1.1.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Remove duplicate nodePort key from Service template when service.type is NodePort
+      description: Add ServiceMonitor options for secure metrics scraping

--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: v1.2.1
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-image-updater to v1.2.1
+    - kind: fixed
+      description: Add ServiceMonitor options for secure metrics scraping

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -129,12 +129,15 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | metrics.service.labels | object | `{}` | Metrics service labels |
 | metrics.service.servicePort | int | `8443` | Metrics service port |
 | metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
+| metrics.serviceMonitor.authorization | object | `{}` | Prometheus ServiceMonitor authorization |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
 | metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | nameOverride | string | `""` | Global name (argocd-image-updater.name in _helpers.tpl) override |
 | namespaceOverride | string | `""` | Global namespace (argocd-image-updater.namespace in _helpers.tpl) override |
 | nodeSelector | object | `{}` | Kubernetes nodeSelector settings for the deployment |

--- a/charts/argocd-image-updater/README.md
+++ b/charts/argocd-image-updater/README.md
@@ -146,12 +146,15 @@ The `config.registries` value can be used exactly as it looks in the documentati
 | metrics.service.labels | object | `{}` | Metrics service labels |
 | metrics.service.servicePort | int | `8443` | Metrics service port |
 | metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor labels |
+| metrics.serviceMonitor.authorization | object | `{}` | Prometheus ServiceMonitor authorization |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | metrics.serviceMonitor.metricRelabelings | list | `[]` | Prometheus [MetricRelabelConfigs] to apply to samples before ingestion |
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
+| metrics.serviceMonitor.scheme | string | `"https"` | Prometheus ServiceMonitor scheme |
 | metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| metrics.serviceMonitor.tlsConfig | object | `{"insecureSkipVerify":true}` | Prometheus ServiceMonitor tlsConfig |
 | nameOverride | string | `""` | Global name (argocd-image-updater.name in _helpers.tpl) override |
 | namespaceOverride | string | `""` | Global namespace (argocd-image-updater.namespace in _helpers.tpl) override |
 | nodeSelector | object | `{}` | Kubernetes nodeSelector settings for the deployment |

--- a/charts/argocd-image-updater/templates/servicemonitor.yaml
+++ b/charts/argocd-image-updater/templates/servicemonitor.yaml
@@ -27,6 +27,17 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.authorization }}
+      authorization:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ include "argocd-image-updater.namespace" . | quote }}

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -301,6 +301,16 @@ metrics:
     selector: {}
       # promtheus: kube-prometheus
 
+    # -- Prometheus ServiceMonitor scheme
+    scheme: ""
+    # -- Prometheus ServiceMonitor tlsConfig
+    tlsConfig: {}
+    # -- Prometheus ServiceMonitor authorization
+    authorization: {}
+      # type: Bearer
+      # credentials:
+      #   name: argocd-image-updater-metrics-token
+      #   key: token
     # -- Prometheus ServiceMonitor namespace
     namespace: ""
     # -- Prometheus ServiceMonitor labels

--- a/charts/argocd-image-updater/values.yaml
+++ b/charts/argocd-image-updater/values.yaml
@@ -301,6 +301,17 @@ metrics:
     selector: {}
       # promtheus: kube-prometheus
 
+    # -- Prometheus ServiceMonitor scheme
+    scheme: https
+    # -- Prometheus ServiceMonitor tlsConfig
+    tlsConfig:
+      insecureSkipVerify: true
+    # -- Prometheus ServiceMonitor authorization
+    authorization: {}
+      # type: Bearer
+      # credentials:
+      #   name: argocd-image-updater-metrics-token
+      #   key: token
     # -- Prometheus ServiceMonitor namespace
     namespace: ""
     # -- Prometheus ServiceMonitor labels


### PR DESCRIPTION
## Summary

This PR adds optional ServiceMonitor settings for Argo CD Image Updater metrics scraping:

- `metrics.serviceMonitor.scheme`
- `metrics.serviceMonitor.tlsConfig`
- `metrics.serviceMonitor.authorization`

This is related to #3815, where the metrics endpoint is served over HTTPS on port `8443`, but the generated ServiceMonitor currently does not allow configuring the scrape scheme or TLS settings.

With this change, users can configure HTTPS metrics scraping, for example:

```yaml
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
    scheme: https
    tlsConfig:
      insecureSkipVerify: true
```

This PR intentionally does not change the default ServiceMonitor behavior. If scheme is not specified, Prometheus Operator defaults to HTTP. Changing the chart default to HTTPS would be a behavior change for existing users, and making insecureSkipVerify: true the default would not be a safe default.

This PR also uses authorization instead of bearerTokenFile, since bearerTokenFile is deprecated in the Prometheus Operator API.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
