### PR TITLE
feat(argo-cd): add startup probes and allow overriding httpGet path for health checks

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.6.0
+version: 9.7.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add Gateway API ListenerSet support for Argo CD server and ApplicationSet webhook
+      description: Add optional startup probes and allow overriding httpGet path for health checks

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1098,6 +1098,7 @@ NAME: my-release
 | controller.podLabels | object | `{}` | Labels to be added to application controller pods |
 | controller.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the application controller pods |
 | controller.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| controller.readinessProbe.httpPath | string | `"/healthz"` | Http path to use for the readiness probe |
 | controller.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | controller.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | controller.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
@@ -1112,6 +1113,13 @@ NAME: my-release
 | controller.serviceAccount.create | bool | `true` | Create a service account for the application controller |
 | controller.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | controller.serviceAccount.name | string | `"argocd-application-controller"` | Service account name |
+| controller.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for application controller |
+| controller.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| controller.startupProbe.httpPath | string | `"/healthz"` | Http path to use for the startup probe |
+| controller.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| controller.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| controller.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| controller.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | controller.statefulsetAnnotations | object | `{}` | Annotations for the application controller StatefulSet |
 | controller.statefulsetLabels | object | `{}` | Labels for the application controller StatefulSet |
 | controller.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
@@ -1171,6 +1179,7 @@ NAME: my-release
 | repoServer.lifecycle | object | `{}` | Specify postStart and preStop lifecycle hooks for your argo-repo-server container |
 | repoServer.livenessProbe.enabled | bool | `true` | Enable Kubernetes liveness probe for Repo Server |
 | repoServer.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| repoServer.livenessProbe.httpPath | string | `"/healthz?full=true"` | Http path to use for the liveness probe |
 | repoServer.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | repoServer.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | repoServer.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
@@ -1208,6 +1217,7 @@ NAME: my-release
 | repoServer.rbac | list | `[]` | Repo server rbac rules |
 | repoServer.readinessProbe.enabled | bool | `true` | Enable Kubernetes readiness probe for Repo Server |
 | repoServer.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| repoServer.readinessProbe.httpPath | string | `"/healthz"` | Http path to use for the readiness probe |
 | repoServer.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | repoServer.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | repoServer.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
@@ -1225,6 +1235,13 @@ NAME: my-release
 | repoServer.serviceAccount.create | bool | `true` | Create repo server service account |
 | repoServer.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | repoServer.serviceAccount.name | string | `""` | Repo server service account name |
+| repoServer.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for Repo Server |
+| repoServer.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| repoServer.startupProbe.httpPath | string | `"/healthz"` | Http path to use for the startup probe |
+| repoServer.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| repoServer.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| repoServer.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| repoServer.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | repoServer.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | repoServer.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | repoServer.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the repo server |
@@ -1355,6 +1372,7 @@ NAME: my-release
 | server.listenerset.parentRef | object | `{}` (See [values.yaml]) | Gateway API parentRef for the ListenerSet |
 | server.livenessProbe.enabled | bool | `true` | Enable Kubernetes liveness probe for default backend |
 | server.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| server.livenessProbe.httpPath | string | `"/healthz?full=true"` | Http path to use for the liveness probe |
 | server.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | server.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | server.livenessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
@@ -1391,6 +1409,7 @@ NAME: my-release
 | server.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the Argo CD server pods |
 | server.readinessProbe.enabled | bool | `true` | Enable Kubernetes readiness probe for default backend |
 | server.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| server.readinessProbe.httpPath | string | `"/healthz"` | Http path to use for the readiness probe |
 | server.readinessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | server.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | server.readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
@@ -1424,6 +1443,13 @@ NAME: my-release
 | server.serviceAccount.create | bool | `true` | Create server service account |
 | server.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | server.serviceAccount.name | string | `"argocd-server"` | Server service account name |
