### PR TITLE
feat(argo-events): Update NATS images and add Renovate coverage for JetStream dependencies

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.11
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.24
+version: 2.4.25
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -18,5 +18,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
+    - kind: changed
+      description: Update JetStream default image to nats:2.14.4 and bump related sidecars (includes upstream PR argoproj/argo-events#4134)
     - kind: added
       description: Support deploymentAnnotations for controller and webhook Deployments

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -21,4 +21,6 @@ annotations:
     - kind: changed
       description: Update JetStream default image to nats:2.14.4 and bump related sidecars (includes upstream PR argoproj/argo-events#4134)
     - kind: added
+      description: Add Renovate coverage for NATS, prometheus-nats-exporter, and nats-server-config-reloader images
+    - kind: added
       description: Support deploymentAnnotations for controller and webhook Deployments

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -67,9 +67,9 @@ done
 | configs.jetstream.streamConfig.maxMsgs | int | `1000000` | Maximum number of messages before expiring oldest message |
 | configs.jetstream.streamConfig.replicas | int | `3` | Number of replicas, defaults to 3 and requires minimal 3 |
 | configs.jetstream.streamConfig.retention | int | `0` | 0: Limits, 1: Interest, 2: WorkQueue |
-| configs.jetstream.versions[0].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.14.0"` |  |
-| configs.jetstream.versions[0].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.14.0"` |  |
-| configs.jetstream.versions[0].natsImage | string | `"nats:2.10.10"` |  |
+| configs.jetstream.versions[0].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.23.0"` |  |
+| configs.jetstream.versions[0].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.20.1"` |  |
+| configs.jetstream.versions[0].natsImage | string | `"nats:2.14.4"` |  |
 | configs.jetstream.versions[0].startCommand | string | `"/nats-server"` |  |
 | configs.jetstream.versions[0].version | string | `"latest"` |  |
 | configs.jetstream.versions[1].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.7.0"` |  |
@@ -112,6 +112,11 @@ done
 | configs.jetstream.versions[8].natsImage | string | `"nats:2.10.10"` |  |
 | configs.jetstream.versions[8].startCommand | string | `"/nats-server"` |  |
 | configs.jetstream.versions[8].version | string | `"2.10.10"` |  |
+| configs.jetstream.versions[9].configReloaderImage | string | `"natsio/nats-server-config-reloader:0.23.0"` |  |
+| configs.jetstream.versions[9].metricsExporterImage | string | `"natsio/prometheus-nats-exporter:0.20.1"` |  |
+| configs.jetstream.versions[9].natsImage | string | `"nats:2.14.4"` |  |
+| configs.jetstream.versions[9].startCommand | string | `"/nats-server"` |  |
+| configs.jetstream.versions[9].version | string | `"2.14.4"` |  |
 | configs.nats.versions | list | See [values.yaml] | Supported versions of NATS event bus |
 | crds.annotations | object | `{}` | Annotations to be added to all CRDs |
 | crds.install | bool | `true` | Install and upgrade CRDs |

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -101,9 +101,9 @@ configs:
     # Supported versions of JetStream eventbus
     versions:
       - version: latest
-        natsImage: nats:2.10.10
-        metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-        configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+        natsImage: nats:2.14.4
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.23.0
         startCommand: /nats-server
       - version: 2.8.1
         natsImage: nats:2.8.1
@@ -144,6 +144,11 @@ configs:
         natsImage: nats:2.10.10
         metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
         configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+        startCommand: /nats-server
+      - version: 2.14.4
+        natsImage: nats:2.14.4
+        metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+        configReloaderImage: natsio/nats-server-config-reloader:0.23.0
         startCommand: /nats-server
 
 # -- Array of extra K8s manifests to deploy

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
     "**/charts/argo-cd/Chart.yaml",
     "**/charts/argo-cd/values.yaml",
     "**/charts/argo-events/Chart.yaml",
+    "**/charts/argo-events/values.yaml",
     "**/charts/argo-rollouts/Chart.yaml",
     "**/charts/argocd-image-updater/Chart.yaml",
     "**/.github/workflows/renovate.yaml"
@@ -72,6 +73,33 @@
     },
     {
       "customType": "regex",
+      "fileMatch": ["charts/argo-events/values.yaml$"],
+      "matchStrings": [
+        "natsImage: (?<depName>nats):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["charts/argo-events/values.yaml$"],
+      "matchStrings": [
+        "metricsExporterImage: (?<depName>natsio/prometheus-nats-exporter):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["charts/argo-events/values.yaml$"],
+      "matchStrings": [
+        "configReloaderImage: (?<depName>natsio/nats-server-config-reloader):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
       "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)"
@@ -88,7 +116,10 @@
         "argoproj-labs/argocd-image-updater",
         "argoprojlabs/argocd-extension-installer",
         "ghcr.io/dexidp/dex",
-        "ghcr.io/oliver006/redis_exporter"
+        "ghcr.io/oliver006/redis_exporter",
+        "^nats$",
+        "natsio/prometheus-nats-exporter",
+        "natsio/nats-server-config-reloader"
       ],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

This MR is to ensure the helm chart has the changes performed here: https://github.com/argoproj/argo-events/pull/4134