### PR TITLE
fix(argocd-image-updater): apply dualStack values to metrics Service

### DIFF
--- a/charts/argocd-image-updater/Chart.yaml
+++ b/charts/argocd-image-updater/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-image-updater
 description: A Helm chart for Argo CD Image Updater, a tool to automatically update the container images of Kubernetes workloads which are managed by Argo CD
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: v1.3.0
 home: https://github.com/argoproj-labs/argocd-image-updater
 icon: https://argocd-image-updater.readthedocs.io/en/stable/assets/logo.png
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump argocd-image-updater to v1.3.0
+    - kind: fixed
+      description: Apply dualStack values to the metrics Service

--- a/charts/argocd-image-updater/templates/metrics-service.yaml
+++ b/charts/argocd-image-updater/templates/metrics-service.yaml
@@ -16,6 +16,7 @@ metadata:
   name: {{ include "argocd-image-updater.fullname" . }}-metrics
   namespace: {{ include "argocd-image-updater.namespace" . | quote }}
 spec:
+  {{- include "argocd-image-updater.dualStack" . | indent 2 }}
   ports:
     - name: metrics
       protocol: TCP


### PR DESCRIPTION
### Description

The `argocd-image-updater.dualStack` helper is included only in `service.yaml` — the webhook Service, disabled by default (`service.enabled: false`). The metrics Service (`metrics-service.yaml`, created when `metrics.enabled: true`) never rendered `dualStack` values, so there was no values path to set `ipFamilies`/`ipFamilyPolicy` on it.

This adds the same include to the metrics Service, in the same position/style as `service.yaml`.

Motivation: on dual-stack clusters where IPv4 ServiceCIDR space is exhausted, operators move Services to IPv6-primary. Without this fix the metrics Service either drifts against GitOps (chart renders it family-less) or cannot be recreated at all (default IPv4 allocation fails).

Default values (`ipFamilyPolicy: ""`, `ipFamilies: []`) render nothing — verified by `helm template` diff against `main`: the only differences are the `helm.sh/chart` version label and its configmap checksum (from the chart version bump itself).

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) — no new values; existing dualStack docs unchanged
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog). — artifacthub.io/changes annotation updated
* [x] Any new values are backwards compatible and/or have sensible default. — no new values; defaults render nothing
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green.
