### PR TITLE
fix(argo-cd): improve listenerset usability

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.5
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.1.4
+version: 10.2.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump redis_exporter to v1.87.0
+      description: Improve Gateway API ListenerSet usability with synthesized default listener and auto-derived HTTPRoute parentRefs from global.domain

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -337,13 +337,59 @@ Use ListenerSet to attach listeners to an existing shared Gateway. This is usefu
 > **Note:**
 > ListenerSet support is **EXPERIMENTAL**. Requires Gateway API v1.5+ and a controller that supports ListenerSet. Refer to [Gateway API implementations](https://gateway-api.sigs.k8s.io/implementations/) for controller-specific details.
 
+Only `parentRef` (pointing to the parent Gateway) is required. A default HTTPS listener is synthesized automatically using `global.domain` as the hostname:
+
+```yaml
+global:
+  domain: argocd.example.com
+
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: gateway-system
+```
+
+Combined with an HTTPRoute to route traffic through the listener to the Argo CD server. The HTTPRoute automatically targets the ListenerSet and inherits the hostname from `global.domain` — no extra configuration needed:
+
+```yaml
+global:
+  domain: argocd.example.com
+
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: gateway-system
+
+  httproute:
+    enabled: true
+```
+
+To customise the synthesized listener (e.g. change the port, protocol, or TLS secret), override the individual fields:
+
 ```yaml
 server:
   listenerset:
     enabled: true
     parentRef:
-      group: gateway.networking.k8s.io
-      kind: Gateway
+      name: example-gateway
+      namespace: gateway-system
+    hostname: custom.example.com   # overrides global.domain
+    port: 8443
+    tls:
+      secretName: my-tls-secret
+```
+
+For full control, provide a `listeners` array directly. When non-empty it is used verbatim and all synthesized listener fields are ignored:
+
+```yaml
+server:
+  listenerset:
+    enabled: true
+    parentRef:
       name: example-gateway
       namespace: gateway-system
     listeners:
@@ -360,35 +406,6 @@ server:
         allowedRoutes:
           namespaces:
             from: Same
-```
-
-Combined with an HTTPRoute to route traffic from the listener to the Argo CD server:
-
-```yaml
-server:
-  listenerset:
-    enabled: true
-    parentRef:
-      name: example-gateway
-      namespace: gateway-system
-    listeners:
-      - name: https
-        port: 443
-        protocol: HTTPS
-        hostname: argocd.example.com
-        tls:
-          mode: Terminate
-          certificateRefs:
-            - group: ""
-              kind: Secret
-              name: argocd-server-tls
-
-  httproute:
-    enabled: true
-    parentRefs:
-      - name: example-gateway
-        namespace: gateway-system
-        sectionName: https
 ```
 
 ## Setting the initial admin password via Argo CD Application CR
@@ -1370,11 +1387,20 @@ NAME: my-release
 | server.ingressGrpc.tls | bool | `false` | Enable TLS configuration for the hostname defined at `server.ingressGrpc.hostname` |
 | server.initContainers | list | `[]` | Init containers to add to the server pod |
 | server.lifecycle | object | `{}` | Specify postStart and preStop lifecycle hooks for your argo-cd-server container |
+| server.listenerset.allowedRoutes | object | `{"namespaces":{"from":"Same"}}` | allowedRoutes for the synthesized listener |
 | server.listenerset.annotations | object | `{}` | Additional ListenerSet annotations |
 | server.listenerset.enabled | bool | `false` | Enable ListenerSet resource for Argo CD server (Gateway API) |
+| server.listenerset.hostname | string | `""` | Hostname for the synthesized listener. Defaults to global.domain when empty. |
 | server.listenerset.labels | object | `{}` | Additional ListenerSet labels |
-| server.listenerset.listeners | list | `[]` (See [values.yaml]) | Listeners to attach to the parent Gateway |
+| server.listenerset.listenerName | string | `"https"` | Name of the synthesized listener. Also used as sectionName in auto-derived httproute parentRefs. |
+| server.listenerset.listeners | list | `[]` (See [values.yaml]) | Listeners to attach to the parent Gateway. When non-empty, used verbatim and all synthesized listener fields above are ignored. |
 | server.listenerset.parentRef | object | `{}` (See [values.yaml]) | Gateway API parentRef for the ListenerSet |
+| server.listenerset.port | int | `443` | Port for the synthesized listener |
+| server.listenerset.protocol | string | `"HTTPS"` | Protocol for the synthesized listener |
+| server.listenerset.tls | object | `{"enabled":true,"mode":"Terminate","secretName":""}` | TLS configuration for the synthesized listener |
+| server.listenerset.tls.enabled | bool | `true` | Enable TLS on the synthesized listener |
+| server.listenerset.tls.mode | string | `"Terminate"` | TLS termination mode |
+| server.listenerset.tls.secretName | string | `""` | Secret name for TLS certificate. Defaults to `argocd-server-tls` when empty. |
 | server.livenessProbe.enabled | bool | `true` | Enable Kubernetes liveness probe for default backend |
 | server.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | server.livenessProbe.httpPath | string | `"/healthz?full=true"` | Http path to use for the liveness probe |
@@ -1830,11 +1856,20 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.ingress.pathType | string | `"Prefix"` | Ingress path type. One of `Exact`, `Prefix` or `ImplementationSpecific` |
 | applicationSet.ingress.tls | bool | `false` | Enable TLS configuration for the hostname defined at `applicationSet.webhook.ingress.hostname` |
 | applicationSet.initContainers | list | `[]` | Init containers to add to the ApplicationSet controller pod |
+| applicationSet.listenerset.allowedRoutes | object | `{"namespaces":{"from":"Same"}}` | allowedRoutes for the synthesized listener |
 | applicationSet.listenerset.annotations | object | `{}` | Additional ListenerSet annotations |
 | applicationSet.listenerset.enabled | bool | `false` | Enable ListenerSet resource for Argo CD ApplicationSet webhook (Gateway API) |
+| applicationSet.listenerset.hostname | string | `""` | Hostname for the synthesized listener. Defaults to global.domain when empty. |
 | applicationSet.listenerset.labels | object | `{}` | Additional ListenerSet labels |
-| applicationSet.listenerset.listeners | list | `[]` (See [values.yaml]) | Listeners to attach to the parent Gateway |
+| applicationSet.listenerset.listenerName | string | `"https"` | Name of the synthesized listener. Also used as sectionName in auto-derived httproute parentRefs. |
+| applicationSet.listenerset.listeners | list | `[]` (See [values.yaml]) | Listeners to attach to the parent Gateway. When non-empty, used verbatim and all synthesized listener fields above are ignored. |
 | applicationSet.listenerset.parentRef | object | `{}` (See [values.yaml]) | Gateway API parentRef for the ListenerSet |
+| applicationSet.listenerset.port | int | `443` | Port for the synthesized listener |
+| applicationSet.listenerset.protocol | string | `"HTTPS"` | Protocol for the synthesized listener |
+| applicationSet.listenerset.tls | object | `{"enabled":true,"mode":"Terminate","secretName":""}` | TLS configuration for the synthesized listener |
+| applicationSet.listenerset.tls.enabled | bool | `true` | Enable TLS on the synthesized listener |
+| applicationSet.listenerset.tls.mode | string | `"Terminate"` | TLS termination mode |
+| applicationSet.listenerset.tls.secretName | string | `""` | Secret name for TLS certificate. Defaults to `argocd-applicationset-controller-tls` when empty. |
 | applicationSet.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for ApplicationSet controller |
 | applicationSet.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | applicationSet.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -336,13 +336,59 @@ Use ListenerSet to attach listeners to an existing shared Gateway. This is usefu
 > **Note:**
 > ListenerSet support is **EXPERIMENTAL**. Requires Gateway API v1.5+ and a controller that supports ListenerSet. Refer to [Gateway API implementations](https://gateway-api.sigs.k8s.io/implementations/) for controller-specific details.
 
+Only `parentRef` (pointing to the parent Gateway) is required. A default HTTPS listener is synthesized automatically using `global.domain` as the hostname:
+
+```yaml
+global:
+  domain: argocd.example.com
+
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: gateway-system
+```
+
+Combined with an HTTPRoute to route traffic through the listener to the Argo CD server. The HTTPRoute automatically targets the ListenerSet and inherits the hostname from `global.domain` — no extra configuration needed:
+
+```yaml
+global:
+  domain: argocd.example.com
+
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: gateway-system
+
+  httproute:
+    enabled: true
+```
+
+To customise the synthesized listener (e.g. change the port, protocol, or TLS secret), override the individual fields:
+
 ```yaml
 server:
   listenerset:
     enabled: true
     parentRef:
-      group: gateway.networking.k8s.io
-      kind: Gateway
+      name: example-gateway
+      namespace: gateway-system
+    hostname: custom.example.com   # overrides global.domain
+    port: 8443
+    tls:
+      secretName: my-tls-secret
+```
+
+For full control, provide a `listeners` array directly. When non-empty it is used verbatim and all synthesized listener fields are ignored:
+
+```yaml
+server:
+  listenerset:
+    enabled: true
+    parentRef:
       name: example-gateway
       namespace: gateway-system
     listeners:
@@ -359,35 +405,6 @@ server:
         allowedRoutes:
           namespaces:
             from: Same
-```
-
-Combined with an HTTPRoute to route traffic from the listener to the Argo CD server:
-
-```yaml
-server:
-  listenerset:
-    enabled: true
-    parentRef:
-      name: example-gateway
-      namespace: gateway-system
-    listeners:
-      - name: https
-        port: 443
-        protocol: HTTPS
-        hostname: argocd.example.com
-        tls:
-          mode: Terminate
-          certificateRefs:
-            - group: ""
-              kind: Secret
-              name: argocd-server-tls
-
-  httproute:
-    enabled: true
-    parentRefs:
-      - name: example-gateway
-        namespace: gateway-system
-        sectionName: https
 ```
 
 ## Setting the initial admin password via Argo CD Application CR

--- a/charts/argo-cd/ci/listenerset-defaults-values.yaml
+++ b/charts/argo-cd/ci/listenerset-defaults-values.yaml
@@ -1,0 +1,14 @@
+crds:
+  keep: false
+
+global:
+  domain: argocd.example.com
+
+server:
+  listenerset:
+    enabled: true
+    parentRef:
+      name: example-gateway
+      namespace: example-gateway-namespace
+  httproute:
+    enabled: true

--- a/charts/argo-cd/templates/argocd-applicationset/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/httproute.yaml
@@ -16,12 +16,21 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- with .Values.applicationSet.httproute.parentRefs }}
-      {{- toYaml . | nindent 4 }}
+    {{- if .Values.applicationSet.httproute.parentRefs }}
+    {{- toYaml .Values.applicationSet.httproute.parentRefs | nindent 4 }}
+    {{- else if .Values.applicationSet.listenerset.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ $fullName }}
+      namespace: {{ include "argo-cd.namespace" . }}
+      sectionName: {{ .Values.applicationSet.listenerset.listenerName }}
     {{- end }}
