### PR TITLE
chore(github): escape Go template syntax in CRD sync scripts

### DIFF
--- a/scripts/update-argo-cd-crds.sh
+++ b/scripts/update-argo-cd-crds.sh
@@ -59,8 +59,10 @@ process_crd() {
 {{- if .Values.crds.install }}
 HEADER
 
-        # Remove leading "---" if present, then process the YAML
-        sed '/^---$/d' "$src_file" | awk '
+        # Remove leading "---" if present, escape Go template syntax that may
+        # appear in upstream CRD descriptions (e.g. "{{args.foo}}" examples,
+        # which Helm would otherwise try to parse), then process the YAML
+        sed '/^---$/d' "$src_file" | sed 's/{{/{{ "{{" }}/g' | awk '
         BEGIN { state = "init" }
 
         state == "init" && /^metadata:$/ {

--- a/scripts/update-argo-events-crds.sh
+++ b/scripts/update-argo-events-crds.sh
@@ -61,8 +61,10 @@ process_crd() {
 {{- if .Values.crds.install }}
 HEADER
 
-        # Remove leading "---" if present, then process the YAML
-        sed '/^---$/d' "$src_file" | awk '
+        # Remove leading "---" if present, escape Go template syntax that may
+        # appear in upstream CRD descriptions (e.g. "{{args.foo}}" examples,
+        # which Helm would otherwise try to parse), then process the YAML
+        sed '/^---$/d' "$src_file" | sed 's/{{/{{ "{{" }}/g' | awk '
         BEGIN { state = "init"; name_line = "" }
 
         # Skip auto-generated comment


### PR DESCRIPTION
## What/Why

Escape `{{` in upstream CRD content during sync in the argo-cd and argo-events CRD update scripts, so upstream field descriptions containing literal Go-template-looking examples (like the `{{args.*}}` analysis syntax argo-rollouts v1.10.0 added to its Prometheus `rangeQuery` docs) don't break `helm lint`/`helm template` when CRDs land under `templates/`. This matches the fix applied to `update-argo-rollouts-crds.sh` on the #4041 branch and the escaping `update-argocd-image-updater-crds.sh` already does. `update-argo-workflows-crds.sh` is intentionally untouched: that chart consumes CRDs via `.Files.Get`, which never hits the template parser.

## Proof it works

Round-trip verified: re-ran both patched scripts against the currently pinned upstream versions (argo-cd v3.5.2, argo-events v1.9.11) and the regenerated CRDs are byte-identical to what's committed, so the change is behavior-neutral until upstream introduces braces. The same escape pattern on the rollouts script fixed the real failure on #4041: `helm lint` passes and the rendered CRD restores the literal upstream text.

## Risk + AI role

Low: scripts-only, no chart output changes today, proven no-op by round-trip. AI-assisted (diagnosis and patch), human-reviewed.

## Review focus

Whether the simple `s/{{/{{ "{{" }}/g` escape (opening braces only) is preferred over the image-updater script's fuller `s/{{[^{}]*}}/{{`&`}}/g` pattern; both render identical output for the known cases, the simple form also covers unbalanced braces.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning) (n/a: scripts only, no chart changes)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) (n/a)
* [x] I have updated the chart changelog according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog) (n/a)
* [x] Any new values are backwards compatible and/or have sensible default. (n/a)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
