### PR TITLE
feat(argo-workflows): support Argo Workflows v4.1 features

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.1.0
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.1.0
+version: 1.1.1
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v4.1.0
+    - kind: added
+      description: Support Argo Workflows v4.1 features (initlessPod, disableAgentPodCreation, S3 addressingStyle, database token authentication)

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -121,6 +121,48 @@ Please see the upstream [Operator Manual's High Availability page](https://argo-
 
 This chart defaults to setting the `controller.instanceID.enabled` to `false` now, which means the deployed controller will act upon any workflow deployed to the cluster. If you would like to limit the behavior and deploy multiple workflow controllers, please use the `controller.instanceID.enabled` attribute along with one of its configuration options to set the `instanceID` of the workflow controller to be properly scoped for your needs.
 
+### Init-less pod layout (beta)
+
+Argo Workflows v4.1+ supports an opt-in [init-less pod layout], where the executor is provided to workflow pods through an [image volume] instead of an init container copying the binary. Enable it with `controller.initlessPod.enabled: true`.
+
+Requirements and caveats:
+
+- Requires the `ImageVolume` feature gate to be enabled on the kube-apiserver and all kubelets running workflow pods. Image volumes are beta in Kubernetes v1.33-1.35 and enabled by default from v1.36. If the cluster does not support them, workflow pod creation will fail.
+- A custom `executor.image` must provide a manifest list covering every node architecture in the cluster.
+- Workflows whose `main` container sets `securityContext.readOnlyRootFilesystem: true` may fail to load input artifacts placed on the read-only root filesystem in this mode.
+
+### OpenTelemetry tracing (beta)
+
+Argo Workflows v4.1+ can emit [OpenTelemetry traces] from the workflow controller and the executor. Tracing is configured entirely through standard `OTEL_*` environment variables and is enabled by setting an OTLP endpoint; the chart already provides the necessary hooks:
+
+```yaml
+controller:
+  # Traces from the workflow controller
+  extraEnv:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otel-collector:4318
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+
+# Traces from the executor in workflow pods
+executor:
+  env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otel-collector:4318
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+
+# Optional: expose the OTEL configuration to your own code in main containers
+mainContainer:
+  env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otel-collector:4318
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+```
+
+The Argo Server is not instrumented for tracing.
+
 ### Argo Workflows server authentication
 
 Argo Workflows server provides some choices for authentication mechanism and you can configure `.Values.server.authModes`. By default, authentication mode is `[server]`, for local development purposes or cases where your gateway authentication is covered by some other means.
@@ -264,6 +306,7 @@ Fields to note:
 | controller.configMap.name | string | `""` | ConfigMap name |
 | controller.cronWorkflowWorkers | string | `nil` | Number of cron workflow workers Only valid for 3.5+ |
 | controller.deploymentAnnotations | object | `{}` | deploymentAnnotations is an optional map of annotations to be applied to the controller Deployment |
+| controller.disableAgentPodCreation | bool | `false` | Disable the creation of agent pods, which are used for HTTP and Plugin templates. When enabled, HTTP and Plugin templates will not be processed by this controller. Only valid for 4.1+ |
 | controller.envFrom | list | `[]` | envFrom to pass to the controller container |
 | controller.extraArgs | list | `[]` | Extra arguments to be added to the controller |
 | controller.extraContainers | list | `[]` | Extra containers to be added to the controller deployment |
@@ -275,6 +318,7 @@ Fields to note:
 | controller.image.repository | string | `"argoproj/workflow-controller"` | Registry to use for the controller |
 | controller.image.tag | string | `""` | Image tag for the workflow controller. Defaults to `.Values.images.tag`. |
 | controller.initialDelay | string | `nil` | Resolves ongoing, uncommon AWS EKS bug: https://github.com/argoproj/argo-workflows/pull/4224 |
+| controller.initlessPod.enabled | bool | `false` | Enable the init-less pod layout (beta), which provides the executor to workflow pods through an image volume instead of an init container. Only valid for 4.1+. Requires the `ImageVolume` feature gate on the kube-apiserver and all kubelets (beta in Kubernetes v1.33-1.35, enabled by default from v1.36). |
 | controller.instanceID.enabled | bool | `false` | Configures the controller to filter workflow submissions to only those which have a matching instanceID attribute. |
 | controller.instanceID.explicitID | string | `""` | Use a custom instanceID |
 | controller.instanceID.useReleaseName | bool | `false` | Use ReleaseName as instanceID |
@@ -310,7 +354,7 @@ Fields to note:
 | controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | [Node selector] |
 | controller.parallelism | string | `nil` | parallelism dictates how many workflows can be running at the same time |
 | controller.pdb.enabled | bool | `false` | Configure [Pod Disruption Budget] for the controller pods |
-| controller.persistence | object | `{}` | enable Workflow Archive to store the status of workflows. Postgres and MySQL (>= 5.7.8) are available. |
+| controller.persistence | object | `{}` | enable Workflow Archive to store the status of workflows. Postgres, MySQL (>= 5.7.8) and MariaDB (>= 10.2.7, requires Argo Workflows v4.1+) are available. |
 | controller.podAnnotations | object | `{}` | podAnnotations is an optional map of annotations to be applied to the controller Pods |
 | controller.podCleanupWorkers | string | `nil` | Number of pod cleanup workers |
 | controller.podGCDeleteDelayDuration | string | `5s` (Argo Workflows default) | The duration in seconds before the pods in the GC queue get deleted. A zero value indicates that the pods will be deleted immediately. |
@@ -545,3 +589,6 @@ Fields to note:
 [changelog]: https://artifacthub.io/packages/helm/argo/argo-workflows?modal=changelog
 [SSO RBAC]: https://argo-workflows.readthedocs.io/en/stable/argo-server-sso/
 [Argo Server Auth Mode]: https://argo-workflows.readthedocs.io/en/stable/argo-server-auth-mode/
+[init-less pod layout]: https://argo-workflows.readthedocs.io/en/latest/initless-pod/
+[image volume]: https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/
+[OpenTelemetry traces]: https://argo-workflows.readthedocs.io/en/latest/telemetry-configuration/

--- a/charts/argo-workflows/README.md.gotmpl
+++ b/charts/argo-workflows/README.md.gotmpl
@@ -121,6 +121,48 @@ Please see the upstream [Operator Manual's High Availability page](https://argo-
 
 This chart defaults to setting the `controller.instanceID.enabled` to `false` now, which means the deployed controller will act upon any workflow deployed to the cluster. If you would like to limit the behavior and deploy multiple workflow controllers, please use the `controller.instanceID.enabled` attribute along with one of its configuration options to set the `instanceID` of the workflow controller to be properly scoped for your needs.
 
+### Init-less pod layout (beta)
+
+Argo Workflows v4.1+ supports an opt-in [init-less pod layout], where the executor is provided to workflow pods through an [image volume] instead of an init container copying the binary. Enable it with `controller.initlessPod.enabled: true`.
+
+Requirements and caveats:
+
+- Requires the `ImageVolume` feature gate to be enabled on the kube-apiserver and all kubelets running workflow pods. Image volumes are beta in Kubernetes v1.33-1.35 and enabled by default from v1.36. If the cluster does not support them, workflow pod creation will fail.
+- A custom `executor.image` must provide a manifest list covering every node architecture in the cluster.
+- Workflows whose `main` container sets `securityContext.readOnlyRootFilesystem: true` may fail to load input artifacts placed on the read-only root filesystem in this mode.
+
+### OpenTelemetry tracing (beta)
+
+Argo Workflows v4.1+ can emit [OpenTelemetry traces] from the workflow controller and the executor. Tracing is configured entirely through standard `OTEL_*` environment variables and is enabled by setting an OTLP endpoint; the chart already provides the necessary hooks:
+
+```yaml
+controller:
+  # Traces from the workflow controller
+  extraEnv:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otel-collector:4318
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+
+# Traces from the executor in workflow pods
+executor:
+  env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otel-collector:4318
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+
+# Optional: expose the OTEL configuration to your own code in main containers
+mainContainer:
+  env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://otel-collector:4318
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+```
+
+The Argo Server is not instrumented for tracing.
+
 ### Argo Workflows server authentication
 
 Argo Workflows server provides some choices for authentication mechanism and you can configure `.Values.server.authModes`. By default, authentication mode is `[server]`, for local development purposes or cases where your gateway authentication is covered by some other means.
@@ -302,3 +344,6 @@ Fields to note:
 [changelog]: https://artifacthub.io/packages/helm/argo/argo-workflows?modal=changelog
 [SSO RBAC]: https://argo-workflows.readthedocs.io/en/stable/argo-server-sso/
 [Argo Server Auth Mode]: https://argo-workflows.readthedocs.io/en/stable/argo-server-auth-mode/
+[init-less pod layout]: https://argo-workflows.readthedocs.io/en/latest/initless-pod/
+[image volume]: https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/
+[OpenTelemetry traces]: https://argo-workflows.readthedocs.io/en/latest/telemetry-configuration/

--- a/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-cluster-roles.yaml
@@ -127,7 +127,9 @@ rules:
   resourceNames:
   {{- if .Values.controller.persistence.postgresql }}
   - {{ .Values.controller.persistence.postgresql.userNameSecret.name }}
-  - {{ .Values.controller.persistence.postgresql.passwordSecret.name }}
+  {{- with .Values.controller.persistence.postgresql.passwordSecret }}
+  - {{ .name }}
+  {{- end}}
   {{- end}}
   {{- if .Values.controller.persistence.mysql }}
   - {{ .Values.controller.persistence.mysql.userNameSecret.name }}

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -109,6 +109,9 @@ data:
         {{- if .Values.artifactRepository.s3.useSDKCreds }}
         useSDKCreds: {{ .Values.artifactRepository.s3.useSDKCreds }}
         {{- end }}
+        {{- with .Values.artifactRepository.s3.addressingStyle }}
+        addressingStyle: {{ . }}
+        {{- end }}
         {{- with .Values.artifactRepository.s3.encryptionOptions }}
         encryptionOptions:
           {{- toYaml . | nindent 10 }}
@@ -224,5 +227,12 @@ data:
     {{- end }}
     {{- with .Values.controller.failedPodRestart }}
     failedPodRestart: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.controller.disableAgentPodCreation }}
