### PR TITLE
feat(argo-cd): add VPA startupBoost passthrough for all components

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.6.4
+version: 10.7.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Hash only the data/stringData of ConfigMaps and Secrets in checksum/* pod annotations so a chart version bump alone no longer restarts all Argo CD pods. Adopting this release recomputes every checksum/* annotation once, so all Argo CD pods roll a single time on this specific upgrade; subsequent version bumps no longer roll them.
+    - kind: added
+      description: Support specifying a VPA startup boost via <component>.vpa.startupBoost for all components

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1184,6 +1184,7 @@ NAME: my-release
 | controller.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the application controller |
 | controller.vpa.labels | object | `{}` | Labels to be added to application controller vpa |
 | controller.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| controller.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | controller.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ## Argo Repo Server
@@ -1306,6 +1307,7 @@ NAME: my-release
 | repoServer.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the repo server |
 | repoServer.vpa.labels | object | `{}` | Labels to be added to repo server vpa |
 | repoServer.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| repoServer.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | repoServer.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ## Argo Server
@@ -1527,6 +1529,7 @@ NAME: my-release
 | server.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the Argo CD server |
 | server.vpa.labels | object | `{}` | Labels to be added to Argo CD server vpa |
 | server.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| server.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | server.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ## Dex
@@ -1639,6 +1642,7 @@ NAME: my-release
 | dex.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the Dex server |
 | dex.vpa.labels | object | `{}` | Labels to be added to Dex server vpa |
 | dex.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| dex.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | dex.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ## Redis
@@ -1747,6 +1751,7 @@ NAME: my-release
 | redis.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the Redis |
 | redis.vpa.labels | object | `{}` | Labels to be added to Redis vpa |
 | redis.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| redis.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | redis.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ### Option 2 - Redis HA
@@ -1983,6 +1988,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the ApplicationSet controller |
 | applicationSet.vpa.labels | object | `{}` | Labels to be added to ApplicationSet controller vpa |
 | applicationSet.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| applicationSet.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | applicationSet.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ## Notifications
@@ -2083,6 +2089,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the notifications controller |
 | notifications.vpa.labels | object | `{}` | Labels to be added to notifications controller vpa |
 | notifications.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| notifications.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | notifications.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ## Commit server (Manifest Hydrator)
@@ -2160,6 +2167,7 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | commitServer.vpa.enabled | bool | `false` | Deploy a [VerticalPodAutoscaler](https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/) for the commit server |
 | commitServer.vpa.labels | object | `{}` | Labels to be added to commit server vpa |
 | commitServer.vpa.recommenders | list | `[]` | The recommenders that will provide recommendations for vertical scaling. Only relevant if a named VPA recommender (e.g. one started with a custom recommender name) is in use; leave unset to use the cluster's default recommender |
+| commitServer.vpa.startupBoost | object | `{}` | Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set |
 | commitServer.vpa.updateMode | string | `"Initial"` | One of the VPA operation modes |
 
 ----------------------------------------------

--- a/charts/argo-cd/ci/vpa-values.yaml
+++ b/charts/argo-cd/ci/vpa-values.yaml
@@ -7,6 +7,11 @@ controller:
     enabled: true
     recommenders:
       - name: test-recommender
+    startupBoost:
+      cpu:
+        type: Factor
+        factor: 2
+        durationSeconds: 10
 
 server:
   vpa:

--- a/charts/argo-cd/templates/argocd-application-controller/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.controller.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.controller.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     {{- if .Values.controller.dynamicClusterDistribution }}

--- a/charts/argo-cd/templates/argocd-applicationset/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.applicationSet.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.applicationSet.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/templates/argocd-commit-server/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.commitServer.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.commitServer.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/templates/argocd-notifications/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.notifications.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.notifications.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/templates/argocd-repo-server/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.repoServer.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.repoServer.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/templates/argocd-server/vpa.yaml
+++ b/charts/argo-cd/templates/argocd-server/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.server.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.server.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/templates/dex/vpa.yaml
+++ b/charts/argo-cd/templates/dex/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.dex.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.dex.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/templates/redis/vpa.yaml
+++ b/charts/argo-cd/templates/redis/vpa.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.redis.vpa.recommenders }}
   recommenders: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.redis.vpa.startupBoost }}
+  startupBoost: {{- toYaml . | nindent 4 }}
+  {{- end }}
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -837,6 +837,13 @@ controller:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## Application controller image
   image:
@@ -1238,6 +1245,13 @@ dex:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## Dex image
   image:
@@ -1563,6 +1577,13 @@ redis:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## Redis image
   image:
@@ -2162,6 +2183,13 @@ server:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## Argo CD server image
   image:
@@ -3074,6 +3102,13 @@ repoServer:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## Repo server image
   image:
@@ -3516,6 +3551,13 @@ applicationSet:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## ApplicationSet controller image
   image:
@@ -4038,6 +4080,13 @@ notifications:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10
 
   ## Notifications controller image
   image:
@@ -4838,3 +4887,10 @@ commitServer:
     ## Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#verticalpodautoscalerspec
     ## NOTE: specify only zero or one recommender as of VPA 1.7.1
     recommenders: []
+    # -- Configures a startup resource boost for faster cold-start (application boot) resource allocation. NOTE: startupBoost is currently a GKE-specific extension to the VPA API and is only honored on GKE clusters; it is rendered only when set
+    ## Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup
+    startupBoost: {}
+      # cpu:
+      #   type: Factor
+      #   factor: 2
+      #   durationSeconds: 10


### PR DESCRIPTION
Closes #3974

This adds an optional `<component>.vpa.startupBoost` value that is threaded into the `VerticalPodAutoscaler` spec for every Argo CD component that ships a `vpa.yaml` (controller, server, repo-server, applicationset, notifications, commit-server, dex, redis). It lets users configure a [VPA startup boost](https://cloud.google.com/kubernetes-engine/docs/how-to/boost-application-startup) for faster cold-start resource allocation, addressing the problem in #3974 where VPA-recommended resources drop so low that pods take longer to boot.

Implementation mirrors the recently merged VPA `recommenders` passthrough (#3985, closing #3984): the field is rendered only when set, via `{{- with .Values.<component>.vpa.startupBoost }}`, directly under the VPA `spec` (the location the GKE startup-boost docs use for pod-level boost). Defaults are therefore unchanged — no VPA output changes unless a user explicitly sets `startupBoost`.

Note: `startupBoost` is currently a GKE-specific extension to the VPA API, so it is documented as such in `values.yaml` (opt-in, honored only on GKE clusters, rendered only when configured).

Verification:
- `helm lint charts/argo-cd` → 0 failed
- `helm template` with `ci/vpa-values.yaml` renders `spec.startupBoost` on the controller VPA as valid YAML; components with VPA enabled but no `startupBoost` set render no `startupBoost` (no regression); default install renders zero VPAs.
- README regenerated with helm-docs v1.9.1 via `./scripts/helm-docs.sh`.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
