### PR TITLE
feat(argo-cd): add gateway API listenerset support

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -117,6 +117,11 @@ jobs:
         run: |
           kubectl apply -f ./.github/configs/external-redis.yaml
 
+      - name: Install Gateway API CRDs for ListenerSet testing
+        if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')
+        run: |
+          kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/experimental-install.yaml
+
       - name: Copy full CRDs to kind nodes for argo-workflows testing
         id: argo-wf-crds
         if: contains(steps.list-changed.outputs.changed_charts, 'argo-workflows')

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.3
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.21
+version: 9.6.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-extension-installer to v1.0.1
+    - kind: added
+      description: Add Gateway API ListenerSet support for Argo CD server and ApplicationSet webhook

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -307,7 +307,7 @@ server:
 
 #### Gateway API with TLS backend
 
-For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy (experimental, v1alpha3):
+For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy:
 
 > **Warning:**
 > BackendTLSPolicy is in **EXPERIMENTAL** status. Not all Gateway controllers support this resource (e.g., Cilium does not yet support it).
@@ -328,6 +328,67 @@ server:
     enabled: true
     hostname: argocd-server.argocd.svc.cluster.local
     wellKnownCACertificates: System
+```
+
+#### Gateway API ListenerSet
+
+Use ListenerSet to attach listeners to an existing shared Gateway. This is useful when you want to contribute listeners to a Gateway managed by another team or namespace.
+
+> **Note:**
+> ListenerSet support is **EXPERIMENTAL**. Requires Gateway API v1.5+ and a controller that supports ListenerSet. Refer to [Gateway API implementations](https://gateway-api.sigs.k8s.io/implementations/) for controller-specific details.
+
+```yaml
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: example-gateway
+      namespace: gateway-system
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: argocd.example.com
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: argocd-server-tls
+        allowedRoutes:
+          namespaces:
+            from: Same
+```
+
+Combined with an HTTPRoute to route traffic from the listener to the Argo CD server:
+
+```yaml
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: gateway-system
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: argocd.example.com
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: argocd-server-tls
+
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+        sectionName: https
 ```
 
 ## Setting the initial admin password via Argo CD Application CR
@@ -1287,6 +1348,11 @@ NAME: my-release
 | server.ingressGrpc.tls | bool | `false` | Enable TLS configuration for the hostname defined at `server.ingressGrpc.hostname` |
 | server.initContainers | list | `[]` | Init containers to add to the server pod |
 | server.lifecycle | object | `{}` | Specify postStart and preStop lifecycle hooks for your argo-cd-server container |
+| server.listenerset.annotations | object | `{}` | Additional ListenerSet annotations |
+| server.listenerset.enabled | bool | `false` | Enable ListenerSet resource for Argo CD server (Gateway API) |
+| server.listenerset.labels | object | `{}` | Additional ListenerSet labels |
+| server.listenerset.listeners | list | `[]` (See [values.yaml]) | Listeners to attach to the parent Gateway |
+| server.listenerset.parentRef | object | `{}` (See [values.yaml]) | Gateway API parentRef for the ListenerSet |
 | server.livenessProbe.enabled | bool | `true` | Enable Kubernetes liveness probe for default backend |
 | server.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | server.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
@@ -1724,6 +1790,11 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | applicationSet.ingress.tls | bool | `false` | Enable TLS configuration for the hostname defined at `applicationSet.webhook.ingress.hostname` |
 | applicationSet.initContainers | list | `[]` | Init containers to add to the ApplicationSet controller pod |
+| applicationSet.listenerset.annotations | object | `{}` | Additional ListenerSet annotations |
+| applicationSet.listenerset.enabled | bool | `false` | Enable ListenerSet resource for Argo CD ApplicationSet webhook (Gateway API) |
+| applicationSet.listenerset.labels | object | `{}` | Additional ListenerSet labels |
+| applicationSet.listenerset.listeners | list | `[]` (See [values.yaml]) | Listeners to attach to the parent Gateway |
+| applicationSet.listenerset.parentRef | object | `{}` (See [values.yaml]) | Gateway API parentRef for the ListenerSet |
 | applicationSet.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for ApplicationSet controller |
 | applicationSet.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | applicationSet.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -306,7 +306,7 @@ server:
 
 #### Gateway API with TLS backend
 
-For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy (experimental, v1alpha3):
+For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy:
 
 > **Warning:**
 > BackendTLSPolicy is in **EXPERIMENTAL** status. Not all Gateway controllers support this resource (e.g., Cilium does not yet support it).
@@ -327,6 +327,67 @@ server:
     enabled: true
     hostname: argocd-server.argocd.svc.cluster.local
     wellKnownCACertificates: System
+```
+
+#### Gateway API ListenerSet
+
+Use ListenerSet to attach listeners to an existing shared Gateway. This is useful when you want to contribute listeners to a Gateway managed by another team or namespace.
+
+> **Note:**
+> ListenerSet support is **EXPERIMENTAL**. Requires Gateway API v1.5+ and a controller that supports ListenerSet. Refer to [Gateway API implementations](https://gateway-api.sigs.k8s.io/implementations/) for controller-specific details.
+
+```yaml
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: example-gateway
+      namespace: gateway-system
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: argocd.example.com
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: argocd-server-tls
+        allowedRoutes:
+          namespaces:
+            from: Same
+```
+
+Combined with an HTTPRoute to route traffic from the listener to the Argo CD server:
+
+```yaml
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: gateway-system
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: argocd.example.com
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: argocd-server-tls
+
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+        sectionName: https
 ```
 
 ## Setting the initial admin password via Argo CD Application CR

--- a/charts/argo-cd/ci/listenerset-values.yaml
+++ b/charts/argo-cd/ci/listenerset-values.yaml
@@ -1,3 +1,6 @@
+crds:
+  keep: false
+
 server:
   listenerset:
     enabled: true

--- a/charts/argo-cd/ci/listenerset-values.yaml
+++ b/charts/argo-cd/ci/listenerset-values.yaml
@@ -1,0 +1,22 @@
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: example-gateway
+      namespace: example-gateway-namespace
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: argocd.example.com
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: argocd-server-tls
+        allowedRoutes:
+          namespaces:
+            from: Same

--- a/charts/argo-cd/templates/argocd-applicationset/listenerset.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/listenerset.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.applicationSet.listenerset.enabled -}}
+{{- $fullName := include "argo-cd.applicationSet.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "argo-cd.namespace" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
+    {{- with .Values.applicationSet.listenerset.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.applicationSet.listenerset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRef:
+    {{- toYaml .Values.applicationSet.listenerset.parentRef | nindent 4 }}
+  {{- with .Values.applicationSet.listenerset.listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/templates/argocd-server/listenerset.yaml
+++ b/charts/argo-cd/templates/argocd-server/listenerset.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.server.listenerset.enabled -}}
+{{- $fullName := include "argo-cd.server.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "argo-cd.namespace" . }}
+  labels:
+    {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
+    {{- with .Values.server.listenerset.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.listenerset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRef:
+    {{- toYaml .Values.server.listenerset.parentRef | nindent 4 }}
+  {{- with .Values.server.listenerset.listeners }}
+  listeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2793,6 +2793,43 @@ server:
       #     kind: ConfigMap
       # wellKnownCACertificates: System
 
+  # Gateway API ListenerSet configuration
+  # NOTE: Gateway API support is in EXPERIMENTAL status
+  # ListenerSet allows attaching additional listeners to an existing Gateway
+  # Requires Gateway API v1alpha2 and a controller that supports ListenerSet
+  # Refer to https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.ListenerSet
+  listenerset:
+    # -- Enable ListenerSet resource for Argo CD server (Gateway API)
+    enabled: false
+    # -- Additional ListenerSet labels
+    labels: {}
+    # -- Additional ListenerSet annotations
+    annotations: {}
+    # -- Gateway API parentRef for the ListenerSet
+    ## Must reference an existing Gateway. Unlike HTTPRoute, ListenerSet accepts exactly one parentRef.
+    # @default -- `{}` (See [values.yaml])
+    parentRef: {}
+      # group: gateway.networking.k8s.io
+      # kind: Gateway
+      # name: example-gateway
+      # namespace: example-gateway-namespace
+    # -- Listeners to attach to the parent Gateway
+    # @default -- `[]` (See [values.yaml])
+    listeners: []
+      # - name: https
+      #   port: 443
+      #   protocol: HTTPS
+      #   hostname: argocd.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - group: ""
+      #         kind: Secret
+      #         name: argocd-server-tls
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
+
   ## Enable this and set the rules: to whatever custom rules you want for the Cluster Role resource.
   ## Defaults to off
   clusterRoleRules:
@@ -3686,6 +3723,43 @@ applicationSet:
         #         - name: X-Custom-Header
         #           value: custom-value
 
+  # Gateway API ListenerSet configuration for the Git Generator webhook
+  ## Ref: https://argocd-applicationset.readthedocs.io/en/master/Generators-Git/#webhook-configuration
+  # NOTE: Gateway API support is in EXPERIMENTAL status
+  # ListenerSet allows attaching additional listeners to an existing Gateway
+  # Requires Gateway API v1alpha2 and a controller that supports ListenerSet
+  # Refer to https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.ListenerSet
+  listenerset:
+    # -- Enable ListenerSet resource for Argo CD ApplicationSet webhook (Gateway API)
+    enabled: false
+    # -- Additional ListenerSet labels
+    labels: {}
+    # -- Additional ListenerSet annotations
+    annotations: {}
+    # -- Gateway API parentRef for the ListenerSet
+    ## Must reference an existing Gateway. Unlike HTTPRoute, ListenerSet accepts exactly one parentRef.
+    # @default -- `{}` (See [values.yaml])
+    parentRef: {}
+      # group: gateway.networking.k8s.io
+      # kind: Gateway
+      # name: example-gateway
+      # namespace: example-gateway-namespace
+    # -- Listeners to attach to the parent Gateway
+    # @default -- `[]` (See [values.yaml])
+    listeners: []
+      # - name: https
+      #   port: 443
+      #   protocol: HTTPS
+      #   hostname: argocd.example.com
+      #   tls:
+      #     mode: Terminate
+      #     certificateRefs:
+      #       - group: ""
+      #         kind: Secret
+      #         name: argocd-applicationset-controller-tls
+      #   allowedRoutes:
+      #     namespaces:
+      #       from: Same
 
   # -- Enable ApplicationSet in any namespace feature
   allowAnyNamespace: false


### PR DESCRIPTION
Hi,

This PR adds support for ListenerSet (GA with Gateway API v1.5).
I tried to keep it simple, any feedback is of course welcome.

Relates to #3931 

Thx,
Fred

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
