### PR TITLE
fix(argo-cd): apply application-controller ServiceMonitor scrapeTimeout

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.4.4
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.1.1
+version: 10.1.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Apply applicationSet NetworkPolicy webhook rule for httproute and create notifications NetworkPolicy when metrics are disabled
+      description: Nest application-controller metrics scrapeTimeout under serviceMonitor so the documented value is actually applied

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1073,7 +1073,6 @@ NAME: my-release
 | controller.metrics.rules.namespace | string | `""` | PrometheusRule namespace |
 | controller.metrics.rules.selector | object | `{}` | PrometheusRule selector |
 | controller.metrics.rules.spec | list | `[]` | PrometheusRule.Spec for the application controller |
-| controller.metrics.scrapeTimeout | string | `""` | Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used. |
 | controller.metrics.service.annotations | object | `{}` | Metrics service annotations |
 | controller.metrics.service.clusterIP | string | `""` | Metrics service clusterIP. `None` makes a "headless service" (no virtual IP) |
 | controller.metrics.service.labels | object | `{}` | Metrics service labels |
@@ -1089,6 +1088,7 @@ NAME: my-release
 | controller.metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | controller.metrics.serviceMonitor.relabelings | list | `[]` | Prometheus [RelabelConfigs] to apply to samples before scraping |
 | controller.metrics.serviceMonitor.scheme | string | `""` | Prometheus ServiceMonitor scheme |
+| controller.metrics.serviceMonitor.scrapeTimeout | string | `""` | Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used. |
 | controller.metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
 | controller.metrics.serviceMonitor.tlsConfig | object | `{}` | Prometheus ServiceMonitor tlsConfig |
 | controller.name | string | `"application-controller"` | Application controller name string |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1029,8 +1029,6 @@ controller:
   metrics:
     # -- Deploy metrics service
     enabled: false
-    # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
-    scrapeTimeout: ""
     applicationLabels:
       # -- Enables additional labels in argocd_app_labels metric
       enabled: false
@@ -1054,6 +1052,8 @@ controller:
       enabled: false
       # -- Prometheus ServiceMonitor interval
       interval: 30s
+      # -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+      scrapeTimeout: ""
       # -- When true, honorLabels preserves the metric’s labels when they collide with the target’s labels.
       honorLabels: false
       # -- Prometheus [RelabelConfigs] to apply to samples before scraping


### PR DESCRIPTION
## Overview

The application-controller's `scrapeTimeout` value is defined at `controller.metrics.scrapeTimeout`, but the ServiceMonitor template reads `controller.metrics.serviceMonitor.scrapeTimeout`. The two never line up, so the documented value is silently ignored, and nothing in the chart reads the metrics-level key.

This moves the value down into `controller.metrics.serviceMonitor` (next to `interval`, `scheme`, `honorLabels`), matching the `server`, `repo-server`, and `applicationset` components and the path the template actually consumes.

Closes #3955

### Why the value, not the template

- The application-controller is the only component that places `scrapeTimeout` outside its `serviceMonitor` block. `server`, `repo-server`, and `applicationset` all nest it under `metrics.serviceMonitor.scrapeTimeout`, which is also the path their templates read.
- Nothing in the chart reads `.metrics.scrapeTimeout`, so the value was orphaned. Pointing the template at the metrics-level key instead would make the controller inconsistent with every other component and place a ServiceMonitor field outside its block.

### Behavior change

Non-breaking:
- The broken documented path (`controller.metrics.scrapeTimeout`) never took effect, so nothing relied on it.
- The working undocumented path (`controller.metrics.serviceMonitor.scrapeTimeout`) is unchanged and now matches the documentation.

### Testing

```
helm template argocd charts/argo-cd
  --set controller.metrics.enabled=true
  --set controller.metrics.serviceMonitor.enabled=true
  --set controller.metrics.serviceMonitor.scrapeTimeout=33s
  --api-versions monitoring.coreos.com/v1
  -s templates/argocd-application-controller/servicemonitor.yaml
```

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [X] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
