### PR TITLE
fix(argo-workflows): honor crds.annotations when rendering minified CRDs

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.1.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 2.0.2
+version: 2.0.3
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argo-workflows to v4.1.2
+    - kind: fixed
+      description: Honor crds.annotations when rendering minified CRDs

--- a/charts/argo-workflows/ci/aa-minimal-crds-values.yaml
+++ b/charts/argo-workflows/ci/aa-minimal-crds-values.yaml
@@ -3,3 +3,5 @@
 crds:
   full: false
   keep: false
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -211,18 +211,20 @@ Allows overriding it for multi-namespace deployments in combined charts.
 {{- end }}
 
 {{/*
-Insert annotations into the workflows CRDs: helm.sh/resource-policy (crds.keep)
-plus any custom annotations (crds.annotations, e.g. argocd.argoproj.io/sync-options)
+Set helm.sh/resource-policy (crds.keep) and crds.annotations on the workflows CRDs
 */}}
 {{- define "argo-workflows.insertCRDAnnotations" -}}
+{{- $crd := fromYaml .input -}}
+{{- if $crd.Error -}}
+  {{- fail (printf "argo-workflows: failed to parse CRD as YAML: %s" $crd.Error) -}}
+{{- end -}}
 {{- $annotations := dict -}}
 {{- if .keep -}}
   {{- $_ := set $annotations "helm.sh/resource-policy" "keep" -}}
 {{- end -}}
 {{- $annotations = merge $annotations (.annotations | default dict) -}}
-{{- $replacement := "\n  annotations: {}\n" -}}
-{{- if $annotations -}}
-  {{- $replacement = printf "\n  annotations:\n%s\n" (toYaml $annotations | indent 4) -}}
-{{- end -}}
-{{- regexReplaceAllLiteral "\n  annotations:\n    helm.sh/resource-policy: keep\n" .input $replacement -}}
+{{- $metadata := $crd.metadata | default dict -}}
+{{- $_ := set $metadata "annotations" $annotations -}}
+{{- $_ := set $crd "metadata" $metadata -}}
+{{- toYaml $crd -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/_helpers.tpl
+++ b/charts/argo-workflows/templates/_helpers.tpl
@@ -211,8 +211,18 @@ Allows overriding it for multi-namespace deployments in combined charts.
 {{- end }}
 
 {{/*
-Insert helm/resource-policy annotations into the workflows CRDs
+Insert annotations into the workflows CRDs: helm.sh/resource-policy (crds.keep)
+plus any custom annotations (crds.annotations, e.g. argocd.argoproj.io/sync-options)
 */}}
-{{- define "argo-workflows.insertResourcePolicyAnnotation" -}}
-{{- regexReplaceAllLiteral "\n  annotations:\n    helm.sh/resource-policy: keep\n" .input (ternary "\n  annotations:\n    helm.sh/resource-policy: keep\n" "\n  annotations: {}\n" .value) -}}
+{{- define "argo-workflows.insertCRDAnnotations" -}}
+{{- $annotations := dict -}}
+{{- if .keep -}}
+  {{- $_ := set $annotations "helm.sh/resource-policy" "keep" -}}
+{{- end -}}
+{{- $annotations = merge $annotations (.annotations | default dict) -}}
+{{- $replacement := "\n  annotations: {}\n" -}}
+{{- if $annotations -}}
+  {{- $replacement = printf "\n  annotations:\n%s\n" (toYaml $annotations | indent 4) -}}
+{{- end -}}
+{{- regexReplaceAllLiteral "\n  annotations:\n    helm.sh/resource-policy: keep\n" .input $replacement -}}
 {{- end -}}

--- a/charts/argo-workflows/templates/crds.yaml
+++ b/charts/argo-workflows/templates/crds.yaml
@@ -2,7 +2,7 @@
 {{- range $path, $_ :=  .Files.Glob  "files/crds/minimal/*.yaml" }}
 {{- if or (contains "clusterworkflowtemplates" $path | not) $.Values.server.clusterWorkflowTemplates.enabled $.Values.controller.clusterWorkflowTemplates.enabled }}
 ---
-{{ include "argo-workflows.insertResourcePolicyAnnotation" (dict "input" ($.Files.Get $path) "value" $.Values.crds.keep) }}
+{{ include "argo-workflows.insertCRDAnnotations" (dict "input" ($.Files.Get $path) "keep" $.Values.crds.keep "annotations" $.Values.crds.annotations) }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #4037

### Motivation

`crds.annotations` is documented in `values.yaml` ("Annotations to be added to all CRDs (only applies when crds.full=false)") but no template references it. The minified CRD path only runs the `insertResourcePolicyAnnotation` helper, a literal string replacement that toggles the hard-coded `helm.sh/resource-policy: keep` block.

Since v4.0 the minimal `workflowtasksets` CRD is no longer minimized (argoproj/argo-workflows#15175) and weighs ~646 KiB — beyond the 262,144-byte `last-applied-configuration` annotation limit of client-side apply. Users on `crds.full=false` with GitOps tooling need a per-resource escape hatch such as `argocd.argoproj.io/sync-options: ServerSideApply=true`, which is exactly what the argo-cd chart already offers through its (implemented) `crds.annotations` after #3704.

### Modifications

- Replace the `insertResourcePolicyAnnotation` helper with `insertCRDAnnotations`: builds the annotations block from `crds.keep` plus `crds.annotations` and substitutes it into the CRD files. Falls back to `annotations: {}` when both are empty, matching current behavior.
- `templates/crds.yaml` passes `crds.annotations` to the helper.
- Extend `ci/aa-minimal-crds-values.yaml` so CI exercises the new path.
- `helm.sh/resource-policy` cannot be overridden via `crds.annotations` when `crds.keep=true` (merge precedence keeps the chart-managed value).

No values schema change: the key already exists with a sensible default (`{}`).

### Verification

`helm template` matrix against the released 2.0.2 package:

| case | result |
|---|---|
| `crds.annotations` empty, `keep=true` | output byte-identical to released 2.0.2 |
| `crds.annotations` empty, `keep=false` | output byte-identical to released 2.0.2 (`annotations: {}`) |
| SSA annotation + `keep=true` | both `helm.sh/resource-policy: keep` and the custom annotation rendered on all 8 CRDs |
| SSA annotation + `keep=false` | only the custom annotation rendered |
| multiple annotations, value containing `:` | correctly quoted via `toYaml` |
| `crds.full=true` | CRDs not rendered in templates (unchanged) |

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
