### PR TITLE
fix(argo-rollouts): remove default controller readinessProbe to align with upstream

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.41.1
+version: 2.42.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-rollouts to v1.9.1
+    - kind: removed
+      description: Remove default readinessProbe from the controller to align with upstream manifests (argo-rollouts#4704)

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -131,7 +131,6 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.podLabels | object | `{}` | Labels to be added to the application controller pods |
 | controller.pprofAddress | string | `""` | Enable pprof profiling on the controller by specifying a listen address (e.g. `:6060` or `localhost:6060`) |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
-| controller.readinessProbe | object | See [values.yaml] | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.selfServiceNotification | bool | `false` | Enable self-service notification support, allowing the controller to pull notification config from the rollout's namespace |

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -131,6 +131,7 @@ For full list of changes please check ArtifactHub [changelog].
 | controller.podLabels | object | `{}` | Labels to be added to the application controller pods |
 | controller.pprofAddress | string | `""` | Enable pprof profiling on the controller by specifying a listen address (e.g. `:6060` or `localhost:6060`) |
 | controller.priorityClassName | string | `""` | [priorityClassName] for the controller |
+| controller.readinessProbe | object | `{}` | Configure readiness [probe] for the controller |
 | controller.replicas | int | `2` | The number of controller pods to run |
 | controller.resources | object | `{}` | Resource limits and requests for the controller pods. |
 | controller.selfServiceNotification | bool | `false` | Enable self-service notification support, allowing the controller to pull notification config from the rollout's namespace |

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -90,8 +90,10 @@ spec:
           name: healthz
         livenessProbe:
           {{- toYaml .Values.controller.livenessProbe | nindent 10 }}
+        {{- with .Values.controller.readinessProbe }}
         readinessProbe:
-          {{- toYaml .Values.controller.readinessProbe | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         {{- with .Values.controller.lifecycle }}

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -210,6 +210,9 @@ controller:
     successThreshold: 1
     timeoutSeconds: 10
 
+  # -- Configure readiness [probe] for the controller
+  readinessProbe: {}
+
   ## Configure Pod Disruption Budget for the controller
   pdb:
     # -- Labels to be added to controller [Pod Disruption Budget]

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -210,18 +210,6 @@ controller:
     successThreshold: 1
     timeoutSeconds: 10
 
-  # -- Configure readiness [probe] for the controller
-  # @default -- See [values.yaml]
-  readinessProbe:
-    httpGet:
-      path: /metrics
-      port: metrics
-    initialDelaySeconds: 15
-    periodSeconds: 5
-    failureThreshold: 3
-    successThreshold: 1
-    timeoutSeconds: 4
-
   ## Configure Pod Disruption Budget for the controller
   pdb:
     # -- Labels to be added to controller [Pod Disruption Budget]


### PR DESCRIPTION
Upstream removed the controller readinessProbe from the install manifests in argoproj/argo-rollouts#4704 (released in v1.9.1), since probing `/metrics` is expensive and process health is already covered by the liveness probe on `/healthz`. This PR aligns the chart with upstream: the default `controller.readinessProbe` is removed, and the probe is rendered only when the value is set.

Users who want the previous behavior can set `controller.readinessProbe` explicitly (partial overrides now require the full probe definition).

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
