### PR TITLE
feat(argo-events): disable controller leader election when replicas is 1

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.10
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.21
+version: 2.4.22
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Rename CRD files to match upstream. The contents are unchanged.
+    - kind: added
+      description: Disable controller leader election and use the Recreate deployment strategy when replicas is set to 1.

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -178,7 +178,7 @@ done
 | controller.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | controller.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
 | controller.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
-| controller.replicas | int | `1` | The number of events controller pods to run. |
+| controller.replicas | int | `1` | The number of events controller pods to run. Leader election is disabled when set to `1`. |
 | controller.resources | object | `{}` | Resource limits and requests for the events controller pods |
 | controller.revisionHistoryLimit | int | `5` | The number of replicasets history to keep |
 | controller.serviceAccount.annotations | object | `{}` | Annotations applied to created service account |

--- a/charts/argo-events/templates/argo-events-controller/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-controller/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       {{- include "argo-events.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   replicas: {{ .Values.controller.replicas }}
+  {{- if eq (int .Values.controller.replicas) 1 }}
+  strategy:
+    type: Recreate
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -45,6 +49,9 @@ spec:
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.controller.image.imagePullPolicy }}
         args:
         - controller
+        {{- if eq (int .Values.controller.replicas) 1 }}
+        - --leader-election=false
+        {{- end }}
         {{- if .Values.controller.rbac.namespaced }}
         - --namespaced
         {{- end }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -204,7 +204,7 @@ controller:
   # -- The number of replicasets history to keep
   revisionHistoryLimit: 5
 
-  # -- The number of events controller pods to run.
+  # -- The number of events controller pods to run. Leader election is disabled when set to `1`.
   replicas: 1
 
   # Pod disruption budget


### PR DESCRIPTION
Disable leader elections in argo-events controller manager when there's only one manager, and set strategy to recreate to prevent dual leaders on upgrades.

This mirrors #2565 and #3848 from argo-workflows' chart.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [NA] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
