### PR TITLE
fix(argo-cd): gate redis metrics NetworkPolicy rule behind exporter.enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.7.0
+version: 9.7.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Add optional startup probes and allow overriding httpGet path for health checks
+    - kind: fixed
+      description: Only render the Redis metrics NetworkPolicy ingress rule when redis.exporter.enabled is true

--- a/charts/argo-cd/templates/redis/networkpolicy.yaml
+++ b/charts/argo-cd/templates/redis/networkpolicy.yaml
@@ -22,11 +22,13 @@ spec:
     ports:
     - port: redis
       protocol: TCP
+  {{- if .Values.redis.exporter.enabled }}
   - from:
     - namespaceSelector: {}
     ports:
     - port: metrics
       protocol: TCP
+  {{- end }}
   podSelector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.redis.name) | nindent 6 }}


### PR DESCRIPTION
The redis `NetworkPolicy` always emitted an ingress rule for the `metrics` named port, but the redis pod only exposes that port when `redis.exporter.enabled` is `true` — `templates/redis/deployment.yaml` already guards the metrics container/port with `{{- if .Values.redis.exporter.enabled }}`. With the exporter disabled (the default), the NetworkPolicy referenced a named port that no pod exposes. This wraps that ingress rule in the same `redis.exporter.enabled` guard.

This change touches only `templates/redis/networkpolicy.yaml` and `Chart.yaml` — no values or user-facing documentation are affected.

Verified: `helm template --set global.networkPolicy.create=true` (default, exporter off) → redis NetworkPolicy ingress ports are `[redis]` only; `--set redis.exporter.enabled=true` → `[redis, metrics]` (unchanged when the exporter is on). `helm lint` passes.

Closes #3915

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
