### PR TITLE
fix(argo-cd): Preserve component suffixes for long release names

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.1
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.13
+version: 9.6.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Use tpl for env var rendering to support Helm template expressions in env values.
+    - kind: fixed
+      description: Preserve component suffixes when truncating resource names for long Helm release names to avoid invalid names and component name collisions. This may rename previously truncated resources during upgrade.

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -1,11 +1,32 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+Create a component fullname while preserving the component suffix.
+*/}}
+{{- define "argo-cd.component.fullname" -}}
+{{- $ctx := .context -}}
+{{- $name := .name -}}
+{{- $suffix := .suffix | default "" -}}
+{{- $maxLen := .maxLen | default 63 | int -}}
+{{- $componentName := $name -}}
+{{- if $suffix -}}
+{{- $componentName = printf "%s-%s" $name $suffix -}}
+{{- end -}}
+{{- /* Reserve space for hyphen + componentName */ -}}
+{{- $baseMaxLen := sub $maxLen (add (len $componentName) 1) | int -}}
+{{- if lt $baseMaxLen 1 -}}
+{{- fail (printf "cannot build fullname for component %q: maxLen %d leaves no room for base name" $componentName $maxLen) -}}
+{{- end -}}
+{{- $base := include "argo-cd.fullname" $ctx | trunc $baseMaxLen | trimSuffix "-" -}}
+{{- printf "%s-%s" $base $componentName | trunc $maxLen | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create controller name and version as used by the chart label.
 Truncated at 52 chars because StatefulSet label 'controller-revision-hash' is limited
 to 63 chars and it includes 10 chars of hash and a separating '-'.
 */}}
 {{- define "argo-cd.controller.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.controller.name | trunc 52 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.controller.name "maxLen" 52) -}}
 {{- end -}}
 
 {{/*
@@ -23,7 +44,7 @@ Create the name of the controller service account to use
 Create dex name and version as used by the chart label.
 */}}
 {{- define "argo-cd.dex.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.dex.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.dex.name) -}}
 {{- end -}}
 
 {{/*
@@ -59,7 +80,7 @@ Create redis name and version as used by the chart label.
         {{- printf "%s-haproxy" (include "redis-ha.fullname" $redisHaContext) | trunc 63 | trimSuffix "-" -}}
     {{- end -}}
 {{- else -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.redis.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.redis.name) -}}
 {{- end -}}
 {{- end -}}
 
@@ -91,7 +112,7 @@ Create the name of the redis service account to use
 Create Redis secret-init name
 */}}
 {{- define "argo-cd.redisSecretInit.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.redisSecretInit.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.redisSecretInit.name) -}}
 {{- end -}}
 
 {{/*
@@ -109,7 +130,7 @@ Create the name of the Redis secret-init service account to use
 Create argocd server name and version as used by the chart label.
 */}}
 {{- define "argo-cd.server.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.server.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.server.name) -}}
 {{- end -}}
 
 {{/*
@@ -127,7 +148,7 @@ Create the name of the Argo CD server service account to use
 Create argocd repo-server name and version as used by the chart label.
 */}}
 {{- define "argo-cd.repoServer.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.repoServer.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.repoServer.name) -}}
 {{- end -}}
 
 {{/*
@@ -145,7 +166,7 @@ Create the name of the repo-server service account to use
 Create argocd application set name and version as used by the chart label.
 */}}
 {{- define "argo-cd.applicationSet.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.applicationSet.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.applicationSet.name) -}}
 {{- end -}}
 
 {{/*
@@ -163,7 +184,7 @@ Create the name of the application set service account to use
 Create argocd notifications name and version as used by the chart label.
 */}}
 {{- define "argo-cd.notifications.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.notifications.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.notifications.name) -}}
 {{- end -}}
 
 {{/*
@@ -181,7 +202,7 @@ Create the name of the notifications service account to use
 Create argocd commit-server name and version as used by the chart label.
 */}}
 {{- define "argo-cd.commitServer.fullname" -}}
-{{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.commitServer.name | trunc 63 | trimSuffix "-" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.commitServer.name) -}}
 {{- end -}}
 
 {{/*
@@ -336,4 +357,75 @@ Return the appropriate apiVersion for monitoring CRDs
 {{- else -}}
 {{- print "monitoring.coreos.com/v1" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create controller metrics service name.
+*/}}
+{{- define "argo-cd.controller.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.controller.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create redis metrics service name.
+*/}}
+{{- define "argo-cd.redis.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.redis.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create server metrics service name.
+*/}}
+{{- define "argo-cd.server.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.server.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create repo-server metrics service name.
+*/}}
+{{- define "argo-cd.repoServer.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.repoServer.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create applicationset metrics service name.
+*/}}
+{{- define "argo-cd.applicationSet.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.applicationSet.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create notifications metrics service name.
+*/}}
+{{- define "argo-cd.notifications.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.notifications.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create commit-server metrics service name.
+*/}}
+{{- define "argo-cd.commitServer.metrics.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.commitServer.name "suffix" "metrics") -}}
+{{- end -}}
+
+{{/*
+Create redis health configmap name.
+*/}}
+{{- define "argo-cd.redis.healthConfigMap.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.redis.name "suffix" "health-configmap") -}}
+{{- end -}}
+
+{{/*
+Create server grpc service/ingress name.
+*/}}
+{{- define "argo-cd.server.grpc.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.server.name "suffix" "grpc") -}}
+{{- end -}}
+
+
+{{/*
+Create aws server grpc service/ingress name.
+*/}}
+{{- define "argo-cd.server.aws.grpc.fullname" -}}
+{{- include "argo-cd.component.fullname" (dict "context" . "name" .Values.server.name "suffix" "grpc" "maxLen" 52) -}}
 {{- end -}}

--- a/charts/argo-cd/templates/argocd-application-controller/metrics.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.controller.fullname" . }}-metrics
+  name: {{ include "argo-cd.controller.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.controller.name "name" "metrics") | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-applicationset/metrics.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.applicationSet.fullname" . }}-metrics
+  name: {{ include "argo-cd.applicationSet.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" "metrics") | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-commit-server/metrics.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.commitServer.fullname" . }}-metrics
+  name: {{ include "argo-cd.commitServer.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.commitServer.name "name" "metrics") | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-notifications/metrics.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.notifications.fullname" . }}-metrics
+  name: {{ include "argo-cd.notifications.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.notifications.name "name" "metrics") | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-repo-server/metrics.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.repoServer.fullname" . }}-metrics
+  name: {{ include "argo-cd.repoServer.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.repoServer.name "name" (printf "%s-metrics" .Values.repoServer.name)) | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/aws/ingress.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    alb.ingress.kubernetes.io/conditions.{{ include "argo-cd.server.fullname" . }}-grpc: |
+    alb.ingress.kubernetes.io/conditions.{{ include "argo-cd.server.aws.grpc.fullname" . }}: |
       [{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "Content-Type", "values":["application/grpc"]}}]
     {{- range $key, $value := .Values.server.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -32,7 +32,7 @@ spec:
             pathType: {{ $.Values.server.ingressGrpc.pathType }}
             backend:
               service:
-                name: {{ include "argo-cd.server.fullname" $ }}-grpc
+                name: {{ include "argo-cd.server.aws.grpc.fullname" $ }}
                 port:
                   number: {{ $servicePort }}
           - path: {{ .Values.server.ingress.path }}

--- a/charts/argo-cd/templates/argocd-server/aws/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/aws/service.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" (print .Values.server.name "-grpc") "name" (print .Values.server.name "-grpc")) | nindent 4 }}
-  name: {{ template "argo-cd.server.fullname" . }}-grpc
+  name: {{ include "argo-cd.server.aws.grpc.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
 spec:
   {{- include "argo-cd.dualStack" . | indent 2 }}

--- a/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
+++ b/charts/argo-cd/templates/argocd-server/ingress-grpc.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "argo-cd.server.fullname" . }}-grpc
+  name: {{ include "argo-cd.server.grpc.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}

--- a/charts/argo-cd/templates/argocd-server/metrics.yaml
+++ b/charts/argo-cd/templates/argocd-server/metrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.server.fullname" . }}-metrics
+  name: {{ include "argo-cd.server.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" (printf "%s-metrics" .Values.server.name)) | nindent 4 }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -210,7 +210,7 @@ spec:
       volumes:
         - name: health
           configMap:
-            name: {{ include "argo-cd.redis.fullname" . }}-health-configmap
+            name: {{ include "argo-cd.redis.healthConfigMap.fullname" . }}
             defaultMode: 493
       {{- with .Values.redis.volumes }}
         {{- toYaml . | nindent 8}}

--- a/charts/argo-cd/templates/redis/health-configmap.yaml
+++ b/charts/argo-cd/templates/redis/health-configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "argo-cd.redis.fullname" . }}-health-configmap
+  name: {{ include "argo-cd.redis.healthConfigMap.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}

--- a/charts/argo-cd/templates/redis/metrics.yaml
+++ b/charts/argo-cd/templates/redis/metrics.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argo-cd.redis.fullname" . }}-metrics
+  name: {{ include "argo-cd.redis.metrics.fullname" . }}
   namespace: {{ include  "argo-cd.namespace" . }}
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.redis.name "name" .Values.redis.name) | nindent 4 }}


### PR DESCRIPTION
## Summary

This PR fixes resource name rendering for the `argo-cd` chart when using long Helm release names.

Previously, some resources appended suffixes such as `-metrics`, `-grpc`, or `-health-configmap` after rendering the component fullname. With long release names, this could either exceed Kubernetes name length limits or truncate away the component-specific suffix, which could lead to invalid or colliding resource names.

This change adds a component-aware fullname helper that reserves space for the component suffix before truncating the base release name. It also updates metrics Services, Redis health ConfigMap references, and Argo CD server gRPC resource names to use dedicated helpers.

Closes #3840.

## Upgrade impact

For normal release names, rendered resource names should remain unchanged.

For very long release names, some existing resources may be renamed because suffixes such as `repo-server`, `redis`, `metrics`, `grpc`, and `health-configmap` are now preserved. 

## Notes

Ideally, the helper could include a deterministic hash of the full base name to distinguish releases that share the same long prefix. This PR does not add such a hash and only preserves component suffixes while truncating the base name. If a follow-up issue is raised for collisions between multiple long release names with the same prefix, I am happy to address that separately.

I considered adding a regression test for this boundary case. If maintainers think it is necessary, I can add a small shell script that renders the chart with a 53-character release name and verifies that rendered resource names stay within the Kubernetes name length limit and do not collide, then run it as a dedicated GitHub Actions step.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