+| server.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for Argo CD server |
+| server.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| server.startupProbe.httpPath | string | `"/healthz"` | Http path to use for the startup probe |
+| server.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| server.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| server.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| server.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | server.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | server.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | server.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the Argo CD server |
@@ -1526,6 +1552,15 @@ NAME: my-release
 | dex.servicePortHttp | int | `5556` | Service port for HTTP access |
 | dex.servicePortHttpName | string | `"http"` | Service port name for HTTP access |
 | dex.servicePortMetrics | int | `5558` | Service port for metrics access |
+| dex.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for Dex >= 2.28.0 |
+| dex.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| dex.startupProbe.httpPath | string | `"/healthz/ready"` | Http path to use for the startup probe |
+| dex.startupProbe.httpPort | string | `"metrics"` | Http port to use for the startup probe |
+| dex.startupProbe.httpScheme | string | `"HTTP"` | Scheme to use for the startup probe (can be HTTP or HTTPS) |
+| dex.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| dex.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| dex.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| dex.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | dex.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | dex.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | dex.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to dex |
@@ -1850,6 +1885,12 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.serviceAccount.create | bool | `true` | Create ApplicationSet controller service account |
 | applicationSet.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | applicationSet.serviceAccount.name | string | `"argocd-applicationset-controller"` | ApplicationSet controller service account name |
+| applicationSet.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for ApplicationSet controller |
+| applicationSet.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| applicationSet.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| applicationSet.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| applicationSet.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| applicationSet.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | applicationSet.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | applicationSet.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | applicationSet.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the ApplicationSet controller |
@@ -1940,6 +1981,12 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.serviceAccount.create | bool | `true` | Create notifications controller service account |
 | notifications.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | notifications.serviceAccount.name | string | `"argocd-notifications-controller"` | Notification controller service account name |
+| notifications.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for notifications controller Pods |
+| notifications.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| notifications.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| notifications.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| notifications.startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the [probe] to be considered successful after having failed |
+| notifications.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | notifications.subscriptions | list | `[]` | Contains centrally managed global application subscriptions |
 | notifications.templates | object | `{}` | The notification template is used to generate the notification content |
 | notifications.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
@@ -1979,6 +2026,7 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | commitServer.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the commit server |
 | commitServer.livenessProbe.enabled | bool | `true` | Enable Kubernetes liveness probe for commit server |
 | commitServer.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| commitServer.livenessProbe.httpPath | string | `"/healthz?full=true"` | Http path to use for the liveness probe |
 | commitServer.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds after the container has started before [probe] is initiated |
 | commitServer.livenessProbe.periodSeconds | int | `30` | How often (in seconds) to perform the [probe] |
 | commitServer.livenessProbe.timeoutSeconds | int | `5` | Number of seconds after which the [probe] times out |
@@ -1997,6 +2045,7 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | commitServer.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the commit server pods |
 | commitServer.readinessProbe.enabled | bool | `true` | Enable Kubernetes liveness probe for commit server |
 | commitServer.readinessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| commitServer.readinessProbe.httpPath | string | `"/healthz"` | Http path to use for the readiness probe |
 | commitServer.readinessProbe.initialDelaySeconds | int | `5` | Number of seconds after the container has started before [probe] is initiated |
 | commitServer.readinessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
 | commitServer.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
@@ -2011,6 +2060,12 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | commitServer.serviceAccount.create | bool | `true` | Create commit server service account |
 | commitServer.serviceAccount.labels | object | `{}` | Labels applied to created service account |
 | commitServer.serviceAccount.name | string | `"argocd-commit-server"` | commit server service account name |
+| commitServer.startupProbe.enabled | bool | `false` | Enable Kubernetes startup probe for commit server |
+| commitServer.startupProbe.failureThreshold | int | `20` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
+| commitServer.startupProbe.httpPath | string | `"/healthz"` | Http path to use for the startup probe |
+| commitServer.startupProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
+| commitServer.startupProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |
+| commitServer.startupProbe.timeoutSeconds | int | `1` | Number of seconds after which the [probe] times out |
 | commitServer.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | commitServer.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | commitServer.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the commit server |

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -371,13 +371,24 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: {{ .Values.controller.readinessProbe.httpPath }}
             port: metrics
           initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+        {{- if .Values.controller.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.controller.startupProbe.httpPath }}
