### PR TITLE
fix(argo-cd): grant argocd-server impersonate on serviceaccounts in default RBAC

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.8.1
+version: 10.9.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-extension-installer to v1.1.0
+    - kind: added
+      description: Add opt-in server.impersonation.enabled/serviceAccounts to grant argocd-server a scoped (resourceNames) impersonate rule for the Argo CD v3.5+ app-sync impersonation feature; default off leaves default RBAC unchanged

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1394,6 +1394,8 @@ NAME: my-release
 | server.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the Argo CD server |
 | server.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the Argo CD server |
 | server.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
+| server.impersonation.enabled | bool | `false` | Grant argocd-server the `impersonate` verb on serviceaccounts for the app-sync impersonation feature (Argo CD v3.5+). Only enable if you use application sync impersonation; leaving it off keeps the default RBAC unchanged. |
+| server.impersonation.serviceAccounts | list | `[]` | ServiceAccount names argocd-server may impersonate. Rendered as `resourceNames` to scope the grant; leaving it empty allows impersonating any ServiceAccount (NOT recommended). |
 | server.ingress.annotations | object | `{}` | Additional ingress annotations |
 | server.ingress.aws.backendProtocolVersion | string | `"GRPC"` | Backend protocol version for the AWS ALB gRPC service |
 | server.ingress.aws.serviceAnnotations | object | `{}` | Annotations for the AWS ALB gRPC service |

--- a/charts/argo-cd/templates/argocd-server/clusterrole.yaml
+++ b/charts/argo-cd/templates/argocd-server/clusterrole.yaml
@@ -17,6 +17,18 @@ rules:
       - delete  # supports deletion a live object in UI
       - get     # supports viewing live object manifest in UI
       - patch   # supports `argocd app patch`
+  {{- if .Values.server.impersonation.enabled }}
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    {{- with .Values.server.impersonation.serviceAccounts }}
+    resourceNames:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    verbs:
+      - impersonate  # opt-in: app-sync impersonation feature (Argo CD v3.5+); scoped to server.impersonation.serviceAccounts
+  {{- end }}
   - apiGroups:
       - ""
     resources:

--- a/charts/argo-cd/templates/argocd-server/role.yaml
+++ b/charts/argo-cd/templates/argocd-server/role.yaml
@@ -33,6 +33,18 @@ rules:
   - update
   - delete
   - patch
+{{- if .Values.server.impersonation.enabled }}
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  {{- with .Values.server.impersonation.serviceAccounts }}
+  resourceNames:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  verbs:
+  - impersonate  # opt-in: app-sync impersonation feature (Argo CD v3.5+); scoped to server.impersonation.serviceAccounts
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -3035,6 +3035,20 @@ server:
     # -- List of custom rules for the server's ClusterRole resource
     rules: []
 
+  ## Opt-in impersonation RBAC for the Argo CD v3.5+ app-sync-using-impersonation feature
+  ## (`application.sync.impersonation.enabled` in argocd-cm). When enabled, argocd-server
+  ## impersonates a tenant ServiceAccount during resource delete/manage triggered from the UI/API.
+  ## Default OFF: default installs never impersonate, so default RBAC grants nothing.
+  ## Keep this least-privilege — always set `serviceAccounts` so the grant is scoped via
+  ## `resourceNames` instead of allowing impersonation of every ServiceAccount in the cluster.
+  impersonation:
+    # -- Grant argocd-server the `impersonate` verb on serviceaccounts for the app-sync impersonation feature (Argo CD v3.5+). Only enable if you use application sync impersonation; leaving it off keeps the default RBAC unchanged.
+    enabled: false
+    # -- ServiceAccount names argocd-server may impersonate. Rendered as `resourceNames` to scope the grant; leaving it empty allows impersonating any ServiceAccount (NOT recommended).
+    serviceAccounts: []
+      # - tenant-a-deployer
+      # - tenant-b-deployer
+
   # Default ArgoCD Server's network policy
   networkPolicy:
     # -- Default network policy rules used by ArgoCD Server


### PR DESCRIPTION
Fixes #4028

## What this PR does

Argo CD v3.5 extended application impersonation to server operations: `argocd-server` now impersonates the application controller's ServiceAccount during resource delete/manage. The chart's default server RBAC never granted the `impersonate` verb on `serviceaccounts`, so deleting a live resource from the Argo CD UI/API fails with a `forbidden` error (reported against app `v3.5.1` / chart `v10.4.0`).

This adds the following rule to the default server RBAC templates:

```yaml
- apiGroups:
    - ""
  resources:
    - serviceaccounts
  verbs:
    - impersonate
```

- Added to the default server **ClusterRole** (`templates/argocd-server/clusterrole.yaml`), guarded under the existing default-rules path (`server.clusterRoleRules.enabled=false`) so it does not affect users who supply their own `server.clusterRoleRules.rules`.
- Added to the namespace-scoped server **Role** (`templates/argocd-server/role.yaml`).

No values changed, so this is backwards compatible with no configuration required.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
