### PR TITLE
fix(argo-cd): add app.kubernetes.io/part-of: argocd to secretTem…

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.7.1
+version: 10.7.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: security
-      description: Bump the redis-ha Redis image to 8.6.4-alpine so it no longer ships an OpenSSL version affected by the RSASVE uninitialized-memory issue (reported by m98anu)
+    - kind: fixed
+      description: "add app.kubernetes.io/part-of: argocd to secretTemplate.label of the server.certificate generated certificate so hot reloading works on certificate rotation"

--- a/charts/argo-cd/templates/argocd-server/certificate.yaml
+++ b/charts/argo-cd/templates/argocd-server/certificate.yaml
@@ -13,8 +13,10 @@ metadata:
   labels:
     {{- include "argo-cd.labels" (dict "context" . "component" .Values.server.name "name" .Values.server.name) | nindent 4 }}
 spec:
-  {{- with .Values.server.certificate.secretTemplateAnnotations }}
   secretTemplate:
+    labels:
+      app.kubernetes.io/part-of: argocd
+  {{- with .Values.server.certificate.secretTemplateAnnotations }}
     annotations:
       {{- range $key, $value := . }}
       {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
…plate.label of the server.certificate generated certificate so hot reloading works on certificate rotation

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

Closes #4017