### PR TITLE
chore(github): switch CI to Helm 4 and bump chart-testing to v3.14.0

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.10.1 # Also update in publish.yaml
+          version: v4.2.3 # Also update in publish.yaml
 
       - name: Set up python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -57,7 +57,7 @@ jobs:
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
         with:
           # Note: Also update in scripts/lint.sh
-          version: v3.11.0
+          version: v3.14.0
 
       - name: List changed charts
         id: list-changed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.10.1 # Also update in lint-and-test.yaml
+          version: v4.2.3 # Also update in lint-and-test.yaml
 
       - name: Add dependency chart repos
         run: |

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # This script runs the chart-testing tool locally. It simulates the linting that is also done by the github action. Run this without any errors before pushing.
+# Note: The chart-testing image ships its own Helm binary (still 3.x), while CI runs Helm 4. Rendering differences are only caught in CI.
 # Reference: https://github.com/helm/chart-testing
 set -eux
 
@@ -9,7 +10,7 @@ echo -e "\n-- Linting all Helm Charts --\n"
 docker run \
      -v "$SRCROOT:/workdir" \
      --entrypoint /bin/sh \
-     quay.io/helmpack/chart-testing:v3.10.0 \
+     quay.io/helmpack/chart-testing:v3.14.0 \
      -c cd /workdir \
      ct lint \
      --config .github/configs/ct-lint.yaml \

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 # This script runs the chart-testing tool locally. It simulates the linting that is also done by the github action. Run this without any errors before pushing.
-# Note: The chart-testing image ships its own Helm binary (still 3.x), while CI runs Helm 4. Rendering differences are only caught in CI.
 # Reference: https://github.com/helm/chart-testing
 set -eux
 
 SRCROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Note: Also update in .github/workflows/lint-and-test.yml
+CT_VERSION=v3.14.0
+HELM_VERSION=v4.2.3
+
+# The chart-testing image ships its own Helm 3 binary, so install the Helm version used by CI before linting.
 echo -e "\n-- Linting all Helm Charts --\n"
 docker run \
      -v "$SRCROOT:/workdir" \
      --entrypoint /bin/sh \
-     quay.io/helmpack/chart-testing:v3.14.0 \
-     -c cd /workdir \
-     ct lint \
-     --config .github/configs/ct-lint.yaml \
-     --lint-conf .github/configs/lintconf.yaml \
-     --debug
+     "quay.io/helmpack/chart-testing:${CT_VERSION}" \
+     -c "arch=\$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') \
+         && curl -sSfL \"https://get.helm.sh/helm-${HELM_VERSION}-linux-\${arch}.tar.gz\" | tar -xz -C /tmp \
+         && rm -f /usr/local/bin/helm \
+         && mv \"/tmp/linux-\${arch}/helm\" /usr/local/bin/helm \
+         && git config --global --add safe.directory /workdir \
+         && cd /workdir \
+         && ct lint --config .github/configs/ct-lint.yaml --lint-conf .github/configs/lintconf.yaml --debug"


### PR DESCRIPTION
Kudos to @tico24 for noticing this.

## What/Why

Argo CD 3.5 bundles Helm 4 (`hack/tool-versions.sh` pins `helm4_version=4.2.1`), so published charts are rendered by Helm 4 at runtime. This switches CI from Helm 3.10.1 to 4.2.3 so we lint and install-test with the same major version, and bumps chart-testing v3.11.0 to v3.14.0 (workflow and local lint image) as the release most likely to be Helm 4 compatible. Helm 3 also enters its end-of-support window soon.

Per review feedback, `scripts/lint.sh` now installs the CI Helm version into the chart-testing container before linting, since the ct image bundles its own Helm 3. While making that change we found the script's unquoted `docker run ... -c cd /workdir ct lint ...` meant sh only ever executed `cd`, so the local lint had been a silent no-op; the quoting is fixed and it now runs for real.

## Proof it works

All 6 charts pass `helm lint` and `helm template` under Helm 4.2.3 locally, with default values and every `ci/*-values.yaml` variant. The repaired `scripts/lint.sh` was run end to end: Helm 4.2.3 installed inside the ct v3.14.0 container and `ct lint` passed against all six charts, so the ct-on-Helm-4 path has now been exercised for real (locally; CI's changed-chart detection still skips it in this PR since no charts are touched).

## Risk + AI role

Low: CI-only change, no chart content touched. Charts stay installable with Helm 3 (apiVersion v2, unchanged packaging); what changes is that CI no longer guards Helm 3 behavior. AI-assisted (version research, edits, local verification), directed and reviewed by a maintainer.

## Review focus

Whether ct v3.11.0 to v3.14.0 brings behavior changes we care about, and whether dropping Helm 3 from CI deserves a note in README or release notes for consumers still installing with Helm 3.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning) (N/A: no chart changes)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) (N/A)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog) (N/A)
* [x] Any new values are backwards compatible and/or have sensible default. (N/A)
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests) (N/A: no chart changes)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
