### PR TITLE
fix(argo-cd): apply applicationSet NetworkPolicy webhook rule when httproute is enabled

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Apply applicationSet NetworkPolicy webhook rule when httproute is enabled
+      description: Apply applicationSet NetworkPolicy webhook rule for httproute and create notifications NetworkPolicy when metrics are disabled

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.1.0
+version: 10.1.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis-ha to v4.38.0
+    - kind: fixed
+      description: Apply applicationSet NetworkPolicy webhook rule when httproute is enabled

--- a/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.applicationSet.networkPolicy.create .Values.global.networkPolicy.create) (or .Values.applicationSet.metrics.enabled .Values.applicationSet.ingress.enabled) }}
+{{- if and (or .Values.applicationSet.networkPolicy.create .Values.global.networkPolicy.create) (or .Values.applicationSet.metrics.enabled .Values.applicationSet.ingress.enabled .Values.applicationSet.httproute.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -8,7 +8,7 @@ metadata:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.applicationSet.name "name" .Values.applicationSet.name) | nindent 4 }}
 spec:
   ingress:
-  {{- if .Values.applicationSet.ingress.enabled }}
+  {{- if or .Values.applicationSet.ingress.enabled .Values.applicationSet.httproute.enabled }}
   - ports:
     - port: webhook
   {{- end }}

--- a/charts/argo-cd/templates/argocd-notifications/networkpolicy.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.notifications.enabled (or .Values.notifications.networkPolicy.create .Values.global.networkPolicy.create) .Values.notifications.metrics.enabled }}
+{{- if and .Values.notifications.enabled (or .Values.notifications.networkPolicy.create .Values.global.networkPolicy.create) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
Fixes #3948

## Overview

**applicationSet webhook (reported issue)**

The default NetworkPolicy only opened the applicationSet webhook port when `applicationSet.ingress.enabled` was set. Users exposing the webhook via the Gateway API (`applicationSet.httproute.enabled`) had no matching ingress rule, so webhook traffic was blocked.

This gates the webhook ingress rule (and the policy's render condition) on `httproute.enabled` in addition to `ingress.enabled`.

**notifications NetworkPolicy (follow-up from discussion)**

While reviewing, @todaywasawesome noticed that the argocd-notifications NetworkPolicy is skipped entirely when `notifications.metrics.enabled` is `false`, even when network policies are otherwise enabled via `global.networkPolicy.create`. That guard dates back to #1184 (2022), when network policies were opt-in (`global.networkPolicy.create` defaulted to `false`) and the policy's only rule allowed metrics scraping, so gating on metrics avoided emitting an empty policy.

Since 0f245abd flipped `global.networkPolicy.create` to true for a default-deny posture, notifications (metrics disabled by default) silently received no policy, unlike application-controller which has the same metrics-only shape but no such gate. This drops `metrics.enabled` from the guard so notifications gets a locked-down policy consistent with application-controller.

**Checklist:**

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
