### PR TITLE
feat(argo-workflows): add optional podLabels to crd installer

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.7
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.19
+version: 1.0.20
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v4.0.7
+    - kind: added
+      description: Added optional podLabels to CRD installer Job

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -217,6 +217,7 @@ Fields to note:
 | crds.upgradeJob.image.tag | string | `"v1.36.2"` | Tag for the kubectl image |
 | crds.upgradeJob.imagePullSecrets | list | `[]` | Image pull secrets for the CRD install Job |
 | crds.upgradeJob.nodeSelector | object | `{}` | Node selector for the CRD install Job |
+| crds.upgradeJob.podLabels | object | `{}` | Optional labels to add to the CRD install Job pod |
 | crds.upgradeJob.podSecurityContext | object | `{}` | Pod security context for the CRD install Job pod |
 | crds.upgradeJob.resources | object | `{}` | Resources for the CRD install Job containers |
 | crds.upgradeJob.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the CRD install Job container |

--- a/charts/argo-workflows/templates/crds-install-job.yaml
+++ b/charts/argo-workflows/templates/crds-install-job.yaml
@@ -63,6 +63,9 @@ spec:
     metadata:
       labels:
         {{- include "argo-workflows.labels" (dict "context" . "component" "crds" "name" "crd-install") | nindent 8 }}
+        {{- with.Values.crds.upgradeJob.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ $crdInstallName }}
       {{- with .Values.crds.upgradeJob.podSecurityContext }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -36,6 +36,8 @@ crds:
     nodeSelector: {}
     # -- Pod security context for the CRD install Job pod
     podSecurityContext: {}
+    # -- Optional labels to add to the CRD install Job pod
+    podLabels: {}
     # -- Tolerations for the CRD install Job
     tolerations: []
     # -- Image pull secrets for the CRD install Job


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->
Closes #3954 

* Add optional `crds.upgradeJob.podLabels` for the CRD installer.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