-  {{- with .Values.applicationSet.httproute.hostnames }}
+  {{- if .Values.applicationSet.httproute.hostnames }}
   hostnames:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.applicationSet.httproute.hostnames | nindent 4 }}
+  {{- else if .Values.applicationSet.listenerset.enabled }}
+  hostnames:
+    - {{ tpl (.Values.applicationSet.listenerset.hostname | default .Values.global.domain) $ | quote }}
   {{- end }}
   rules:
     {{- range .Values.applicationSet.httproute.rules }}

--- a/charts/argo-cd/templates/argocd-applicationset/listenerset.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/listenerset.yaml
@@ -17,8 +17,23 @@ metadata:
 spec:
   parentRef:
     {{- toYaml .Values.applicationSet.listenerset.parentRef | nindent 4 }}
-  {{- with .Values.applicationSet.listenerset.listeners }}
   listeners:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if .Values.applicationSet.listenerset.listeners }}
+    {{- toYaml .Values.applicationSet.listenerset.listeners | nindent 4 }}
+    {{- else }}
+    - name: {{ .Values.applicationSet.listenerset.listenerName }}
+      port: {{ .Values.applicationSet.listenerset.port }}
+      protocol: {{ .Values.applicationSet.listenerset.protocol }}
+      hostname: {{ tpl (.Values.applicationSet.listenerset.hostname | default .Values.global.domain) $ }}
+      {{- if .Values.applicationSet.listenerset.tls.enabled }}
+      tls:
+        mode: {{ .Values.applicationSet.listenerset.tls.mode }}
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: {{ .Values.applicationSet.listenerset.tls.secretName | default "argocd-applicationset-controller-tls" }}
+      {{- end }}
+      allowedRoutes:
+        {{- toYaml .Values.applicationSet.listenerset.allowedRoutes | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-server/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-server/httproute.yaml
@@ -18,12 +18,21 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- with .Values.server.httproute.parentRefs }}
-      {{- toYaml . | nindent 4 }}
+    {{- if .Values.server.httproute.parentRefs }}
+    {{- toYaml .Values.server.httproute.parentRefs | nindent 4 }}
+    {{- else if .Values.server.listenerset.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ $fullName }}
+      namespace: {{ include "argo-cd.namespace" . }}
+      sectionName: {{ .Values.server.listenerset.listenerName }}
     {{- end }}
