### PR TITLE
fix(argo-workflows): skip static credential rendering when useSDKCreds is true

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.6
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.16
+version: 1.0.17
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump kubectl to v1.36.2
+    - kind: fixed
+      description: Skip rendering accessKeySecret/secretKeySecret when useSDKCreds is true

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -76,7 +76,7 @@ data:
       {{- end }}
       {{- if .Values.artifactRepository.s3 }}
       s3:
-        {{- if .Values.useStaticCredentials }}
+        {{- if and .Values.useStaticCredentials (not .Values.artifactRepository.s3.useSDKCreds) }}
         accessKeySecret:
           key: {{ tpl .Values.artifactRepository.s3.accessKeySecret.key . }}
           name: {{ tpl .Values.artifactRepository.s3.accessKeySecret.name . }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## What this PR does

When `artifactRepository.s3.useSDKCreds: true` is set (e.g. for IRSA / IAM Roles for Service Accounts on EKS), the chart still renders `accessKeySecret` and `secretKeySecret` because `useStaticCredentials` defaults to `true`.

Since `accessKeySecret` is not provided by the user in this case, the template fails with a nil pointer error:

> `nil pointer evaluating interface {}.key`

This makes the Helm release unrenderable, causing ArgoCD to show `ComparisonError` and the `argo` namespace to never be created.

## Changes

Conditionally skip the `accessKeySecret` / `secretKeySecret` / `sessionTokenSecret` block when `useSDKCreds: true`, regardless of the `useStaticCredentials` value.

```diff
- {{- if .Values.useStaticCredentials }}
+ {{- if and .Values.useStaticCredentials (not .Values.artifactRepository.s3.useSDKCreds) }}
```

## Backward compatibility

- Users relying on static credentials (`useStaticCredentials: true` with `accessKeySecret` set) are unaffected.
- Users using SDK-based auth (`useSDKCreds: true`) no longer need to set `useStaticCredentials: false` explicitly or provide dummy credential values as a workaround.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
