### PR TITLE
fix(argo-cd): render valid redis secret name when redis-ha haproxy disabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.0.0
+version: 10.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Enable network policies for all components by default
+      description: Render a valid redis secret name for Redis sentinel env vars when redis-ha is enabled with haproxy disabled

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -57,6 +57,8 @@ Create redis name and version as used by the chart label.
 {{- if $redisHa.enabled -}}
     {{- if $redisHa.haproxy.enabled -}}
         {{- printf "%s-haproxy" (include "redis-ha.fullname" $redisHaContext) | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- include "redis-ha.fullname" $redisHaContext | trunc 63 | trimSuffix "-" -}}
     {{- end -}}
 {{- else -}}
 {{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.redis.name | trunc 63 | trimSuffix "-" -}}


### PR DESCRIPTION
## Description

The `argo-cd.redis.fullname` helper has no `else` branch for the case where **`redis-ha` is enabled but `redis-ha.haproxy` is disabled**:

```gotmpl
{{- if $redisHa.enabled -}}
    {{- if $redisHa.haproxy.enabled -}}
        {{- printf "%s-haproxy" (include "redis-ha.fullname" $redisHaContext) | trunc 63 | trimSuffix "-" -}}
    {{- end -}}          {{/* <-- no else: returns "" in haproxy-less mode */}}
{{- else -}}
    {{- printf "%s-%s" (include "argo-cd.fullname" .) .Values.redis.name | trunc 63 | trimSuffix "-" -}}
{{- end -}}
```

In that mode the helper returns an empty string, which flows into the `REDIS_SENTINEL_USERNAME` / `REDIS_SENTINEL_PASSWORD` env `secretKeyRef.name` on `argocd-server`, `argocd-repo-server` and `argocd-application-controller`:

```yaml
- name: REDIS_SENTINEL_USERNAME
  valueFrom:
    secretKeyRef:
      name: {{ default (include "argo-cd.redis.fullname" .) .Values.externalRedis.existingSecret }}
      key: redis-sentinel-username
      optional: true
```

With no `externalRedis.existingSecret` set, the rendered name is empty and Kubernetes rejects the manifest even though the ref is `optional: true`:

```
secretKeyRef.name: Invalid value: "": a lowercase RFC 1123 subdomain must
consist of lower case alphanumeric characters, '-' or '.', and must start
and end with an alphanumeric character
```

This makes haproxy-less (sentinel-native) redis-ha — a legitimate way to run HA redis without the 3 extra haproxy pods, using ArgoCD's native `--sentinel` discovery — impossible to deploy without a workaround.

## Fix

Add the missing `else` branch returning the redis-ha service name:

```gotmpl
    {{- if $redisHa.haproxy.enabled -}}
        {{- printf "%s-haproxy" (include "redis-ha.fullname" $redisHaContext) | trunc 63 | trimSuffix "-" -}}
    {{- else -}}
        {{- include "redis-ha.fullname" $redisHaContext | trunc 63 | trimSuffix "-" -}}
    {{- end -}}
```

## Verification

`helm template` with `redis-ha.enabled=true`, `redis-ha.haproxy.enabled=false`:

| | sentinel `secretKeyRef.name` |
|---|---|
| **before** | `""`  (rejected by k8s) |
| **after** | `argocd-redis-ha` (valid) |

No change to any other rendered output (haproxy-enabled and standalone-redis paths are untouched). No `values.yaml` / `README.md.gotmpl` change, so no helm-docs regeneration needed.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning) (`10.0.0` -> `10.0.1`, patch — backwards-compatible bug fix)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) (no `values.yaml` change, so no README regeneration needed)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog) (`artifacthub.io/changes` entry added)
* [x] Any new values are backwards compatible and/or have sensible default. (no new values added)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests) (only `argo-cd` chart touched)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