-  {{- with .Values.server.httproute.hostnames }}
+  {{- if .Values.server.httproute.hostnames }}
   hostnames:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .Values.server.httproute.hostnames | nindent 4 }}
+  {{- else if .Values.server.listenerset.enabled }}
+  hostnames:
+    - {{ tpl (.Values.server.listenerset.hostname | default .Values.global.domain) $ | quote }}
   {{- end }}
   rules:
   {{- range .Values.server.httproute.rules }}

--- a/charts/argo-cd/templates/argocd-server/listenerset.yaml
+++ b/charts/argo-cd/templates/argocd-server/listenerset.yaml
@@ -17,8 +17,23 @@ metadata:
 spec:
   parentRef:
     {{- toYaml .Values.server.listenerset.parentRef | nindent 4 }}
-  {{- with .Values.server.listenerset.listeners }}
   listeners:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if .Values.server.listenerset.listeners }}
+    {{- toYaml .Values.server.listenerset.listeners | nindent 4 }}
+    {{- else }}
+    - name: {{ .Values.server.listenerset.listenerName }}
+      port: {{ .Values.server.listenerset.port }}
+      protocol: {{ .Values.server.listenerset.protocol }}
+      hostname: {{ tpl (.Values.server.listenerset.hostname | default .Values.global.domain) $ }}
+      {{- if .Values.server.listenerset.tls.enabled }}
+      tls:
+        mode: {{ .Values.server.listenerset.tls.mode }}
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: {{ .Values.server.listenerset.tls.secretName | default "argocd-server-tls" }}
+      {{- end }}
+      allowedRoutes:
+        {{- toYaml .Values.server.listenerset.allowedRoutes | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2873,11 +2873,29 @@ server:
     ## Must reference an existing Gateway. Unlike HTTPRoute, ListenerSet accepts exactly one parentRef.
     # @default -- `{}` (See [values.yaml])
     parentRef: {}
-      # group: gateway.networking.k8s.io
-      # kind: Gateway
       # name: example-gateway
       # namespace: example-gateway-namespace
-    # -- Listeners to attach to the parent Gateway
+    # -- Hostname for the synthesized listener. Defaults to global.domain when empty.
+    hostname: ""
+    # -- Name of the synthesized listener. Also used as sectionName in auto-derived httproute parentRefs.
+    listenerName: https
+    # -- Port for the synthesized listener
+    port: 443
+    # -- Protocol for the synthesized listener
+    protocol: HTTPS
+    # -- TLS configuration for the synthesized listener
+    tls:
+      # -- Enable TLS on the synthesized listener
+      enabled: true
+      # -- TLS termination mode
+      mode: Terminate
+      # -- Secret name for TLS certificate. Defaults to `argocd-server-tls` when empty.
+      secretName: ""
+    # -- allowedRoutes for the synthesized listener
+    allowedRoutes:
+      namespaces:
+        from: Same
+    # -- Listeners to attach to the parent Gateway. When non-empty, used verbatim and all synthesized listener fields above are ignored.
     # @default -- `[]` (See [values.yaml])
     listeners: []
       # - name: https
@@ -3842,11 +3860,29 @@ applicationSet:
     ## Must reference an existing Gateway. Unlike HTTPRoute, ListenerSet accepts exactly one parentRef.
     # @default -- `{}` (See [values.yaml])
     parentRef: {}
-      # group: gateway.networking.k8s.io
-      # kind: Gateway
       # name: example-gateway
       # namespace: example-gateway-namespace
-    # -- Listeners to attach to the parent Gateway
+    # -- Hostname for the synthesized listener. Defaults to global.domain when empty.
+    hostname: ""
+    # -- Name of the synthesized listener. Also used as sectionName in auto-derived httproute parentRefs.
+    listenerName: https
+    # -- Port for the synthesized listener
+    port: 443
+    # -- Protocol for the synthesized listener
+    protocol: HTTPS
+    # -- TLS configuration for the synthesized listener
+    tls:
+      # -- Enable TLS on the synthesized listener
+      enabled: true
+      # -- TLS termination mode
+      mode: Terminate
+      # -- Secret name for TLS certificate. Defaults to `argocd-applicationset-controller-tls` when empty.
+      secretName: ""
+    # -- allowedRoutes for the synthesized listener
+    allowedRoutes:
+      namespaces:
+        from: Same
+    # -- Listeners to attach to the parent Gateway. When non-empty, used verbatim and all synthesized listener fields above are ignored.
     # @default -- `[]` (See [values.yaml])
     listeners: []
       # - name: https


### PR DESCRIPTION
Following #3932 and the comment from @rgarcia89 I'm proposing some changes.

Improvements:
* default listener from structured fields - can be customized or fully overridden
* using `global.domain` as hostname fallback (logic already in place for ingress)
* HTTPRoute parentRefs derived from ListenerSet when it is enabled

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
