### PR TITLE
feat(argo-events): support deploymentAnnotations for controller and webhook

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.11
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.23
+version: 2.4.24
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-events to v1.9.11
+    - kind: added
+      description: Support deploymentAnnotations for controller and webhook Deployments

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -138,6 +138,7 @@ done
 |-----|------|---------|-------------|
 | controller.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | controller.containerSecurityContext | object | `{}` | Events controller container-level security context |
+| controller.deploymentAnnotations | object | `{}` | Annotations to be added to events controller Deployment |
 | controller.env | list | `[]` | Environment variables to pass to events controller |
 | controller.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to events controller |
 | controller.extraContainers | list | `[]` | Additional containers to be added to the events controller pods |
@@ -196,6 +197,7 @@ done
 |-----|------|---------|-------------|
 | webhook.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | webhook.containerSecurityContext | object | `{}` | Event controller container-level security context |
+| webhook.deploymentAnnotations | object | `{}` | Annotations to be added to admission webhook Deployment |
 | webhook.enabled | bool | `false` | Enable admission webhook. Applies only for cluster-wide installation |
 | webhook.env | list | `[]` (See [values.yaml]) | Environment variables to pass to event controller |
 | webhook.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to event controller |

--- a/charts/argo-events/templates/argo-events-controller/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-controller/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "argo-events.controller.fullname" . }}
   namespace: {{ include "argo-events.namespace" . | quote }}
+  {{- with .Values.controller.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
     app.kubernetes.io/version: {{ include "argo-events.controller_chart_version_label" . }}

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   name: events-webhook
   namespace: {{ include "argo-events.namespace" . | quote }}
+  {{- with .Values.webhook.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.webhook.name "name" .Values.webhook.name) | nindent 4 }}
     app.kubernetes.io/version: {{ include "argo-events.webhook_chart_version_label" . }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -234,6 +234,9 @@ controller:
   # -- Annotations to be added to events controller pods
   podAnnotations: {}
 
+  # -- Annotations to be added to events controller Deployment
+  deploymentAnnotations: {}
+
   # -- Labels to be added to events controller pods
   podLabels: {}
 
@@ -399,6 +402,9 @@ webhook:
 
   # -- Annotations to be added to event controller pods
   podAnnotations: {}
+
+  # -- Annotations to be added to admission webhook Deployment
+  deploymentAnnotations: {}
 
   # -- Labels to be added to event controller pods
   podLabels: {}


### PR DESCRIPTION
  ## Motivation

  The `argo-events` chart currently only exposes `podAnnotations` (via `controller.podAnnotations` / `webhook.podAnnotations`), which annotates the pod template inside the Deployment. There is no way to annotate the Deployment resource itself - e.g. for ownership metadata required by admission policies (Kyverno `require-*-annotations` policies), Argo CD sync-wave metadata, or other operator-visible annotations that must live on the Deployment.

  ## Changes

  - Add `controller.deploymentAnnotations` and `webhook.deploymentAnnotations` (both default `{}`, backward-compatible).
  - Render each into `metadata.annotations` on the respective Deployment templates, using the same `{{- with … }}` guard pattern the chart already uses elsewhere.
  - Bump chart version 2.4.23 → 2.4.24.
  - Regenerate README via helm-docs v1.9.1.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
