### PR TITLE
ci(renovate): propagate the main service's semver level to the chart

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,7 +93,7 @@
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -o {{currentValue}} -v {{newVersion}}",
           "./scripts/helm-docs.sh"
         ]
       }
@@ -110,7 +110,7 @@
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -o {{currentValue}} -v {{newVersion}}",
           "./scripts/helm-docs.sh"
         ]
       }
@@ -120,7 +120,7 @@
       "commitMessagePrefix": "chore(argo-workflows):",
       "postUpgradeTasks": {
         "commands": [
-          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -v {{newVersion}}",
+          "./scripts/renovate-bump-version.sh -c {{parentDir}} -d {{depName}} -o {{currentValue}} -v {{newVersion}}",
           "./scripts/helm-docs.sh"
         ]
       }

--- a/scripts/renovate-bump-version.sh
+++ b/scripts/renovate-bump-version.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-while getopts c:d:v: opt; do
+while getopts c:d:o:v: opt; do
   case ${opt} in
     c) chart=${OPTARG} ;;
     d) dependency_name=${OPTARG} ;;
+    o) dependency_old_version=${OPTARG} ;;
     v) dependency_version=${OPTARG} ;;
     *)
       echo 'Usage:' >&2
       echo '-c: chart       Related Helm chart name' >&2
       echo '-d  dependency  Name of the updated dependency' >&2
+      echo '-o  old version Previous version of the updated dependency (optional)' >&2
       echo '-v  version     New version of the updated dependency' >&2
       exit 1
   esac
@@ -23,12 +25,57 @@ chart_yaml_path="charts/${chart}/Chart.yaml"
 # This way we can drop prefixes like "argoproj/..." , "argoproj-labs/..." , "quay.io/foo/..."
 dependency_name="${dependency_name##*/}"
 
-# Bump the chart version by one patch version
+# Strip a leading "v" as well as pre-release and build metadata,
+# e.g. "v3.5.0-rc1" becomes "3.5.0"
+normalize_version() {
+  local version="${1#v}"
+  version="${version%%-*}"
+  echo "${version%%+*}"
+}
+
+# Determine how much of the chart version has to be bumped.
+# The chart's main application propagates its own bump level to the chart, so a
+# major or minor application update is not hidden behind a chart patch release.
+# Sidecars and other dependencies (Dex, Redis, kubectl, ...) always stay on patch.
+bump_level='patch'
+if [ "${dependency_name}" = "${chart}" ] && [ -n "${dependency_old_version}" ]; then
+  old_version=$(normalize_version "${dependency_old_version}")
+  new_version=$(normalize_version "${dependency_version}")
+  if [[ "${old_version}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+    old_major="${BASH_REMATCH[1]}"
+    old_minor="${BASH_REMATCH[2]}"
+    if [[ "${new_version}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+      new_major="${BASH_REMATCH[1]}"
+      new_minor="${BASH_REMATCH[2]}"
+      if [ "${new_major}" -gt "${old_major}" ]; then
+        bump_level='major'
+      elif [ "${new_major}" -eq "${old_major}" ] && [ "${new_minor}" -gt "${old_minor}" ]; then
+        bump_level='minor'
+      fi
+    fi
+  fi
+fi
+
+# Bump the chart version according to the determined bump level
 version=$(grep '^version:' "${chart_yaml_path}" | awk '{print $2}')
 major=$(echo "${version}" | cut -d. -f1)
 minor=$(echo "${version}" | cut -d. -f2)
 patch=$(echo "${version}" | cut -d. -f3)
-patch=$((patch + 1))
+case "${bump_level}" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  *)
+    patch=$((patch + 1))
+    ;;
+esac
+echo "Bumping ${chart} chart from ${version} to ${major}.${minor}.${patch} (${bump_level})"
 sed -i "s/^version:.*/version: ${major}.${minor}.${patch}/g" "${chart_yaml_path}"
 
 # Add a changelog entry


### PR DESCRIPTION
fixes #4009

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [+] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
