### PR TITLE
feat(argo-cd): support opt-in hostUsers for container isolation

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 9.5.22
+version: 9.5.23
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-cd to v3.4.4
+    - kind: added
+      description: Add support for hostUsers configuration

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -46,6 +46,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.controller "hostUsers" }}
+      hostUsers: {{ .Values.controller.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -47,6 +47,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.controller "hostUsers" }}
+      hostUsers: {{ .Values.controller.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -46,6 +46,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.applicationSet "hostUsers" }}
+      hostUsers: {{ .Values.applicationSet.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
@@ -45,6 +45,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.commitServer "hostUsers" }}
+      hostUsers: {{ .Values.commitServer.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -47,6 +47,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.notifications "hostUsers" }}
+      hostUsers: {{ .Values.notifications.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -57,6 +57,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.repoServer "hostUsers" }}
+      hostUsers: {{ .Values.repoServer.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -51,6 +51,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.server "hostUsers" }}
+      hostUsers: {{ .Values.server.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -53,6 +53,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.dex "hostUsers" }}
+      hostUsers: {{ .Values.dex.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -43,6 +43,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if hasKey .Values.redis "hostUsers" }}
+      hostUsers: {{ .Values.redis.hostUsers }}
+      {{- else if hasKey .Values.global "hostUsers" }}
+      hostUsers: {{ .Values.global.hostUsers }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -108,6 +108,9 @@ global:
   #   hostnames:
   #   - git.myhostname
 
+  # -- Toggle `hostUsers` for all pods. Set to `false` to opt-in to user namespaces for enhanced container runtime isolation.
+  # hostUsers: false
+
   # Configure dual-stack used by all component services
   dualStack:
     # -- IP family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)


### PR DESCRIPTION

## Summary
This PR adds explicit support for the `hostUsers` PodSpec field, mapping to the upstream hardening feature discussed in argoproj/argo-cd#28251.

Setting `hostUsers: false` forces the container runtime to allocate a user namespace, heavily restricting pod-to-host privilege escalation. Since this breaks clusters without proper `subuid`/`subgid` configuration (such as `kind`), we have exposed it as a commented-out option (`# hostUsers: false`) globally in `values.yaml`. This preserves backwards compatibility while providing a discoverable mechanism for cluster administrators to opt-in cleanly.

Fixes #3918

Checklist:

* [x] I have bumped the chart version according to versioning
* [x] I have updated the documentation according to documentation
* [x] I have updated the chart changelog with all the changes that come with this pull request according to changelog.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by DCO.
* [x] I have created a separate pull request for each chart according to pull requests
* [x] My build is green (troubleshooting builds).