+            port: metrics
+          initialDelaySeconds: {{ .Values.controller.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.controller.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.controller.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.controller.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.controller.startupProbe.failureThreshold }}
+        {{- end }}
         resources:
           {{- toYaml .Values.controller.resources | nindent 10 }}
         {{- with .Values.controller.containerSecurityContext }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -278,6 +278,16 @@ spec:
             successThreshold: {{ .Values.applicationSet.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.applicationSet.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.applicationSet.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: probe
+            initialDelaySeconds: {{ .Values.applicationSet.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.applicationSet.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.applicationSet.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.applicationSet.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.applicationSet.startupProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.applicationSet.resources | nindent 12 }}
           {{- with .Values.applicationSet.containerSecurityContext }}

--- a/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
@@ -118,7 +118,7 @@ spec:
         {{- if .Values.commitServer.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /healthz?full=true
+            path: {{ .Values.commitServer.livenessProbe.httpPath }}
             port: 8087
           initialDelaySeconds: {{ .Values.commitServer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.commitServer.livenessProbe.periodSeconds }}
@@ -128,12 +128,22 @@ spec:
         {{- if .Values.commitServer.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: {{ .Values.commitServer.readinessProbe.httpPath }}
             port: 8087
           initialDelaySeconds: {{ .Values.commitServer.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.commitServer.readinessProbe.periodSeconds }}
           failureThreshold: {{ .Values.commitServer.readinessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.commitServer.readinessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.commitServer.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.commitServer.startupProbe.httpPath }}
+            port: 8087
+          initialDelaySeconds: {{ .Values.commitServer.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.commitServer.startupProbe.periodSeconds }}
+          failureThreshold: {{ .Values.commitServer.startupProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.commitServer.startupProbe.timeoutSeconds }}
         {{- end }}
         resources:
           {{- toYaml .Values.commitServer.resources | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -150,6 +150,16 @@ spec:
             successThreshold: {{ .Values.notifications.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.notifications.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.notifications.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: {{ .Values.notifications.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.notifications.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.notifications.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.notifications.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.notifications.startupProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.notifications.resources | nindent 12 }}
           {{- with .Values.notifications.containerSecurityContext }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -386,7 +386,7 @@ spec:
         {{- if .Values.repoServer.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /healthz?full=true
+            path: {{ .Values.repoServer.livenessProbe.httpPath }}
             port: metrics
           initialDelaySeconds: {{ .Values.repoServer.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.repoServer.livenessProbe.periodSeconds }}
@@ -397,13 +397,24 @@ spec:
         {{- if .Values.repoServer.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: {{ .Values.repoServer.readinessProbe.httpPath }}
             port: metrics
           initialDelaySeconds: {{ .Values.repoServer.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.repoServer.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.repoServer.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.repoServer.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.repoServer.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.repoServer.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.repoServer.startupProbe.httpPath }}
+            port: metrics
+          initialDelaySeconds: {{ .Values.repoServer.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.repoServer.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.repoServer.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.repoServer.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.repoServer.startupProbe.failureThreshold }}
         {{- end }}
         resources:
           {{- toYaml .Values.repoServer.resources | nindent 10 }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -424,7 +424,7 @@ spec:
         {{- if .Values.server.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /healthz?full=true
+            path: {{ .Values.server.livenessProbe.httpPath }}
             port: server
           initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
@@ -435,13 +435,24 @@ spec:
         {{- if .Values.server.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: {{ .Values.server.readinessProbe.httpPath }}
             port: server
           initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.server.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.server.startupProbe.httpPath }}
+            port: server
+          initialDelaySeconds: {{ .Values.server.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.server.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.server.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
         {{- end }}
         resources:
           {{- toYaml .Values.server.resources | nindent 10 }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -152,6 +152,18 @@ spec:
           successThreshold: {{ .Values.dex.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.dex.readinessProbe.failureThreshold }}
         {{- end }}
+        {{- if .Values.dex.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.dex.startupProbe.httpPath }}
+            port: {{ .Values.dex.startupProbe.httpPort }}
+            scheme: {{ .Values.dex.startupProbe.httpScheme }}
+          initialDelaySeconds: {{ .Values.dex.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.dex.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.dex.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.dex.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.dex.startupProbe.failureThreshold }}
+        {{- end }}
         resources:
           {{- toYaml .Values.dex.resources | nindent 10 }}
         {{- with .Values.dex.containerSecurityContext }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -951,8 +951,28 @@ controller:
   # Readiness probe for application controller
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   readinessProbe:
+    # -- Http path to use for the readiness probe
+    httpPath: /healthz
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+
+  ## Startup probe for application controller (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe:
+    # -- Enable Kubernetes startup probe for application controller
+    enabled: false
+    # -- Http path to use for the startup probe
+    httpPath: /healthz
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
     # -- Number of seconds after the container has started before [probe] is initiated
     initialDelaySeconds: 10
     # -- How often (in seconds) to perform the [probe]
@@ -1370,6 +1390,28 @@ dex:
     httpScheme: HTTP
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+
+  ## Startup probe for Dex server (optional)
+  ## Supported from Dex >= 2.28.0
+  startupProbe:
+    # -- Enable Kubernetes startup probe for Dex >= 2.28.0
+    enabled: false
+    # -- Http path to use for the startup probe
+    httpPath: /healthz/ready
+    # -- Http port to use for the startup probe
+    httpPort: metrics
+    # -- Scheme to use for the startup probe (can be HTTP or HTTPS)
+    httpScheme: HTTP
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
     # -- Number of seconds after the container has started before [probe] is initiated
     initialDelaySeconds: 10
     # -- How often (in seconds) to perform the [probe]
@@ -2271,6 +2313,8 @@ server:
   readinessProbe:
     # -- Enable Kubernetes readiness probe for default backend
     enabled: true
+    # -- Http path to use for the readiness probe
+    httpPath: /healthz
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
     # -- Number of seconds after the container has started before [probe] is initiated
@@ -2285,8 +2329,28 @@ server:
   livenessProbe:
     # -- Enable Kubernetes liveness probe for default backend
     enabled: true
+    # -- Http path to use for the liveness probe
+    httpPath: /healthz?full=true
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+
+  ## Startup probe for Argo CD server (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe:
+    # -- Enable Kubernetes startup probe for Argo CD server
+    enabled: false
+    # -- Http path to use for the startup probe
+    httpPath: /healthz
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
     # -- Number of seconds after the container has started before [probe] is initiated
     initialDelaySeconds: 10
     # -- How often (in seconds) to perform the [probe]
@@ -3112,6 +3176,8 @@ repoServer:
   readinessProbe:
     # -- Enable Kubernetes readiness probe for Repo Server
     enabled: true
+    # -- Http path to use for the readiness probe
+    httpPath: /healthz
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
     # -- Number of seconds after the container has started before [probe] is initiated
@@ -3126,8 +3192,28 @@ repoServer:
   livenessProbe:
     # -- Enable Kubernetes liveness probe for Repo Server
     enabled: true
+    # -- Http path to use for the liveness probe
+    httpPath: /healthz?full=true
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+
+  ## Startup probe for Repo Server (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe:
+    # -- Enable Kubernetes startup probe for Repo Server
+    enabled: false
+    # -- Http path to use for the startup probe
+    httpPath: /healthz
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
     # -- Number of seconds after the container has started before [probe] is initiated
     initialDelaySeconds: 10
     # -- How often (in seconds) to perform the [probe]
@@ -3544,6 +3630,22 @@ applicationSet:
     successThreshold: 1
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
+
+  ## Startup probe for ApplicationSet controller (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe:
+    # -- Enable Kubernetes startup probe for ApplicationSet controller
+    enabled: false
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
 
   # -- terminationGracePeriodSeconds for container lifecycle hook
   terminationGracePeriodSeconds: 30
@@ -4034,6 +4136,22 @@ notifications:
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
 
+  ## Startup probe for notifications controller Pods (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe:
+    # -- Enable Kubernetes startup probe for notifications controller Pods
+    enabled: false
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+    # -- Minimum consecutive successes for the [probe] to be considered successful after having failed
+    successThreshold: 1
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
+
   # -- terminationGracePeriodSeconds for container lifecycle hook
   terminationGracePeriodSeconds: 30
 
@@ -4500,6 +4618,8 @@ commitServer:
   readinessProbe:
     # -- Enable Kubernetes liveness probe for commit server
     enabled: true
+    # -- Http path to use for the readiness probe
+    httpPath: /healthz
     # -- Number of seconds after the container has started before [probe] is initiated
     initialDelaySeconds: 5
     # -- How often (in seconds) to perform the [probe]
@@ -4512,6 +4632,8 @@ commitServer:
   livenessProbe:
     # -- Enable Kubernetes liveness probe for commit server
     enabled: true
+    # -- Http path to use for the liveness probe
+    httpPath: /healthz?full=true
     # -- Number of seconds after the container has started before [probe] is initiated
     initialDelaySeconds: 30
     # -- How often (in seconds) to perform the [probe]
@@ -4520,6 +4642,22 @@ commitServer:
     timeoutSeconds: 5
     # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
     failureThreshold: 3
+
+  ## Startup probe for commit server (optional)
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe:
+    # -- Enable Kubernetes startup probe for commit server
+    enabled: false
+    # -- Http path to use for the startup probe
+    httpPath: /healthz
+    # -- Number of seconds after the container has started before [probe] is initiated
+    initialDelaySeconds: 10
+    # -- How often (in seconds) to perform the [probe]
+    periodSeconds: 10
+    # -- Number of seconds after which the [probe] times out
+    timeoutSeconds: 1
+    # -- Minimum consecutive failures for the [probe] to be considered failed after having succeeded
+    failureThreshold: 20
 
   # -- terminationGracePeriodSeconds for container lifecycle hook
   terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

## Summary

This PR adds two enhancements to health check configuration in the `argo-cd` chart.

### 1. Optional startup probes (disabled by default)

Adds `startupProbe` configuration to all components: `server`, `repoServer`, `controller`, `applicationSet`, `notifications`, `commitServer`, and `dex`.

Startup probes are disabled by default (`enabled: false`) so there is no change in behavior for existing deployments. When enabled, they default to `failureThreshold: 20` with `periodSeconds: 10`, giving containers up to 200 seconds to start before liveness/readiness checks kick in.

Addresses: #3933, #1827

### 2. Configurable httpGet path for liveness and readiness probes

Adds an `httpPath` field to `livenessProbe` and `readinessProbe` for components that use `httpGet`: `server`, `repoServer`, `controller`, and `commitServer`.

The default values preserve the current behavior (`/healthz?full=true` for liveness, `/healthz` for readiness), so this is fully backwards compatible.

**Motivation:** Provides flexibility for future troubleshooting and workarounds. For example, on `repoServer` the liveness probe at `/healthz?full=true` invokes the gRPC health service, which has historically been a source of issues (see argoproj/argo-cd#25931). While `GRPC_ENABLE_TXT_SERVICE_CONFIG=false` is now the default from ArgoCD 3.4 onwards and mitigates the known DNS lookup problem, being able to switch the probe path (e.g. to `/healthz`) remains a useful escape hatch for diagnosing or working around gRPC-related health check issues in the future.