### PR TITLE
fix(argo-rollouts): harden dashboard security context

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.10.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.43.0
+version: 2.43.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-rollouts to v1.10.0
+    - kind: security
+      description: Harden the dashboard container security context by default

--- a/charts/argo-rollouts/README.md
+++ b/charts/argo-rollouts/README.md
@@ -156,7 +156,7 @@ For full list of changes please check ArtifactHub [changelog].
 |-----|------|---------|-------------|
 | dashboard.affinity | object | `{}` | Assign custom [affinity] rules to the deployment |
 | dashboard.component | string | `"rollouts-dashboard"` | Value of label `app.kubernetes.io/component` |
-| dashboard.containerSecurityContext | object | `{}` | Security Context to set on container level |
+| dashboard.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context to set on container level |
 | dashboard.createClusterRole | bool | `true` | flag to enable creation of dashbord cluster role (requires cluster RBAC) |
 | dashboard.deploymentAnnotations | object | `{}` | Annotations to be added to the dashboard deployment |
 | dashboard.deploymentLabels | object | `{}` | Labels to be added to the dashboard deployment |

--- a/charts/argo-rollouts/values.yaml
+++ b/charts/argo-rollouts/values.yaml
@@ -394,7 +394,14 @@ dashboard:
   podSecurityContext:
     runAsNonRoot: true
   # -- Security Context to set on container level
-  containerSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
   service:
     # -- Sets the type of the Service
     type: ClusterIP


### PR DESCRIPTION
## Summary

- prevent privilege escalation in the dashboard container by default
- drop all Linux capabilities from the dashboard container
- use a read-only root filesystem and the RuntimeDefault seccomp profile
- rebase onto current main and bump the argo-rollouts chart to 2.43.1
- regenerate documentation

This aligns the optional dashboard with the Kubernetes Restricted Pod Security Standard controls already configured for the controller while preserving value overrides.

## Testing

- `helm lint charts/argo-rollouts -f charts/argo-rollouts/ci/enable-dashboard-values.yaml`
- rendered the dashboard and verified the complete default security context, including `readOnlyRootFilesystem: true`
- the repository-wide `./scripts/lint.sh` requires Docker, which is unavailable in the current WSL environment; chart CI will run it

## Checklist

* [x] I have bumped the chart version according to versioning
* [x] I have updated the documentation according to documentation
* [x] I have updated the chart changelog with all changes in this pull request
* [x] Any new values are backwards compatible and/or have sensible defaults
* [x] I have signed off all commits as required by DCO
* [x] I have created a separate pull request for this chart
* [x] My local chart lint and render are green
