### PR TITLE
fix(argo-cd): default HTTPRoute hostnames to global.domain when unset

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.6.4
+version: 10.6.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Hash only the data/stringData of ConfigMaps and Secrets in checksum/* pod annotations so a chart version bump alone no longer restarts all Argo CD pods. Adopting this release recomputes every checksum/* annotation once, so all Argo CD pods roll a single time on this specific upgrade; subsequent version bumps no longer roll them.
+      description: HTTPRoute now defaults spec.hostnames to global.domain when httproute.hostnames is unset. This changes behavior — an omitted hostnames previously matched all hostnames of the bound listener, and now narrows to global.domain (default placeholder argocd.example.com). To restore match-all, set httproute.hostnames explicitly or set global.domain to "".

--- a/charts/argo-cd/templates/argocd-applicationset/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/httproute.yaml
@@ -31,6 +31,9 @@ spec:
   {{- else if .Values.applicationSet.listenerset.enabled }}
   hostnames:
     - {{ tpl (.Values.applicationSet.listenerset.hostname | default .Values.global.domain) $ | quote }}
+  {{- else if .Values.global.domain }}
+  hostnames:
+    - {{ tpl .Values.global.domain $ | quote }}
   {{- end }}
   rules:
     {{- range .Values.applicationSet.httproute.rules }}

--- a/charts/argo-cd/templates/argocd-server/httproute.yaml
+++ b/charts/argo-cd/templates/argocd-server/httproute.yaml
@@ -33,6 +33,9 @@ spec:
   {{- else if .Values.server.listenerset.enabled }}
   hostnames:
     - {{ tpl (.Values.server.listenerset.hostname | default .Values.global.domain) $ | quote }}
+  {{- else if .Values.global.domain }}
+  hostnames:
+    - {{ tpl .Values.global.domain $ | quote }}
   {{- end }}
   rules:
   {{- range .Values.server.httproute.rules }}


### PR DESCRIPTION
Defaults the argo-cd `server` and `applicationSet` HTTPRoute `spec.hostnames` to `global.domain` when `hostnames` are not set and no ListenerSet is enabled. Previously the rendered HTTPRoute omitted `spec.hostnames` entirely in that case. This mirrors the existing ListenerSet branch, which already falls back to `global.domain`.

Verified with `helm lint` and `helm template`:
- `hostnames` unset → `spec.hostnames: ["<global.domain>"]`
- `hostnames` set → uses the provided values (unchanged)
- omitted when `global.domain` is also empty

Closes #3990

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Closes #3972