### PR TITLE
fix(argo-cd): hash only config data in checksum/* annotations to avoid restarting pods on chart bump

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.6.3
+version: 10.6.4
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Mark the argocd-tls-certs-cm configMap volume as optional so pods start when configs.tls.create=false
+    - kind: changed
+      description: Hash only the data/stringData of ConfigMaps and Secrets in checksum/* pod annotations so a chart version bump alone no longer restarts all Argo CD pods. Adopting this release recomputes every checksum/* annotation once, so all Argo CD pods roll a single time on this specific upgrade; subsequent version bumps no longer roll them.

--- a/charts/argo-cd/templates/_helpers.tpl
+++ b/charts/argo-cd/templates/_helpers.tpl
@@ -271,6 +271,26 @@ Merge Argo Params Configuration with Preset Configuration
 {{- end -}}
 
 {{/*
+Return a sha256sum of only the `data` and `stringData` sections of a rendered
+ConfigMap/Secret template, for use in `checksum/*` pod annotations.
+
+Only the config payload is hashed - not the full manifest. The manifest's
+`metadata.labels` includes `helm.sh/chart`, which changes on every chart
+version bump, so hashing the whole manifest would roll all pods on every
+release even when the configuration is unchanged. Hashing only the data keeps
+a pure version bump a no-op for the pods, while any real config change still
+rolls them. Ref: https://github.com/argoproj/argo-helm/issues/3958
+
+Usage:
+  checksum/cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cm.yaml") }}
+*/}}
+{{- define "argo-cd.config.checksum" -}}
+{{- $rendered := include (print .context.Template.BasePath .path) .context | fromYaml -}}
+{{- $data := merge (dict) (dig "data" dict $rendered) (dig "stringData" dict $rendered) -}}
+{{- $data | toYaml | sha256sum -}}
+{{- end -}}
+
+{{/*
 Expand the namespace of the release.
 Allows overriding it for multi-namespace deployments in combined charts.
 */}}

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -24,9 +24,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- if .Values.configs.cm.create }}
-        checksum/cm: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cm.yaml") . | sha256sum }}
+        checksum/cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cm.yaml") }}
         {{- end }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.controller.podAnnotations) }}
         {{- range $key, $value := . }}

--- a/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
@@ -25,9 +25,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- if .Values.configs.cm.create }}
-        checksum/cm: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cm.yaml") . | sha256sum }}
+        checksum/cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cm.yaml") }}
         {{- end }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.controller.podAnnotations) }}
         {{- range $key, $value := . }}

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.applicationSet.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/argo-cd/templates/argocd-notifications/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.notifications.podAnnotations) }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -29,15 +29,15 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- if .Values.repoServer.certificateSecret.enabled }}
-        checksum/repo-server-tls: {{ include (print $.Template.BasePath "/argocd-configs/argocd-repo-server-tls-secret.yaml") . | sha256sum }}
+        checksum/repo-server-tls: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-repo-server-tls-secret.yaml") }}
         {{- end }}
         {{- if .Values.configs.cm.create }}
-        checksum/cm: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cm.yaml") . | sha256sum }}
+        checksum/cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cm.yaml") }}
         {{- end }}
         {{- if .Values.configs.cmp.create }}
-        checksum/cmp-cm: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmp-cm.yaml") . | sha256sum }}
+        checksum/cmp-cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmp-cm.yaml") }}
         {{- end }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.repoServer.podAnnotations) }}
         {{- range $key, $value := . }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -29,9 +29,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- if .Values.configs.cm.create }}
-        checksum/cm: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cm.yaml") . | sha256sum }}
+        checksum/cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cm.yaml") }}
         {{- end }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.server.podAnnotations) }}
         {{- range $key, $value := . }}

--- a/charts/argo-cd/templates/dex/deployment.yaml
+++ b/charts/argo-cd/templates/dex/deployment.yaml
@@ -28,12 +28,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cmd-params-cm.yaml") . | sha256sum }}
+        checksum/cmd-params: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cmd-params-cm.yaml") }}
         {{- if (index .Values.configs.cm "dex.config") }}
-        checksum/cm: {{ include (print $.Template.BasePath "/argocd-configs/argocd-cm.yaml") . | sha256sum }}
+        checksum/cm: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-cm.yaml") }}
         {{- end }}
         {{- if .Values.dex.certificateSecret.enabled }}
-        checksum/dex-server-tls: {{ include (print $.Template.BasePath "/argocd-configs/argocd-dex-server-tls-secret.yaml") . | sha256sum }}
+        checksum/dex-server-tls: {{ include "argo-cd.config.checksum" (dict "context" $ "path" "/argocd-configs/argocd-dex-server-tls-secret.yaml") }}
         {{- end }}
         {{- with (mergeOverwrite (deepCopy .Values.global.podAnnotations) .Values.dex.podAnnotations) }}
         {{- range $key, $value := . }}


### PR DESCRIPTION
Fixes #3958

### What this does

The `checksum/*` pod annotations (`checksum/cm`, `checksum/cmd-params`, `checksum/cmp-cm`, `checksum/repo-server-tls`, `checksum/dex-server-tls`) previously hashed the **entire rendered** ConfigMap/Secret manifest. Each manifest's `metadata.labels` is built from `argo-cd.labels`, which includes `helm.sh/chart: argo-cd-<version>`. That value changes on **every** chart version bump, so the checksums changed on every upgrade and **all** Argo CD pods were rolled even when no configuration actually changed.

This PR adds a small shared helper `argo-cd.config.checksum` that hashes only the `data`/`stringData` section of a rendered config resource, and switches all `checksum/*` annotations to use it:

```yaml
{{- define "argo-cd.config.checksum" -}}
{{- $rendered := include (print .context.Template.BasePath .path) .context | fromYaml -}}
{{- $data := merge (dict) (dig "data" dict $rendered) (dig "stringData" dict $rendered) -}}
{{- $data | toYaml | sha256sum -}}
{{- end -}}
```

Result: a pure chart version bump no longer changes any checksum (pods are not restarted), while a real change to the config `data`/`stringData` still updates the checksum and rolls the affected pods.

> **Note:** adopting this release rolls all Argo CD pods once (every `checksum/*` value changes as it switches to the data-only hash); subsequent bumps do not.

### Verification

Rendered `helm template` at `10.4.2` vs `10.4.3` (version bump only) — all checksums identical:

| annotation | 10.4.2 | 10.4.3 |
|---|---|---|
| checksum/cm | `154d089e…` | `154d089e…` |
| checksum/cmd-params | `82a74192…` | `82a74192…` |
| checksum/cmp-cm | `de56ae00…` | `de56ae00…` |
| checksum/repo-server-tls | `868858687…` | `868858687…` |
| checksum/dex-server-tls | `868858687…` | `868858687…` |

Changing a real `.data` value still moves the checksum, e.g. adding a key to `configs.cm` → `checksum/cm` `154d089e…` → `57ec2838…`, and `configs.params` → `checksum/cmd-params` `82a74192…` → `33cba314…`.

`helm lint charts/argo-cd` passes.

### Context

This is a fresh implementation of the simplified approach discussed in #3027, which was not rejected but went stale because the author could not get DCO sign-off working. All commits here are signed off. The single-helper approach (hashing only `data`/`stringData` for both ConfigMaps and Secrets) keeps one consistent technique across every annotation.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

