### PR TITLE
fix(argo-workflows): explain executor RBAC in install notes instead of instructing a failing submit

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.1.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 2.0.3
+version: 2.0.4
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Honor crds.annotations when rendering minified CRDs
+      description: Install notes no longer instruct submitting workflows without executor RBAC; they now explain the workflow ServiceAccount requirement and the values that create it

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -58,7 +58,14 @@ kubectl apply -k "https://github.com/argoproj/argo-workflows/manifests/base/crds
 ```
 
 ### ServiceAccount for Workflow Spec
-In order for each Workflow run, you create ServiceAccount via `values.yaml` like below.
+
+The workflow executor needs RBAC to report status back to the controller (creating and patching `workflowtaskresults.argoproj.io`). The default ServiceAccount in a namespace does not have this permission, so submitting a workflow without any setup fails with:
+
+```
+workflowtaskresults.argoproj.io is forbidden: User "system:serviceaccount:<namespace>:default" cannot create resource "workflowtaskresults"
+```
+
+To have the chart create a workflow ServiceAccount with the required RBAC in the release namespace (and any `controller.workflowNamespaces`), configure `values.yaml` like below, and submit workflows with that ServiceAccount (`argo submit --serviceaccount argo-workflow ...` or `spec.serviceAccountName`).
 
 ```yaml
 workflow:

--- a/charts/argo-workflows/README.md.gotmpl
+++ b/charts/argo-workflows/README.md.gotmpl
@@ -58,7 +58,14 @@ kubectl apply -k "https://github.com/argoproj/argo-workflows/manifests/base/crds
 ```
 
 ### ServiceAccount for Workflow Spec
-In order for each Workflow run, you create ServiceAccount via `values.yaml` like below.
+
+The workflow executor needs RBAC to report status back to the controller (creating and patching `workflowtaskresults.argoproj.io`). The default ServiceAccount in a namespace does not have this permission, so submitting a workflow without any setup fails with:
+
+```
+workflowtaskresults.argoproj.io is forbidden: User "system:serviceaccount:<namespace>:default" cannot create resource "workflowtaskresults"
+```
+
+To have the chart create a workflow ServiceAccount with the required RBAC in the release namespace (and any `controller.workflowNamespaces`), configure `values.yaml` like below, and submit workflows with that ServiceAccount (`argo submit --serviceaccount argo-workflow ...` or `spec.serviceAccountName`).
 
 ```yaml
 workflow:

--- a/charts/argo-workflows/templates/NOTES.txt
+++ b/charts/argo-workflows/templates/NOTES.txt
@@ -6,6 +6,30 @@ DEPRECATED option server.authMode - Use server.authModes
 
 kubectl --namespace {{ .Release.Namespace }} get services -o wide | grep {{ template "argo-workflows.server.fullname" . }}
 
+{{- if .Values.workflow.serviceAccount.create }}
+
 2. Submit the hello-world workflow by running:
 
-argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/hello-world.yaml --watch
+argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/hello-world.yaml --serviceaccount {{ .Values.workflow.serviceAccount.name }} --watch
+
+Note: submit in a namespace the workflow controller manages ({{ if .Values.controller.workflowNamespaces }}{{ join ", " .Values.controller.workflowNamespaces }}{{ else }}{{ .Release.Namespace }}{{ end }}), where the {{ .Values.workflow.serviceAccount.name }} ServiceAccount and its executor RBAC were created.
+{{- else }}
+
+2. Before submitting workflows, set up executor RBAC. The workflow executor
+   needs permission to create workflowtaskresults, and the default
+   ServiceAccount does not have it, so submitting without this setup fails
+   with 'workflowtaskresults.argoproj.io is forbidden'.
+
+   Either let this chart create a workflow ServiceAccount with the required
+   RBAC by upgrading with:
+
+     --set workflow.serviceAccount.create=true
+
+   and then submit with:
+
+     argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/hello-world.yaml --serviceaccount {{ .Values.workflow.serviceAccount.name }} --watch
+
+   or create a ServiceAccount with equivalent RBAC yourself in each namespace
+   where workflows run. See the "ServiceAccount for Workflow Spec" section of
+   the chart README for details.
+{{- end }}


### PR DESCRIPTION
Fixes #3592

## What/Why

The chart's post-install notes instruct every user to `argo submit` the hello-world example with the default ServiceAccount, which fails with `workflowtaskresults.argoproj.io is forbidden` on any current Argo Workflows, since the executor needs RBAC to report task results. The chart already has the knobs (`workflow.serviceAccount.create` + `workflow.rbac.create`), but nothing connected them to the scripted first-run experience, producing a year of "still an issue" reports. The notes now explain the requirement with both remedies when the workflow ServiceAccount is not chart-managed, and include `--serviceaccount` plus a managed-namespaces hint in the example when it is. The existing "ServiceAccount for Workflow Spec" README section gains the failure-mode context (exact error text) ahead of its values example.

## Proof it works

`./scripts/lint.sh` passes, and `helm lint` also passes with `workflow.serviceAccount.create=true` and multiple `controller.workflowNamespaces`, covering both NOTES branches. README regenerated via `./scripts/helm-docs.sh`. No manifest output changes; chart bumped to 2.0.4 with changelog entry.

## Risk + AI role

Low: NOTES templating and docs only. AI-assisted, author-reviewed.

## Review focus

Wording of the two NOTES branches, and the choice to point at the existing README section rather than add a new one.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog)
* [x] Any new values are backwards compatible and/or have sensible default. (n/a: no new values)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
