### PR TITLE
feat(argo-rollouts): Add Gateway API HTTPRoute support for the dashboard

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.40.10
+version: 2.41.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Replace deprecated --metricsport flag with --metricsPort in controller deployment
+    - kind: added
+      description: Add Gateway API HTTPRoute support for the dashboard

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -163,6 +163,12 @@ For full list of changes please check ArtifactHub [changelog].
 | dashboard.enabled | bool | `false` | Deploy dashboard server |
 | dashboard.extraArgs | list | `[]` | Additional command line arguments to pass to rollouts-dashboard. A list of flags. |
 | dashboard.extraEnv | list | `[]` | Additional environment variables for rollouts-dashboard. A list of name/value maps. |
+| dashboard.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| dashboard.httproute.enabled | bool | `false` | Enable HTTPRoute resource for the dashboard (Gateway API) |
+| dashboard.httproute.hostnames | list | `[]` (See [values.yaml]) | List of hostnames for the HTTPRoute |
+| dashboard.httproute.labels | object | `{}` | Additional HTTPRoute labels |
+| dashboard.httproute.parentRefs | list | `[]` (See [values.yaml]) | Gateway API parentRefs for the HTTPRoute |
+| dashboard.httproute.rules | list | `[]` (See [values.yaml]) | HTTPRoute rules configuration |
 | dashboard.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | dashboard.image.registry | string | `"quay.io"` | Registry to use |
 | dashboard.image.repository | string | `"argoproj/kubectl-argo-rollouts"` | Repository to use |

--- a/charts/argo-rollouts/templates/dashboard/httproute.yaml
+++ b/charts/argo-rollouts/templates/dashboard/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.httproute.enabled -}}
+{{- $serviceName := printf "%s-dashboard" (include "argo-rollouts.fullname" .) -}}
+{{- $servicePort := .Values.dashboard.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "argo-rollouts.fullname" . }}-dashboard
+  namespace: {{ include "argo-rollouts.namespace" . | quote }}
+  labels:
+    {{- include "argo-rollouts.labels" . | nindent 4 }}
+    {{- with .Values.dashboard.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.dashboard.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.dashboard.httproute.parentRefs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.dashboard.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- range .Values.dashboard.httproute.rules }}
+    - backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $serviceName }}
+          port: {{ $servicePort }}
+          weight: 1
+    {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -495,6 +495,42 @@ dashboard:
       #   hosts:
       #     - argorollouts.example.com
 
+  ## HTTPRoute configuration (Gateway API).
+  ## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+  ##
+  httproute:
+    # -- Enable HTTPRoute resource for the dashboard (Gateway API)
+    enabled: false
+    # -- Additional HTTPRoute labels
+    labels: {}
+    # -- Additional HTTPRoute annotations
+    annotations: {}
+    # -- Gateway API parentRefs for the HTTPRoute
+    ## Must reference an existing Gateway
+    # @default -- `[]` (See [values.yaml])
+    parentRefs: []
+      # - name: example-gateway
+      #   namespace: example-gateway-namespace
+      #   sectionName: https
+    # -- List of hostnames for the HTTPRoute
+    # @default -- `[]` (See [values.yaml])
+    hostnames: []
+      # - argorollouts.example.com
+    # -- HTTPRoute rules configuration
+    # @default -- `[]` (See [values.yaml])
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        # filters: []
+        #   - type: RequestHeaderModifier
+        #     requestHeaderModifier:
+        #       add:
+        #         - name: X-Custom-Header
+        #           value: custom-value
+        # timeouts: {}
+
   # -- Additional volumes to add to the dashboard pod
   volumes: []
 


### PR DESCRIPTION
Adds optional Gateway API `HTTPRoute` support for the Argo Rollouts dashboard, mirroring the existing `dashboard.ingress` option. Lets users expose the dashboard through a Gateway API gateway instead of an Ingress controller. Disabled by default (`dashboard.httproute.enabled: false`), so the change is fully backwards compatible. Follows the pattern already merged for the `argo-cd` and `argo-workflows` charts.

Validation:
- `helm lint charts/argo-rollouts` → 0 failed
- `helm template` with `dashboard.httproute.enabled=true` renders a valid HTTPRoute (parentRefs / hostnames / backendRefs to the `-dashboard` service on port 3100)
- Default values render nothing (gated on `dashboard.enabled && dashboard.httproute.enabled`)
- Empty-matches edge case renders a valid rule (backendRefs-first)
- `./scripts/helm-docs.sh` run; README regenerated; chart version `2.40.10` → `2.41.0`; `artifacthub.io/changes` updated

### Checklist
- [x] Version bumped (`2.40.10` → `2.41.0`, MINOR — new optional feature)
- [x] Documentation regenerated via `./scripts/helm-docs.sh`
- [x] `artifacthub.io/changes` annotation updated
- [x] Backwards compatible (disabled by default)
- [x] DCO sign-off present
- [x] One chart per PR (argo-rollouts only)