+    disableAgentPodCreation: {{ .Values.controller.disableAgentPodCreation }}
+    {{- end }}
+    {{- if .Values.controller.initlessPod.enabled }}
+    initlessPod:
+      enabled: {{ .Values.controller.initlessPod.enabled }}
     {{- end }}
 {{- end }}

--- a/charts/argo-workflows/templates/server/server-cluster-roles.yaml
+++ b/charts/argo-workflows/templates/server/server-cluster-roles.yaml
@@ -91,7 +91,9 @@ rules:
   resourceNames:
   {{- with .Values.controller.persistence.postgresql }}
   - {{ .userNameSecret.name }}
-  - {{ .passwordSecret.name }}
+  {{- with .passwordSecret }}
+  - {{ .name }}
+  {{- end}}
   {{- end}}
   {{- with .Values.controller.persistence.mysql }}
   - {{ .userNameSecret.name }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -226,7 +226,7 @@ controller:
     capabilities:
       drop:
         - ALL
-  # -- enable Workflow Archive to store the status of workflows. Postgres and MySQL (>= 5.7.8) are available.
+  # -- enable Workflow Archive to store the status of workflows. Postgres, MySQL (>= 5.7.8) and MariaDB (>= 10.2.7, requires Argo Workflows v4.1+) are available.
   ## Ref: https://argo-workflows.readthedocs.io/en/stable/workflow-archive/
   persistence: {}
   # connectionPool:
@@ -248,6 +248,16 @@ controller:
   #   passwordSecret:
   #     name: argo-postgres-config
   #     key: password
+  #   # Instead of passwordSecret, Postgres can authenticate with a token.
+  #   # Requires Argo Workflows v4.1+; userNameSecret is still required.
+  #   # Microsoft Entra ID (needs Azure Workload Identity on the controller's service account):
+  #   azureToken:
+  #     enabled: true
+  #     scope: https://ossrdbms-aad.database.windows.net/.default
+  #   # AWS RDS IAM authentication (needs IRSA or EKS Pod Identity on the controller's service account):
+  #   awsRDSToken:
+  #     enabled: true
+  #     region: us-east-1
   #   ssl: true
   #   # sslMode must be one of: disable, require, verify-ca, verify-full
   #   # you can find more information about those ssl options here: https://godoc.org/github.com/lib/pq
@@ -534,6 +544,16 @@ controller:
     enabled: false
     # -- Maximum number of automatic restarts per node before giving up.
     maxRestarts: 3
+
+  # -- Disable the creation of agent pods, which are used for HTTP and Plugin templates. When enabled, HTTP and Plugin templates will not be processed by this controller.
+  # Only valid for 4.1+
+  disableAgentPodCreation: false
+
+  initlessPod:
+    # -- Enable the init-less pod layout (beta), which provides the executor to workflow pods through an image volume instead of an init container.
+    # Only valid for 4.1+. Requires the `ImageVolume` feature gate on the kube-apiserver and all kubelets (beta in Kubernetes v1.33-1.35, enabled by default from v1.36).
+    ## Ref: https://argo-workflows.readthedocs.io/en/latest/initless-pod/
+    enabled: false
 
 # mainContainer adds default config for main container that could be overriden in workflows template
 mainContainer:
@@ -1033,6 +1053,9 @@ artifactRepository:
     # region:
     # roleARN:
     # useSDKCreds: true
+    # # addressingStyle must be one of: "" (auto-detect), path, virtual-hosted
+    # # Only valid for 4.1+
+    # addressingStyle: ""
     # encryptionOptions:
     #   enableEncryption: true
   # -- Store artifact in a GCS object store


### PR DESCRIPTION
Adds chart support for new configuration introduced in Argo Workflows v4.1.0

- `controller.initlessPod.enabled` — opt-in beta [init-less pod layout](https://argo-workflows.readthedocs.io/en/latest/initless-pod/) (argoproj/argo-workflows#16161). Documented with the `ImageVolume` feature-gate requirement (beta in Kubernetes v1.33-1.35, on by default from v1.36) and caveats.
- `controller.disableAgentPodCreation` — disable agent pods for HTTP and Plugin templates (argoproj/argo-workflows#15844).
- `artifactRepository.s3.addressingStyle` — virtual-hosted-style S3 support (argoproj/argo-workflows#15734).
- Make `persistence.postgresql.passwordSecret` optional in the controller and server ClusterRoles. The new Azure Entra (`azureToken`, argoproj/argo-workflows#15511) and AWS RDS IAM (`awsRDSToken`, argoproj/argo-workflows#15833) token authentication is used without a password secret, and the templates previously failed rendering with a nil pointer in that case. The persistence config itself passes through unchanged; commented examples added to values.yaml.
- Documentation: OpenTelemetry tracing setup via the existing `controller.extraEnv` / `executor.env` / `mainContainer.env` hooks (tracing is configured purely with `OTEL_*` environment variables upstream), and MariaDB as a supported archive database.

All new values default to off, so rendering is unchanged for existing users on v4.0.x.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
