### PR TITLE
feat(argo-workflows): add server.sso.rootCA for custom OIDC CA

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.0.8
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 1.0.23
+version: 1.0.24
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Add envFrom to the controller and argo-server containers
+      description: Add server.sso.rootCA to configure a custom CA for the OIDC provider

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -488,6 +488,7 @@ Fields to note:
 | server.sso.rbac.enabled | bool | `true` | Adds ServiceAccount Policy to server (Cluster)Role. |
 | server.sso.rbac.secretWhitelist | list | `[]` | Whitelist to allow server to fetch Secrets |
 | server.sso.redirectUrl | string | `""` | The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback. |
+| server.sso.rootCA | string | `""` | Custom PEM encoded CA certificate file contents used to validate the OIDC provider's certificate |
 | server.sso.scopes | list | `[]` | Scopes requested from the SSO ID provider |
 | server.sso.sessionExpiry | string | `""` | Define how long your login is valid for (in hours) |
 | server.sso.userInfoPath | string | `""` | Specify the user info endpoint that contains the groups claim |

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -180,6 +180,10 @@ data:
       {{- with .Values.server.sso.insecureSkipVerify }}
       insecureSkipVerify: {{ toYaml . }}
       {{- end }}
+      {{- with .Values.server.sso.rootCA }}
+      rootCA: |-
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.server.sso.filterGroupsRegex }}
       filterGroupsRegex: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -937,6 +937,8 @@ server:
     userInfoPath: ""
     # -- Skip TLS verification for the HTTP client
     insecureSkipVerify: false
+    # -- Custom PEM encoded CA certificate file contents used to validate the OIDC provider's certificate
+    rootCA: ""
     # -- Filter the groups returned by the OIDC provider
     ## A logical "OR" is used between each regex in the list
     filterGroupsRegex: []


### PR DESCRIPTION
Adds a `server.sso.rootCA` value to the `argo-workflows` chart so a custom PEM-encoded CA certificate can be supplied to validate the OIDC provider's TLS certificate (useful for self-signed / private CAs). argo-workflows already supports this via the `rootCA` SSO config field (`config/sso.go`); the chart now renders it into the workflow-controller config map alongside the existing `insecureSkipVerify` option.

Verified with `helm lint` and `helm template`: a multiline `server.sso.rootCA` renders as a correctly-indented `rootCA: |-` block scalar under the `sso:` config, and the field is omitted when left at its `""` default.

Closes #3963

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
