### PR TITLE
fix(argo-cd): prevent dex and repo-server copyutil from poisoning shared volume on OOMKill

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -85,6 +85,14 @@ jobs:
             echo -e '\033[0;32mDocumentation up to date\033[0m ✔'
           fi
 
+      - name: Install helm-unittest plugin
+        if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v0.6.1
+
+      - name: Run helm-unittest on argo-cd chart
+        if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')
+        run: helm unittest charts/argo-cd
+
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/argo-cd/.helmignore
+++ b/charts/argo-cd/.helmignore
@@ -1,4 +1,5 @@
 /*.tgz
 output
 ci/
+tests/
 *.gotmpl

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.14
+version: 9.6.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.4.2
+    - kind: fixed
+      description: Prevent dex and repo-server copyutil init containers from poisoning the shared volume with a truncated argocd binary when killed mid-copy. repoServer.copyutil.extraArgs default flips from --update=none to -f, both copyutil resources blocks default to 256Mi memory limit and request, and the defaults no longer inherit from dex.resources / repoServer.resources. A matching dex.initImage.extraArgs knob is added. See README section 9.6.0 for the full upgrade note.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -398,6 +398,22 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 9.6.0
+
+This release changes the defaults for the dex and repo-server `copyutil` init containers to avoid a failure mode where the ~220 MiB argocd binary gets truncated on the shared volume after an OOMKill, leaving the main container to crash-loop against the partial binary. Three behavior changes are worth knowing about on upgrade:
+
+1. `repoServer.copyutil.resources` now defaults to `{limits: {memory: 256Mi}}` (was `{}`), and `dex.initImage.resources` now defaults to the same. Previously both keys defaulted to empty and the templates fell back to `repoServer.resources` / `dex.resources` via Helm's `default` helper, so the init container inherited the parent component's resources block. The init container now has its own resource defaults regardless of the parent. If you relied on the inheritance to give `copyutil` a larger limit, set `repoServer.copyutil.resources` (or `dex.initImage.resources`) explicitly. Setting it to `null` opts back into the inheritance path.
+
+2. `repoServer.copyutil.extraArgs` now defaults to `"-f"` (was `"--update=none"`). On retry after a partial copy, `cp -f` removes the destination if it exists and is not writable, then rewrites it, instead of silently skipping it. If you rely on the previous skip-if-exists semantics (e.g. a custom `initContainer` that pre-populates the shared volume), set `repoServer.copyutil.extraArgs: "--update=none"` to restore the old behavior. Users who already override `repoServer.copyutil.extraArgs` will not pick up the new default automatically. The short flag form (`-f`) is used so the chart remains compatible with BusyBox-based custom images.
+
+3. The dex copyutil init container now has a matching `dex.initImage.extraArgs` knob (defaulting to `"-f"`), mirroring the repo-server side. Previously the cp flag was hardcoded in the template with no override. The dex copyutil runs in exec form (no shell wrapper) — the value is split on whitespace and each token becomes a separate `argv` element, so shell metacharacters in `dex.initImage.extraArgs` are passed to `cp` as literal arguments (and rejected by `cp`) rather than interpreted by a shell. Setting `dex.initImage.extraArgs: ""` renders bare `cp` (which still overwrites by default).
+
+The repo-server copyutil still runs under `sh -c` because the init container chains `cp ... && ln -sf ...` for the `argocd-cmp-server` symlink. `repoServer.copyutil.extraArgs` is therefore shell-interpreted on that side (this matches the pre-9.6.0 behavior — only the default value changed). Treat `repoServer.copyutil.extraArgs` as you would any other shell-rendered value: avoid metacharacters unless you know what you are putting there.
+
+Both copyutil resources blocks set `requests.memory` equal to `limits.memory` so the scheduler reserves the headroom on the node rather than letting the init container run as Burstable with aggressive reclaim under pressure.
+
+If you still see the copyutil init container OOMKill at the new 256Mi default — for example on a node that runs many copyutil instances concurrently under memory pressure, or after a future argocd binary growth crosses the headroom — raise `repoServer.copyutil.resources.limits.memory` (or `dex.initImage.resources.limits.memory`) further. 256Mi is sized to comfortably hold the ~220 MiB binary plus copy buffers in the common case, not to guarantee no OOMKill under adversarial memory pressure.
+
 ### 9.1.0
 This chart contains a breaking change (if using `redis-ha`), which was introduced by the dependency `redis-ha` (as seen [here](https://github.com/DandyDeveloper/charts/blob/a03b6a6f4d72b6606ce9a218c7d0026350b48ad0/charts/redis-ha/README.md#4341---upgrade-may-complain-about-selector-label-changes-being-immutable)). The upgrade will complain about selector label changes being immutable, which requires a replacement of the `argocd-redis-ha-haproxy` deployment. To overcome this, you will need to delete (orphaning children) this deployment, updated ArgoCD to disable server-side diffing, then allow the new deployment of `argocd-redis-ha-haproxy` to rollout with the updated label selectors.
 
@@ -1088,8 +1104,8 @@ NAME: my-release
 | repoServer.containerPorts.metrics | int | `8084` | Metrics container port |
 | repoServer.containerPorts.server | int | `8081` | Repo server container port |
 | repoServer.containerSecurityContext | object | See [values.yaml] | Repo server container-level security context |
-| repoServer.copyutil.extraArgs | string | `"--update=none"` | Extra arguments for the cp command in the repo server copyutil initContainer |
-| repoServer.copyutil.resources | object | `{}` | Resource limits and requests for the repo server copyutil initContainer |
+| repoServer.copyutil.extraArgs | string | `"-f"` | Extra arguments for the cp command in the repo server copyutil initContainer |
+| repoServer.copyutil.resources | object | `{"limits":{"memory":"256Mi"},"requests":{"memory":"256Mi"}}` | Resource limits and requests for the repo server copyutil initContainer |
 | repoServer.deploymentAnnotations | object | `{}` | Annotations to be added to repo server Deployment |
 | repoServer.deploymentLabels | object | `{}` | Labels for the repo server Deployment |
 | repoServer.deploymentStrategy | object | `{}` | Deployment strategy to be added to the repo server Deployment |
@@ -1401,9 +1417,10 @@ NAME: my-release
 | dex.image.tag | string | `"v2.45.1"` | Dex image tag |
 | dex.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | dex.initContainers | list | `[]` | Init containers to add to the dex pod |
+| dex.initImage.extraArgs | string | `"-f"` | Extra arguments for the cp command in the dex copyutil initContainer |
 | dex.initImage.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Argo CD init image imagePullPolicy |
 | dex.initImage.repository | string | `""` (defaults to global.image.repository) | Argo CD init image repository |
-| dex.initImage.resources | object | `{}` (defaults to dex.resources) | Argo CD init image resources |
+| dex.initImage.resources | object | `{"limits":{"memory":"256Mi"},"requests":{"memory":"256Mi"}}` | Argo CD init image resources |
 | dex.initImage.tag | string | `""` (defaults to global.image.tag) | Argo CD init image tag |
 | dex.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for Dex >= 2.28.0 |
 | dex.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -398,6 +398,22 @@ For full list of changes please check ArtifactHub [changelog].
 
 Highlighted versions provide information about additional steps that should be performed by user when upgrading to newer version.
 
+### 9.6.0
+
+This release changes the defaults for the dex and repo-server `copyutil` init containers to avoid a failure mode where the ~220 MiB argocd binary gets truncated on the shared volume after an OOMKill, leaving the main container to crash-loop against the partial binary. Three behavior changes are worth knowing about on upgrade:
+
+1. `repoServer.copyutil.resources` now defaults to `{limits: {memory: 256Mi}}` (was `{}`), and `dex.initImage.resources` now defaults to the same. Previously both keys defaulted to empty and the templates fell back to `repoServer.resources` / `dex.resources` via Helm's `default` helper, so the init container inherited the parent component's resources block. The init container now has its own resource defaults regardless of the parent. If you relied on the inheritance to give `copyutil` a larger limit, set `repoServer.copyutil.resources` (or `dex.initImage.resources`) explicitly. Setting it to `null` opts back into the inheritance path.
+
+2. `repoServer.copyutil.extraArgs` now defaults to `"-f"` (was `"--update=none"`). On retry after a partial copy, `cp -f` removes the destination if it exists and is not writable, then rewrites it, instead of silently skipping it. If you rely on the previous skip-if-exists semantics (e.g. a custom `initContainer` that pre-populates the shared volume), set `repoServer.copyutil.extraArgs: "--update=none"` to restore the old behavior. Users who already override `repoServer.copyutil.extraArgs` will not pick up the new default automatically. The short flag form (`-f`) is used so the chart remains compatible with BusyBox-based custom images.
+
+3. The dex copyutil init container now has a matching `dex.initImage.extraArgs` knob (defaulting to `"-f"`), mirroring the repo-server side. Previously the cp flag was hardcoded in the template with no override. The dex copyutil runs in exec form (no shell wrapper) — the value is split on whitespace and each token becomes a separate `argv` element, so shell metacharacters in `dex.initImage.extraArgs` are passed to `cp` as literal arguments (and rejected by `cp`) rather than interpreted by a shell. Setting `dex.initImage.extraArgs: ""` renders bare `cp` (which still overwrites by default).
+
+The repo-server copyutil still runs under `sh -c` because the init container chains `cp ... && ln -sf ...` for the `argocd-cmp-server` symlink. `repoServer.copyutil.extraArgs` is therefore shell-interpreted on that side (this matches the pre-9.6.0 behavior — only the default value changed). Treat `repoServer.copyutil.extraArgs` as you would any other shell-rendered value: avoid metacharacters unless you know what you are putting there.
+
+Both copyutil resources blocks set `requests.memory` equal to `limits.memory` so the scheduler reserves the headroom on the node rather than letting the init container run as Burstable with aggressive reclaim under pressure.
+
+If you still see the copyutil init container OOMKill at the new 256Mi default — for example on a node that runs many copyutil instances concurrently under memory pressure, or after a future argocd binary growth crosses the headroom — raise `repoServer.copyutil.resources.limits.memory` (or `dex.initImage.resources.limits.memory`) further. 256Mi is sized to comfortably hold the ~220 MiB binary plus copy buffers in the common case, not to guarantee no OOMKill under adversarial memory pressure.
+
 ### 9.1.0
 This chart contains a breaking change (if using `redis-ha`), which was introduced by the dependency `redis-ha` (as seen [here](https://github.com/DandyDeveloper/charts/blob/a03b6a6f4d72b6606ce9a218c7d0026350b48ad0/charts/redis-ha/README.md#4341---upgrade-may-complain-about-selector-label-changes-being-immutable)). The upgrade will complain about selector label changes being immutable, which requires a replacement of the `argocd-redis-ha-haproxy` deployment. To overcome this, you will need to delete (orphaning children) this deployment, updated ArgoCD to disable server-side diffing, then allow the new deployment of `argocd-redis-ha-haproxy` to rollout with the updated label selectors.
 

--- a/charts/argo-cd/ci/copyutil-resources-values.yaml
+++ b/charts/argo-cd/ci/copyutil-resources-values.yaml
@@ -1,0 +1,38 @@
+# Smoke-test that user overrides on the copyutil resources block render through.
+# The chart sets a default memory limit of 256Mi on dex.initImage.resources and
+# repoServer.copyutil.resources; this file exercises explicit overrides on both
+# so chart-testing renders the override path on every PR. Note that chart-testing
+# only renders + installs — it does not assert on rendered values, so this file
+# catches a template that fails to render with overrides, not a refactor that
+# silently drops them.
+
+# crds.keep: false so chart-testing can iterate multiple values files in the
+# same kind cluster without the CRDs from a previous install blocking the next.
+crds:
+  keep: false
+
+dex:
+  enabled: true
+  initImage:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 384Mi
+      requests:
+        cpu: 10m
+        memory: 192Mi
+
+repoServer:
+  copyutil:
+    # Both copyutil paths read extraArgs from values now. The dex side renders
+    # in exec form (each whitespace-separated token becomes an argv element);
+    # the repo-server side renders inside `sh -c` because of the `&&` chain
+    # with `ln -sf`, so the value is shell-interpreted on that side.
+    extraArgs: "--force --verbose"
+    resources:
+      limits:
+        cpu: 100m
+        memory: 384Mi
+      requests:
+        cpu: 10m
+        memory: 192Mi

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -181,7 +181,11 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.dex.initImage.imagePullPolicy }}
         command:
         - /bin/cp
-        - -n
+        {{- range (splitList " " .Values.dex.initImage.extraArgs) }}
+          {{- if . }}
+        - {{ . | quote }}
+          {{- end }}
+        {{- end }}
         - /usr/local/bin/argocd
         - /shared/argocd-dex
         volumeMounts:

--- a/charts/argo-cd/tests/copyutil_test.yaml
+++ b/charts/argo-cd/tests/copyutil_test.yaml
@@ -1,0 +1,136 @@
+suite: copyutil init container rendering
+
+tests:
+  - it: dex copyutil command uses cp -f in exec form (no shell)
+    template: templates/dex/deployment.yaml
+    set:
+      dex.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - /bin/cp
+            - "-f"
+            - /usr/local/bin/argocd
+            - /shared/argocd-dex
+      - isNull:
+          path: spec.template.spec.initContainers[0].args
+
+  - it: dex copyutil is not vulnerable to shell injection via extraArgs
+    template: templates/dex/deployment.yaml
+    set:
+      dex.enabled: true
+      dex.initImage.extraArgs: "foo; rm -rf /"
+    asserts:
+      ## Each whitespace-separated token becomes its own argv element, so a
+      ## metacharacter like ';' is delivered as a literal cp argument (cp
+      ## rejects it with "unrecognized option") rather than being parsed by
+      ## a shell. The kubelet never invokes a shell for this command.
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - /bin/cp
+            - "foo;"
+            - "rm"
+            - "-rf"
+            - "/"
+            - /usr/local/bin/argocd
+            - /shared/argocd-dex
+
+  - it: dex copyutil resources default matches documented shape
+    template: templates/dex/deployment.yaml
+    set:
+      dex.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 256Mi
+
+  - it: dex copyutil respects user override on extraArgs
+    template: templates/dex/deployment.yaml
+    set:
+      dex.enabled: true
+      dex.initImage.extraArgs: "--update=none"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - /bin/cp
+            - "--update=none"
+            - /usr/local/bin/argocd
+            - /shared/argocd-dex
+
+  - it: dex copyutil with empty extraArgs renders bare cp
+    template: templates/dex/deployment.yaml
+    set:
+      dex.enabled: true
+      dex.initImage.extraArgs: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - /bin/cp
+            - /usr/local/bin/argocd
+            - /shared/argocd-dex
+
+  - it: dex copyutil resources fall back to dex.resources when set to null
+    template: templates/dex/deployment.yaml
+    set:
+      dex.enabled: true
+      dex.initImage.resources: null
+      dex.resources:
+        limits:
+          memory: 999Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            limits:
+              memory: 999Mi
+
+  - it: repo-server copyutil args use cp -f, not --update=none
+    template: templates/argocd-repo-server/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].args
+          value:
+            - /bin/cp -f /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+
+  - it: repo-server copyutil resources default matches documented shape
+    template: templates/argocd-repo-server/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 256Mi
+
+  - it: repo-server copyutil respects user override on extraArgs
+    template: templates/argocd-repo-server/deployment.yaml
+    set:
+      repoServer.copyutil.extraArgs: "--update=none"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].args
+          value:
+            - /bin/cp --update=none /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+
+  - it: repo-server copyutil resources fall back to repoServer.resources when set to null
+    template: templates/argocd-repo-server/deployment.yaml
+    set:
+      repoServer.copyutil.resources: null
+      repoServer.resources:
+        limits:
+          memory: 999Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources
+          value:
+            limits:
+              memory: 999Mi

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1229,15 +1229,28 @@ dex:
     # -- Argo CD init image imagePullPolicy
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: ""
+    # -- Extra arguments for the cp command in the dex copyutil initContainer
+    ## Short flag -f is used instead of --force so the chart remains
+    ## compatible with images that ship BusyBox cp (e.g. alpine-based custom
+    ## images), which does not accept GNU long flags.
+    extraArgs: "-f"
     # -- Argo CD init image resources
-    # @default -- `{}` (defaults to dex.resources)
-    resources: {}
-    #  requests:
-    #    cpu: 5m
-    #    memory: 96Mi
-    #  limits:
-    #    cpu: 10m
-    #    memory: 144Mi
+    # @default -- `{"limits":{"memory":"256Mi"},"requests":{"memory":"256Mi"}}`
+    ## NOTE: copyutil copies the full argocd binary (~220Mi) into a shared
+    ## volume. The kernel charges the page cache for the copy to the
+    ## cgroup; clean cache is normally reclaimable, but tight limits
+    ## combined with concurrent allocations can cross memory.max before
+    ## reclaim catches up and trigger an OOMKill mid-copy. The default
+    ## of 256Mi reduces (but does not eliminate) that risk; extraArgs
+    ## defaults to -f so any partial binary left by an OOMKill is
+    ## overwritten on retry rather than silently kept. requests.memory
+    ## equals limits.memory so the scheduler reserves the headroom on
+    ## the node rather than letting the init run as Burstable.
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 256Mi
 
   # -- Environment variables to pass to the Dex server
   env: []
@@ -2972,16 +2985,32 @@ repoServer:
 
   copyutil:
     # -- Extra arguments for the cp command in the repo server copyutil initContainer
-    # @default -- `"--update=none"`
-    extraArgs: "--update=none"
+    ## The previous default was --update=none (equivalent to cp -n), which
+    ## silently SKIPS the copy when the destination already exists. If a
+    ## prior init attempt was killed mid-copy and left a partial argocd
+    ## binary on the shared volume, the next attempt would exit 0 without
+    ## rewriting it and the main container would then load the truncated
+    ## binary. Default cp already overwrites; -f additionally removes and
+    ## retries when the destination is not writable (e.g. mode 0400 from a
+    ## prior copy). Short flag form is used so the chart remains compatible
+    ## with images shipping BusyBox cp.
+    extraArgs: "-f"
     # -- Resource limits and requests for the repo server copyutil initContainer
-    resources: {}
-    #  limits:
-    #    cpu: 100m
-    #    memory: 128Mi
-    #  requests:
-    #    cpu: 50m
-    #    memory: 64Mi
+    # @default -- `{"limits":{"memory":"256Mi"},"requests":{"memory":"256Mi"}}`
+    ## NOTE: copyutil copies the full argocd binary (~220Mi) into a shared
+    ## volume. The kernel charges the page cache for the copy to the cgroup;
+    ## clean cache is normally reclaimable, but tight limits combined with
+    ## concurrent allocations can cross memory.max before reclaim catches up
+    ## and trigger an OOMKill mid-copy. The default of 256Mi reduces (but
+    ## does not eliminate) that risk; -f in extraArgs ensures any partial
+    ## binary left by an OOMKill is overwritten on retry. requests.memory
+    ## equals limits.memory so the scheduler reserves the headroom on the
+    ## node rather than letting the init run as Burstable.
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 256Mi
 
   # -- Additional volumeMounts to the repo server main container
   volumeMounts: []


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
  > Defaults are sensible but NOT backwards compatible — `repoServer.copyutil.extraArgs` flips from `--update=none` to `-f`, and both copyutil `resources` blocks stop inheriting from the parent component's `resources`. Documented under README §9.6.0. Hence the minor bump rather than a patch.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
  > The chart change is argo-cd only. The PR also touches `.github/workflows/lint-and-test.yml` to wire helm-unittest behind a `contains(... 'argo-cd')` gate, so it runs only when the argo-cd chart changes. Happy to split that out if maintainers prefer.
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

## Summary

Fix a silent failure mode in the dex and repo-server `copyutil` init containers where the ~220 MiB argocd binary gets truncated on the shared volume after an OOMKill, leaving the main container to crash-loop against the partial binary forever.

> Note on PR scope: dex and repo-server are fixed in the same PR on purpose. They are the same bug — both copyutil containers copy the same argocd binary with the same `cp -n`-equivalent flag against the same memory inheritance pattern, and the upgrade impact (resource defaults, extraArgs flip) is symmetric. Splitting them would force users through two near-identical migrations and leave the chart in an inconsistent state between releases.

Two failure modes compound:

1. The init containers had no default memory limit and inherited the parent component's `resources` block. A tight `dex.resources` / `repoServer.resources` (e.g. `limits.memory: 64Mi`) causes the kernel to OOMKill `cp` mid-copy — page cache for the in-flight write is charged against the cgroup, and tight limits combined with concurrent allocations can cross `memory.max` before reclaim catches up.

2. The dex copyutil hardcoded `cp -n` and the repo-server copyutil defaulted to `extraArgs: "--update=none"` (equivalent to `cp -n`). On retry after the OOMKill, `cp -n` finds the partial binary on the shared volume, silently skips the copy, exits 0. Kubelet marks the init Completed. The main container then loads the truncated binary and SIGSEGVs on every restart. Reported in the field with 1100+ restarts over 4 days.

## Changes

- Default `dex.initImage.resources` and `repoServer.copyutil.resources` to `{limits: {memory: 256Mi}, requests: {memory: 256Mi}}`. Comfortable headroom over the ~220 MiB binary; request equals limit so the scheduler reserves the memory on the node rather than letting the init run as Burstable.
- Flip `repoServer.copyutil.extraArgs` default from `--update=none` to `-f`, and add a matching `dex.initImage.extraArgs` knob (also defaulting to `-f`). Short flag form for BusyBox compatibility on custom images.
- Keep the dex copyutil in exec form (no `sh -c` wrapper) — `extraArgs` is split on whitespace and each token becomes a separate `argv` element so shell metacharacters cannot be interpreted. Repo-server still uses `sh -c` because of the `cp ... && ln -sf ...` chain for the `argocd-cmp-server` symlink; that side's `extraArgs` is shell-interpreted on rendering (matches pre-9.6.0 behavior).

## Upgrade impact

Two documented behavior changes — full prose under `### 9.6.0` in the chart README:

- The copyutil `resources` blocks no longer inherit from the parent component's `resources` via Helm's `default` helper. If you relied on the inheritance to give copyutil a larger limit, set `repoServer.copyutil.resources` (or `dex.initImage.resources`) explicitly. Setting it to `null` opts back into the inheritance path.
- `repoServer.copyutil.extraArgs` default flips to `-f`. Users who already override `repoServer.copyutil.extraArgs` won't pick up the new default automatically. Users relying on the previous skip-if-exists semantics (e.g. a custom initContainer that pre-populates the shared volume) must set `extraArgs` back to `--update=none`.

## Tests

`helm-unittest` cases under `charts/argo-cd/tests/copyutil_test.yaml` pin the rendered output on both sides: default flag, default resources shape, user override on extraArgs, inheritance fall-back when set to `null`, empty-extraArgs rendering, and a shell-injection contract test (`dex.initImage.extraArgs: "foo; rm -rf /"` renders each token as a literal argv element). `helm-unittest` is wired into `.github/workflows/lint-and-test.yml` so the contract is gated on every PR that touches the argo-cd chart.

Closes #3895
