### PR TITLE
fix(argo-cd): move ARGOCD_CONTROLLER_REPLICAS above the dynamic env block

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis_exporter to v1.84.0
+    - kind: fixed
+      description: Fix ARGOCD_CONTROLLER_REPLICAS env var ordering to allow user overrides via controller.env.

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.15
+version: 9.5.16
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.16
+version: 9.5.17
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix ARGOCD_CONTROLLER_REPLICAS env var ordering to allow user overrides via controller.env.
+      description: Fix env vars ordering to allow user overrides via controller.env.

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -80,6 +80,7 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.controller.image.imagePullPolicy }}
         name: {{ .Values.controller.name }}
         env:
+          {{/* Must come before the dynamic env block so users can override it via controller.env (last definition wins in Kubernetes). */}}
           - name: ARGOCD_CONTROLLER_REPLICAS
             value: {{ .Values.controller.replicas | quote }}
           {{- with (concat .Values.global.env .Values.controller.env) }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -80,12 +80,8 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.controller.image.imagePullPolicy }}
         name: {{ .Values.controller.name }}
         env:
-          {{/* Must come before the dynamic env block so users can override it via controller.env (last definition wins in Kubernetes). */}}
           - name: ARGOCD_CONTROLLER_REPLICAS
             value: {{ .Values.controller.replicas | quote }}
-          {{- with (concat .Values.global.env .Values.controller.env) }}
-            {{- tpl (toYaml .) $ | nindent 10 }}
-          {{- end }}
           - name: ARGOCD_APPLICATION_CONTROLLER_NAME
             value: {{ template "argo-cd.controller.fullname" . }}
           - name: ARGOCD_RECONCILIATION_TIMEOUT
@@ -362,6 +358,9 @@ spec:
                 optional: true
           - name: KUBECACHEDIR
             value: /tmp/kubecache
+          {{- with (concat .Values.global.env .Values.controller.env) }}
+            {{- tpl (toYaml .) $ | nindent 10 }}
+          {{- end }}
         {{- with .Values.controller.envFrom }}
         envFrom:
           {{- toYaml . | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -80,11 +80,11 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.controller.image.imagePullPolicy }}
         name: {{ .Values.controller.name }}
         env:
+          - name: ARGOCD_CONTROLLER_REPLICAS
+            value: {{ .Values.controller.replicas | quote }}
           {{- with (concat .Values.global.env .Values.controller.env) }}
             {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
-          - name: ARGOCD_CONTROLLER_REPLICAS
-            value: {{ .Values.controller.replicas | quote }}
           - name: ARGOCD_APPLICATION_CONTROLLER_NAME
             value: {{ template "argo-cd.controller.fullname" . }}
           - name: ARGOCD_RECONCILIATION_TIMEOUT


### PR DESCRIPTION
solve #3903

This pull request makes a minor version bump to the Argo CD Helm chart and reorders environment variable definitions in the `argocd-application-controller` StatefulSet template for improved clarity.

Chart version update:

* Updated the chart version in `Chart.yaml` from `9.5.15` to `9.5.16`, indicating a new release.

Template improvements:

* Moved the `ARGOCD_CONTROLLER_REPLICAS` environment variable above the templated environment variables in the `statefulset.yaml` to improve readability and maintainability.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
