### PR TITLE
fix(argo-events): RoleBinding missing metadata.namespace under controller.rbac.namespaced

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.11
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.24
+version: 2.4.25
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:

--- a/charts/argo-events/templates/argo-events-controller/rbac.yaml
+++ b/charts/argo-events/templates/argo-events-controller/rbac.yaml
@@ -113,6 +113,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.controller.rbac.namespaced | ternary "RoleBinding" "ClusterRoleBinding" }}
 metadata:
   name: {{ include "argo-events.controller.fullname" . }}
+  {{- if .Values.controller.rbac.namespaced }}
+  namespace: {{ include "argo-events.namespace" . | quote }}
+  {{- end }}
   labels:
     {{- include "argo-events.labels" (dict "context" . "component" .Values.controller.name "name" .Values.controller.name) | nindent 4 }}
 roleRef:


### PR DESCRIPTION
## What

`charts/argo-events/templates/argo-events-controller/rbac.yaml`'s `Role`/`ClusterRole`
block correctly conditions `metadata.namespace` on `controller.rbac.namespaced`:

```yaml
metadata:
  name: {{ include "argo-events.controller.fullname" . }}
  {{- if .Values.controller.rbac.namespaced }}
  namespace: {{ include "argo-events.namespace" . | quote }}
  {{- end }}
```

The sibling `RoleBinding`/`ClusterRoleBinding` block right below it has no such condition
at all — `metadata.namespace` is simply absent, in both modes.

## Impact

With `controller.rbac.namespaced: true`, the rendered `RoleBinding` has no
`metadata.namespace`, so `kubectl apply`/`helm install` places it wherever the apply
context's own default namespace is, not the chart's release namespace. The controller pod
still comes up `Running`, but every `list`/`watch` call it makes against its own CRs
(`EventSource`, `Sensor`, `EventBus`) and core resources fails `forbidden … in the
namespace "<release-namespace>"`, since the RoleBinding granting those permissions isn't
actually bound in that namespace.

Found running this chart (`v2.4.24`) in production with the namespaced RBAC option enabled,
as a lower-privilege alternative to the chart's default cluster-wide `ClusterRole`/
`ClusterRoleBinding`.

## Fix

Add the identical conditional already used one block above, to the `RoleBinding`/
`ClusterRoleBinding` block's `metadata`.

## Verified

```
$ helm template test . --namespace argo-events --set controller.rbac.namespaced=true -s templates/argo-events-controller/rbac.yaml
kind: RoleBinding
metadata:
  name: test-argo-events-controller-manager
  namespace: "argo-events"
  ...
```

Default (cluster-wide) mode confirmed unaffected — `ClusterRoleBinding` still renders with
no `metadata.namespace`, as expected for a cluster-scoped object.

Chart version bumped `2.4.24` → `2.4.25` per `CONTRIBUTING.md`.

Closes #4023.