### PR TITLE
fix(argo-cd): mark argocd-tls-certs-cm volume optional

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.6.1
+version: 10.6.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Support tpl for url and statusbadge.url values in argocd-cm
+      description: Mark the argocd-tls-certs-cm configMap volume as optional so pods start when configs.tls.create=false

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -352,6 +352,7 @@ spec:
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm
+            optional: true
         - name: gpg-keys
           configMap:
             name: argocd-gpg-keys-cm

--- a/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
@@ -180,6 +180,7 @@ spec:
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm
+            optional: true
         - name: gpg-keys
           configMap:
             name: argocd-gpg-keys-cm

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -212,6 +212,7 @@ spec:
         - name: tls-certs
           configMap:
             name: argocd-tls-certs-cm
+            optional: true
         - name: argocd-repo-server-tls
           secret:
             secretName: argocd-repo-server-tls

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -529,6 +529,7 @@ spec:
       - name: tls-certs
         configMap:
           name: argocd-tls-certs-cm
+          optional: true
       - name: gpg-keys
         configMap:
           name: argocd-gpg-keys-cm

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -549,6 +549,7 @@ spec:
       - name: tls-certs
         configMap:
           name: argocd-tls-certs-cm
+          optional: true
       - name: styles
         configMap:
           name: argocd-styles-cm


### PR DESCRIPTION
Closes #4007

When `configs.tls.create=false` the `argocd-tls-certs-cm` ConfigMap is not rendered, but the `tls-certs` `configMap` volume in the Deployments still referenced it as a non-optional volume. A fresh pod then fails to start with:

```
configmap "argocd-tls-certs-cm" not found
```

This PR marks the `tls-certs` configMap volume `optional: true` in every Deployment that mounts it — `argocd-server`, `argocd-repo-server`, `argocd-notifications`, `argocd-applicationset` and `argocd-commit-server` — mirroring how other optional cert bundles (e.g. `argocd-styles-cm`, `argocd-repo-server-tls`) are already declared.

The `volumeMount` path is preserved, so an externally-managed ConfigMap is still picked up (the maintainer intent noted in #3157), while pods can boot when the chart does not create the ConfigMap. This is narrower than #3157, which gated the volumes entirely.

Verification:

- `helm lint charts/argo-cd` → `0 chart(s) failed`.
- `helm template charts/argo-cd --set configs.tls.create=false` → the ConfigMap is absent and every rendered `tls-certs` volume now carries `optional: true`.
- `helm template charts/argo-cd` (defaults) → ConfigMap still created, volumes carry `optional: true` (a no-op when the ConfigMap exists); no regression.

No `values.yaml` changes, so no `helm-docs` regeneration was needed.

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
