### PR TITLE
feat(argo-cd): add hostnetwork to redis

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.4.2
+version: 10.4.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis_exporter to v1.90.0
+    - kind: added
+      description: Added dnsPolicy/dnsConfig support for the secret initialization of Redis. Added hostNetwork support for Redis and the Redis secret initialization.

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1679,6 +1679,7 @@ NAME: my-release
 | redis.exporter.resources | object | `{}` | Resource limits and requests for redis-exporter sidecar |
 | redis.extraArgs | list | `[]` | Additional command line arguments to pass to redis-server |
 | redis.extraContainers | list | `[]` | Additional containers to be added to the redis pod |
+| redis.hostNetwork | bool | `false` | Host Network for redis pods |
 | redis.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Redis image pull policy |
 | redis.image.repository | string | `"ecr-public.aws.com/docker/library/redis"` | Redis repository |
 | redis.image.tag | string | `"8.6.4-alpine"` | Redis tag |
@@ -1814,8 +1815,11 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 |-----|------|---------|-------------|
 | redisSecretInit.affinity | object | `{}` | Assign custom [affinity] rules to the Redis secret-init Job |
 | redisSecretInit.containerSecurityContext | object | See [values.yaml] | Application controller container-level security context |
+| redisSecretInit.dnsConfig | object | `{}` | [DNS configuration] |
+| redisSecretInit.dnsPolicy | string | `"ClusterFirst"` | Alternative DNS policy for Redis secret-init Job |
 | redisSecretInit.enabled | bool | `true` | Enable Redis secret initialization. If disabled, secret must be provisioned by alternative methods |
 | redisSecretInit.extraArgs | list | `[]` | Additional command line arguments for the Redis secret-init Job |
+| redisSecretInit.hostNetwork | bool | `false` | Host Network for redis-secret-init pods |
 | redisSecretInit.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the Redis secret-init Job |
 | redisSecretInit.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the Redis secret-init Job |
 | redisSecretInit.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the Redis secret-init Job |

--- a/charts/argo-cd/templates/redis-secret-init/job.yaml
+++ b/charts/argo-cd/templates/redis-secret-init/job.yaml
@@ -72,5 +72,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.redisSecretInit.hostNetwork }}
+      hostNetwork: {{ .Values.redisSecretInit.hostNetwork }}
+      {{- end }}
+      {{- with .Values.redisSecretInit.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: {{ .Values.redisSecretInit.dnsPolicy }}
       serviceAccountName: {{ include "argo-cd.redisSecretInit.serviceAccountName" . }}
 {{- end }}

--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -215,6 +215,9 @@ spec:
       {{- with .Values.redis.volumes }}
         {{- toYaml . | nindent 8}}
       {{- end }}
+      {{- if .Values.redis.hostNetwork }}
+      hostNetwork: {{ .Values.redis.hostNetwork }}
+      {{- end }}
       {{- with .Values.redis.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1733,6 +1733,9 @@ redis:
     # -- Metrics container port
     metrics: 9121
 
+  # -- Host Network for redis pods
+  hostNetwork: false
+
   # -- [DNS configuration]
   dnsConfig: {}
   # -- Alternative DNS policy for Redis server pods
@@ -2035,6 +2038,14 @@ redisSecretInit:
   # -- Priority class for Redis secret-init Job
   # @default -- `""` (defaults to global.priorityClassName)
   priorityClassName: ""
+
+  # -- Host Network for redis-secret-init pods
+  hostNetwork: false
+
+  # -- [DNS configuration]
+  dnsConfig: {}
+  # -- Alternative DNS policy for Redis secret-init Job
+  dnsPolicy: "ClusterFirst"
 
   # -- Assign custom [affinity] rules to the Redis secret-init Job
   affinity: {}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

This PR simply adds the ability to toggle hostNetwork on the Redis deployed by the chart.
Useful when installing ArgoCD on an empty cluster (with no CNI) if ArgoCD is to install the CNI itself.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
