### PR TITLE
feat(argo-workflows): add envFrom to controller and argo-server containers

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.8
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.22
+version: 1.0.23
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump kubectl to v1.36.3
+    - kind: added
+      description: Add envFrom to the controller and argo-server containers

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -264,6 +264,7 @@ Fields to note:
 | controller.configMap.name | string | `""` | ConfigMap name |
 | controller.cronWorkflowWorkers | string | `nil` | Number of cron workflow workers Only valid for 3.5+ |
 | controller.deploymentAnnotations | object | `{}` | deploymentAnnotations is an optional map of annotations to be applied to the controller Deployment |
+| controller.envFrom | list | `[]` | envFrom to pass to the controller container |
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
 | controller.extraEnv | list | `[]` | Extra environment variables to provide to the controller container |
@@ -411,6 +412,7 @@ Fields to note:
 | server.clusterWorkflowTemplates.enabled | bool | `true` | Create a ClusterRole and CRB for the server to access ClusterWorkflowTemplates. |
 | server.deploymentAnnotations | object | `{}` | optional map of annotations to be applied to the ui Deployment |
 | server.enabled | bool | `true` | Deploy the Argo Server |
+| server.envFrom | list | `[]` | envFrom to pass to the argo-server container |
 | server.extraArgs | list | `[]` | Extra arguments to provide to the Argo server binary. |
 | server.extraContainers | list | `[]` | Extra containers to be added to the server deployment |
 | server.extraEnv | list | `[]` | Extra environment variables to provide to the argo-server container |

--- a/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-deployment.yaml
@@ -100,6 +100,10 @@ spec:
           {{- with .Values.controller.extraEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.controller.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           {{- with .Values.controller.volumeMounts }}

--- a/charts/argo-workflows/templates/server/server-deployment.yaml
+++ b/charts/argo-workflows/templates/server/server-deployment.yaml
@@ -121,6 +121,10 @@ spec:
           {{- with .Values.server.extraEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.server.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
           volumeMounts:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -392,6 +392,9 @@ controller:
     # - name: FOO
     #   value: "bar"
 
+  # -- envFrom to pass to the controller container
+  envFrom: []
+
   # -- Extra arguments to be added to the controller
   extraArgs: []
   # -- Additional volume mounts to the controller main container
@@ -707,6 +710,9 @@ server:
   extraEnv: []
     # - name: FOO
     #   value: "bar"
+
+  # -- envFrom to pass to the argo-server container
+  envFrom: []
 
   # -- Deprecated; use server.authModes instead.
   authMode: ""


### PR DESCRIPTION
## Summary

Adds an optional `controller.envFrom` and `server.envFrom` to the argo-workflows chart, so the workflow-controller and argo-server containers can load environment variables from ConfigMaps/Secrets via `envFrom`.

This mirrors patterns already in the chart and the wider repo:
- the Workflow main container already has `mainContainer.envFrom` (added in #1736)
- the sibling `argo-events` chart exposes per-controller `envFrom`
- both `controller` and `server` already expose `extraEnv`, so `envFrom` is the natural companion

Default is `[]`, so the rendered output is unchanged for existing users (the field only renders when set).

## Validation (local)

- `helm lint`: 1 chart linted, 0 failed
- `./scripts/helm-docs.sh` (helm-docs v1.9.1): README regenerated, diff is only the two new rows
- `helm template`:
  - default: no `envFrom` rendered, default manifests byte-identical except the `helm.sh/chart` version label
  - `controller.envFrom` set: renders `envFrom` on the controller container
  - `server.envFrom` set: renders `envFrom` on the argo-server container

## Changes

- `values.yaml`: `controller.envFrom` + `server.envFrom` (default `[]`)
- `templates/controller/workflow-controller-deployment.yaml`, `templates/server/server-deployment.yaml`: wire `envFrom`
- `README.md`: helm-docs rows
- `Chart.yaml`: version 1.0.22 -> 1.0.23 + changelog annotation
