### PR TITLE
feat(argo-cd): add optional h2c service port for Gateway API gRPC backend protocol selection

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.0
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.3.1
+version: 10.3.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis_exporter to v1.89.0
+    - kind: added
+      description: Add an optional h2c server service port so Gateway API implementations can select the backend protocol for gRPC traffic when running in insecure mode

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -305,6 +305,35 @@ server:
         sectionName: grpc
 ```
 
+When the Argo CD server runs in insecure mode (`server.insecure: true`), it serves the web UI (HTTP/1.1 only) and gRPC (HTTP/2 only) on the same container port. `appProtocol` is single-valued per Service port, so the `http` port cannot describe both protocols. Per [GEP-1911](https://gateway-api.sigs.k8s.io/geps/gep-1911/) implementations only *may* infer the backend protocol from the route type, so gRPC works on some Gateway controllers and not others. Set `server.service.servicePortHttp2` to expose an additional Service port, and `server.service.servicePortHttp2AppProtocol` to declare its protocol explicitly. The GRPCRoute then targets that port, while the HTTPRoute keeps using the `http` port:
+
+```yaml
+configs:
+  params:
+    server.insecure: true
+
+server:
+  service:
+    servicePortHttp2: 8080
+    servicePortHttp2AppProtocol: kubernetes.io/h2c
+
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+
+  grpcroute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+        sectionName: grpc
+```
+
+> **Note:**
+> The `kubernetes.io/h2c` application protocol is defined by [KEP-3726](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols), and not every implementation uses it — Istio, for example, expects `http2` or `grpc`, and can also select the protocol from `servicePortHttp2Name` alone. Set `servicePortHttp2AppProtocol` to whatever your controller understands. The port is only rendered in insecure mode, since h2c does not apply to a TLS backend.
+
 #### Gateway API with TLS backend
 
 For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy:
@@ -1461,8 +1490,12 @@ NAME: my-release
 | server.service.loadBalancerIP | string | `""` | LoadBalancer will get created with the IP specified in this field |
 | server.service.loadBalancerSourceRanges | list | `[]` | Source IP ranges to allow access to service from |
 | server.service.nodePortHttp | int | `30080` | Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort") |
+| server.service.nodePortHttp2 | int | `nil` (a random node port is assigned) | Server service http2 port for NodePort service type (only if `server.service.servicePortHttp2` is set and `server.service.type` is set to "NodePort") |
 | server.service.nodePortHttps | int | `30443` | Server service https port for NodePort service type (only if `server.service.type` is set to "NodePort") |
 | server.service.servicePortHttp | int | `80` | Server service http port |
+| server.service.servicePortHttp2 | int | `nil` (disabled) | Server service cleartext http2 (h2c) port, targeting the same container port as `servicePortHttp` |
+| server.service.servicePortHttp2AppProtocol | string | `""` | Server service http2 port appProtocol, e.g. `kubernetes.io/h2c`. Implementations that select the protocol from the port name instead do not need it |
+| server.service.servicePortHttp2Name | string | `"http2"` | Server service http2 port name, can be used to route traffic via istio |
 | server.service.servicePortHttpName | string | `"http"` | Server service http port name, can be used to route traffic via istio |
 | server.service.servicePortHttps | int | `443` | Server service https port |
 | server.service.servicePortHttpsAppProtocol | string | `""` | Server service https port appProtocol |

--- a/charts/argo-cd/README.md.gotmpl
+++ b/charts/argo-cd/README.md.gotmpl
@@ -304,6 +304,35 @@ server:
         sectionName: grpc
 ```
 
