### PR TITLE
fix(github): bump chart minor when renovate updates the app minor or major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,7 +93,7 @@
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}} -t {{updateType}}",
           "./scripts/helm-docs.sh"
         ]
       }
@@ -110,7 +110,7 @@
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}} -t {{updateType}}",
           "./scripts/helm-docs.sh"
         ]
       }
@@ -120,7 +120,7 @@
       "commitMessagePrefix": "chore(argo-workflows):",
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}} -t {{updateType}}",
           "./scripts/helm-docs.sh"
         ]
       }

--- a/scripts/renovate-bump-version.sh
+++ b/scripts/renovate-bump-version.sh
@@ -25,7 +25,9 @@ chart_yaml_path="charts/${chart}/Chart.yaml"
 # This way we can drop prefixes like "argoproj/..." , "argoproj-labs/..." , "quay.io/foo/..."
 dependency_name="${dependency_name##*/}"
 
-# Mirror the upstream update type for the main application of each chart.
+# Map the upstream update type for the main application of each chart:
+# upstream major/minor -> chart minor, upstream patch -> chart patch (per CONTRIBUTING.md).
+# Chart major bumps stay manual since they require an Upgrading section in the README.
 # Auxiliary images (dex, redis, kubectl, ...) always bump the chart patch version.
 main_apps='argo-cd argo-workflows argo-events argo-rollouts argocd-image-updater'
 if [[ " ${main_apps} " != *" ${dependency_name} "* ]]; then
@@ -38,8 +40,7 @@ major=$(echo "${version}" | cut -d. -f1)
 minor=$(echo "${version}" | cut -d. -f2)
 patch=$(echo "${version}" | cut -d. -f3)
 case "${update_type}" in
-  major) major=$((major + 1)); minor=0; patch=0 ;;
-  minor) minor=$((minor + 1)); patch=0 ;;
+  major|minor) minor=$((minor + 1)); patch=0 ;;
   *) patch=$((patch + 1)) ;;
 esac
 sed -i "s/^version:.*/version: ${major}.${minor}.${patch}/g" "${chart_yaml_path}"

--- a/scripts/renovate-bump-version.sh
+++ b/scripts/renovate-bump-version.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-while getopts c:d:v: opt; do
+while getopts c:d:v:t: opt; do
   case ${opt} in
     c) chart=${OPTARG} ;;
     d) dependency_name=${OPTARG} ;;
     v) dependency_version=${OPTARG} ;;
+    t) update_type=${OPTARG} ;;
     *)
       echo 'Usage:' >&2
       echo '-c: chart       Related Helm chart name' >&2
       echo '-d  dependency  Name of the updated dependency' >&2
       echo '-v  version     New version of the updated dependency' >&2
+      echo '-t  type        Renovate update type (major, minor, patch)' >&2
       exit 1
   esac
 done
@@ -23,12 +25,23 @@ chart_yaml_path="charts/${chart}/Chart.yaml"
 # This way we can drop prefixes like "argoproj/..." , "argoproj-labs/..." , "quay.io/foo/..."
 dependency_name="${dependency_name##*/}"
 
-# Bump the chart version by one patch version
+# Mirror the upstream update type for the main application of each chart.
+# Auxiliary images (dex, redis, kubectl, ...) always bump the chart patch version.
+main_apps='argo-cd argo-workflows argo-events argo-rollouts argocd-image-updater'
+if [[ " ${main_apps} " != *" ${dependency_name} "* ]]; then
+  update_type='patch'
+fi
+
+# Bump the chart version according to the update type
 version=$(grep '^version:' "${chart_yaml_path}" | awk '{print $2}')
 major=$(echo "${version}" | cut -d. -f1)
 minor=$(echo "${version}" | cut -d. -f2)
 patch=$(echo "${version}" | cut -d. -f3)
-patch=$((patch + 1))
+case "${update_type}" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  *) patch=$((patch + 1)) ;;
+esac
 sed -i "s/^version:.*/version: ${major}.${minor}.${patch}/g" "${chart_yaml_path}"
 
 # Add a changelog entry


### PR DESCRIPTION
Relates to #3999

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning) (N/A - no chart changes, repo tooling only)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) (N/A)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog). (N/A)
* [x] Any new values are backwards compatible and/or have sensible default. (N/A)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

## What/Why

Renovate's post-upgrade script hardcodes a chart patch bump, so upstream minor/major releases (e.g. argo-cd 3.4 -> 3.5 in #3998) are published as chart patches. This passes Renovate's `updateType` to `renovate-bump-version.sh` and maps it per the [versioning policy](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning) for each chart's main application (argo-cd, argo-workflows, argo-events, argo-rollouts, argocd-image-updater): upstream minor and major -> chart minor, upstream patch -> chart patch. Chart majors remain a manual decision since they require an Upgrading section in the chart README. Auxiliary images (dex, redis, kubectl, ...) still bump patch only.

## Proof it works

Sandbox runs against a fake `Chart.yaml` at version 8.6.5:

| dependency | update type | chart version |
|---|---|---|
| argoproj/argo-cd | major | 8.7.0 |
| argoproj/argo-cd | minor | 8.7.0 |
| argoproj/argo-cd | patch | 8.6.6 |
| ghcr.io/dexidp/dex | major | 8.6.6 |
| redis | minor | 8.6.6 |
| argoproj/argo-cd | (no `-t` flag) | 8.6.6 |

The `artifacthub.io/changes` annotation regenerates correctly, and shellcheck passes.

## Risk + AI role

Low - only affects Renovate-generated version bumps and falls back to the current patch behavior for unknown update types or a missing `-t` flag. Changes were AI-assisted; verified manually.

## Review focus

The `main_apps` allowlist in `renovate-bump-version.sh` - confirm it matches the set of dependencies that should mirror upstream semver, and that upstream majors mapping to chart minors (per the maintainer discussion in #3999 and CONTRIBUTING) is the intended behavior.
