### PR TITLE
fix(argo-rollouts): replace deprecated --metricsport with --metricsPort

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.8.3
+appVersion: v1.9.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.5
+version: 2.40.10
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: use named port for service
+    - kind: fixed
+      description: Replace deprecated --metricsport flag with --metricsPort in controller deployment

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       - image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
         args:
         - --healthzPort={{ .Values.controller.containerPorts.healthz }}
-        - --metricsport={{ .Values.controller.containerPorts.metrics }}
+        - --metricsPort={{ .Values.controller.containerPorts.metrics }}
         - "--loglevel={{ .Values.controller.logging.level }}"
         - "--logformat={{ .Values.controller.logging.format }}"
         - "--kloglevel={{ .Values.controller.logging.kloglevel }}"


### PR DESCRIPTION
## What this PR does / why we need it

The controller deployment template passes `--metricsport` (all-lowercase) to the rollouts-controller binary. As of v1.9.0 this flag is deprecated in favour of `--metricsPort` (camelCase), producing a startup warning on every controller pod:

```
Flag --metricsport has been deprecated, use --metricsPort instead
```

The deprecation is defined here:
https://github.com/argoproj/argo-rollouts/blob/200f934fd6c94c39ab29f74547f0551af50062ab/cmd/rollouts-controller/main.go#L307-L308

## Changes

- `charts/argo-rollouts/templates/controller/deployment.yaml`: `--metricsport` → `--metricsPort`
- `charts/argo-rollouts/Chart.yaml`: version bump 2.40.9 → 2.40.10 with changelog entry

## Pre-requisites / testing

- [ ] Chart linting passes (`./scripts/lint.sh`)
- [ ] No values changes — purely a template flag rename, fully backwards-compatible