+When the Argo CD server runs in insecure mode (`server.insecure: true`), it serves the web UI (HTTP/1.1 only) and gRPC (HTTP/2 only) on the same container port. `appProtocol` is single-valued per Service port, so the `http` port cannot describe both protocols. Per [GEP-1911](https://gateway-api.sigs.k8s.io/geps/gep-1911/) implementations only *may* infer the backend protocol from the route type, so gRPC works on some Gateway controllers and not others. Set `server.service.servicePortHttp2` to expose an additional Service port, and `server.service.servicePortHttp2AppProtocol` to declare its protocol explicitly. The GRPCRoute then targets that port, while the HTTPRoute keeps using the `http` port:
+
+```yaml
+configs:
+  params:
+    server.insecure: true
+
+server:
+  service:
+    servicePortHttp2: 8080
+    servicePortHttp2AppProtocol: kubernetes.io/h2c
+
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+
+  grpcroute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: gateway-system
+        sectionName: grpc
+```
+
+> **Note:**
+> The `kubernetes.io/h2c` application protocol is defined by [KEP-3726](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols), and not every implementation uses it — Istio, for example, expects `http2` or `grpc`, and can also select the protocol from `servicePortHttp2Name` alone. Set `servicePortHttp2AppProtocol` to whatever your controller understands. The port is only rendered in insecure mode, since h2c does not apply to a TLS backend.
+
 #### Gateway API with TLS backend
 
 For HTTPS backends with Gateway API, you may need to configure BackendTLSPolicy:

--- a/charts/argo-cd/ci/grpcroute-h2c-values.yaml
+++ b/charts/argo-cd/ci/grpcroute-h2c-values.yaml
@@ -1,0 +1,25 @@
+crds:
+  keep: false
+
+configs:
+  params:
+    server.insecure: true
+server:
+  service:
+    servicePortHttp2: 8080
+    servicePortHttp2AppProtocol: kubernetes.io/h2c
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: example-gateway-namespace
+  grpcroute:
+    enabled: true
+    parentRefs:
+      - name: example-gateway
+        namespace: example-gateway-namespace
+    rules:
+      - matches:
+          - method:
+              type: Exact
+              service: argocd.ApplicationService

--- a/charts/argo-cd/templates/argocd-server/grpcroute.yaml
+++ b/charts/argo-cd/templates/argocd-server/grpcroute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.server.grpcroute.enabled -}}
 {{- $fullName := include "argo-cd.server.fullname" . -}}
 {{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
-{{- $servicePort := eq $insecure "true" | ternary .Values.server.service.servicePortHttp .Values.server.service.servicePortHttps -}}
+{{- $servicePort := eq $insecure "true" | ternary (.Values.server.service.servicePortHttp2 | default .Values.server.service.servicePortHttp) .Values.server.service.servicePortHttps -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:

--- a/charts/argo-cd/templates/argocd-server/service.yaml
+++ b/charts/argo-cd/templates/argocd-server/service.yaml
@@ -1,3 +1,4 @@
+{{- $insecure := index .Values.configs.params "server.insecure" | toString -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -44,6 +45,18 @@ spec:
     {{- if and (eq .Values.server.service.type "NodePort") .Values.server.service.nodePortHttp }}
     nodePort: {{ .Values.server.service.nodePortHttp }}
     {{- end }}
+  {{- if and (eq $insecure "true") .Values.server.service.servicePortHttp2 }}
+  - name: {{ .Values.server.service.servicePortHttp2Name }}
+    protocol: TCP
+    port: {{ .Values.server.service.servicePortHttp2 }}
+    targetPort: {{ .Values.server.containerPorts.server }}
+    {{- if and (eq .Values.server.service.type "NodePort") .Values.server.service.nodePortHttp2 }}
+    nodePort: {{ .Values.server.service.nodePortHttp2 }}
+    {{- end }}
+    {{- with .Values.server.service.servicePortHttp2AppProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
+  {{- end }}
   - name: {{ .Values.server.service.servicePortHttpsName }}
     protocol: TCP
     port: {{ .Values.server.service.servicePortHttps }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -2464,16 +2464,33 @@ server:
     type: ClusterIP
     # -- Server service http port for NodePort service type (only if `server.service.type` is set to "NodePort")
     nodePortHttp: 30080
+    # -- (int) Server service http2 port for NodePort service type (only if `server.service.servicePortHttp2` is set and `server.service.type` is set to "NodePort")
+    # @default -- `nil` (a random node port is assigned)
+    nodePortHttp2:
     # -- Server service https port for NodePort service type (only if `server.service.type` is set to "NodePort")
     nodePortHttps: 30443
     # -- Server service http port
     servicePortHttp: 80
+    # -- (int) Server service cleartext http2 (h2c) port, targeting the same container port as `servicePortHttp`
+    # @default -- `nil` (disabled)
+    ## The Argo CD server serves the web UI (HTTP/1.1) and gRPC (HTTP/2) on a single container port, and
+    ## `appProtocol` is single-valued per service port. Set this to expose a second port advertising the
+    ## h2c backend protocol, for Gateway API implementations that do not infer it from the route type.
+    ## Leave empty to disable. Only rendered when `configs.params."server.insecure"` is `true`, since
+    ## h2c is not applicable to a TLS backend.
+    servicePortHttp2:
     # -- Server service https port
     servicePortHttps: 443
     # -- Server service http port name, can be used to route traffic via istio
     servicePortHttpName: http
+    # -- Server service http2 port name, can be used to route traffic via istio
+    servicePortHttp2Name: http2
     # -- Server service https port name, can be used to route traffic via istio
     servicePortHttpsName: https
+    # -- Server service http2 port appProtocol, e.g. `kubernetes.io/h2c`. Implementations that select the
+    # protocol from the port name instead do not need it
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
+    servicePortHttp2AppProtocol: ""
     # -- Server service https port appProtocol
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
     servicePortHttpsAppProtocol: ""


### PR DESCRIPTION
In insecure mode the Argo CD server multiplexes the web UI (HTTP/1.1 only) and
gRPC (HTTP/2 only) on a single container port, and both the HTTPRoute and the
GRPCRoute target `servicePortHttp`. `appProtocol` is single-valued per Service
port, so that one port cannot describe both: leaving it unset relies on the
implementation guessing the backend protocol, while setting `kubernetes.io/h2c`
on it would break the UI.

Per [GEP-1911], implementations only *MAY* infer the backend protocol from the
Route type, so gRPC works on some controllers and not others. This adds an
optional second Service port targeting the same container port, whose
`appProtocol` ([KEP-3726]) and port name can be set to declare the protocol
explicitly instead. The GRPCRoute uses that port when set, while the HTTPRoute
keeps using the http port.

`servicePortHttp2` is empty by default, so the rendered output is unchanged and
the GRPCRoute keeps targeting `servicePortHttp` — controllers that already infer
h2c correctly need no changes. The port is only rendered when `server.insecure`
is `true`, since h2c does not apply to a TLS backend.

This continues #3585, which was closed by the stale bot, and applies the review
feedback on that PR to gate the port on `server.insecure`. The existing https
port is kept rather than replaced, since removing it would be a breaking change.

[GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
[KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
