### PR TITLE
feat(argo-cd): allow appending additional resource.exclusions without overriding the chart defaults

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.4.3
+version: 10.5.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Added dnsPolicy/dnsConfig support for the secret initialization of Redis. Added hostNetwork support for Redis and the Redis secret initialization.
+      description: Add configs.cm.resourceExclusionsAdditional to append custom resource.exclusions entries without overriding the chart defaults

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1044,6 +1044,7 @@ NAME: my-release
 | configs.cm."timeout.reconciliation.jitter" | string | `"60s"` | Maximum jitter added to the reconciliation timeout to spread out refreshes and reduce repo-server load |
 | configs.cm.annotations | object | `{}` | Annotations to be added to argocd-cm configmap |
 | configs.cm.create | bool | `true` | Create the argocd-cm configmap for [declarative setup] |
+| configs.cm.resourceExclusionsAdditional | list | `[]` | Additional resource exclusions to append to the default `resource.exclusions` list above, so that the defaults can be kept up to date without needing to duplicate/override them. These entries are always appended, never substituted: if you also set `resource.exclusions` yourself, they are appended to your value rather than to the chart defaults. |
 | configs.cmp.annotations | object | `{}` | Annotations to be added to argocd-cmp-cm configmap |
 | configs.cmp.create | bool | `false` | Create the argocd-cmp-cm configmap |
 | configs.cmp.plugins | object | `{}` | Plugin yaml files to be added to argocd-cmp-cm |

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -216,9 +216,15 @@ Argo Configuration Preset Values (Influenced by Values configuration)
 Merge Argo Configuration with Preset Configuration
 */}}
 {{- define "argo-cd.config.cm" -}}
-{{- $config := omit .Values.configs.cm "create" "annotations" -}}
+{{- $config := omit .Values.configs.cm "create" "annotations" "resourceExclusionsAdditional" -}}
 {{- $preset := include "argo-cd.config.cm.presets" . | fromYaml | default dict -}}
-{{- range $key, $value := mergeOverwrite $preset $config }}
+{{- $merged := mergeOverwrite $preset $config -}}
+{{- if .Values.configs.cm.resourceExclusionsAdditional }}
+{{- $existing := get $merged "resource.exclusions" | default "" | trimSuffix "\n" }}
+{{- $additional := .Values.configs.cm.resourceExclusionsAdditional | toYaml }}
+{{- $_ := set $merged "resource.exclusions" (list $existing $additional | compact | join "\n") -}}
+{{- end }}
+{{- range $key, $value := $merged }}
 {{- $fmted := $value | toString }}
 {{- if not (eq $fmted "") }}
 {{ $key }}: {{ $fmted | toYaml }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -426,6 +426,13 @@ configs:
         - ClusterBackgroundScanReport
         - UpdateRequest
 
+    # -- Additional resource exclusions to append to the default `resource.exclusions` list above,
+    # so that the defaults can be kept up to date without needing to duplicate/override them.
+    # These entries are always appended, never substituted: if you also set `resource.exclusions`
+    # yourself, they are appended to your value rather than to the chart defaults.
+    # @default -- `[]`
+    resourceExclusionsAdditional: []
+
   # Argo CD configuration parameters
   ## Ref: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/argocd-cmd-params-cm.yaml
   params:


### PR DESCRIPTION
Closes #3291

## Overview

`configs.cm."resource.exclusions"` is a single YAML-in-string block containing Argo CD's default resource exclusion list. Overriding it is all-or-nothing: to add one exclusion of your own on top of the defaults, you have to copy the entire default list into your values file, which then drifts out of sync as the chart's defaults change.

This adds `configs.cm.resourceExclusionsAdditional`, a plain list that gets appended onto the default `resource.exclusions` string at render time, so the chart's default list stays intact and users can layer their own entries on top of it, adapted here since `resource.exclusions` is a stringified block rather than a real Helm list.

### Prior art

Exposing a separate `*Additional`/`*Include` value that appends to chart-managed defaults (rather than replacing them) is an established pattern in other popular charts:

- **Kyverno** added [`config.resourceFiltersInclude` / `resourceFiltersIncludeNamespaces`](https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml) so users can extend the default `resourceFilters` list without duplicating it, the same all-or-nothing problem this PR addresses (see kyverno/kyverno#9529).
- **kube-prometheus-stack** exposes [`prometheus.prometheusSpec.additionalScrapeConfigs`](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) to append user scrape configs on top of the chart-managed defaults.

### Backwards compatibility

**Non-breaking:** the new value defaults to `[]`, which is falsy in the merge template, so nothing changes when it's left unset. Verified the rendered `argocd-cm` output is byte-identical to before this change (aside from the chart version label) with default values.

### Testing

```
helm template charts/argo-cd
  --set 'configs.cm.resourceExclusionsAdditional[0].apiGroups[0]=example.com'
  --set 'configs.cm.resourceExclusionsAdditional[0].kinds[0]=MyCustomResource'
  -s templates/argocd-configs/argocd-cm.yaml
```

Confirms the appended entry renders correctly and the resulting `resource.exclusions` string still parses as valid YAML.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [X] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [X] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
