### PR TITLE
chore(github): move pdrastil to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @mkilchhofer @jmeridth @yu-croco @tico24
 
 /charts/argo-workflows/        @vladlosev @jmeridth @yu-croco @tico24
-/charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @pdrastil @tico24
-/charts/argo-events/           @pdrastil @jmeridth @tico24 @yu-croco
+/charts/argo-cd/               @mbevc1 @mkilchhofer @yu-croco @jmeridth @tico24
+/charts/argo-events/           @jmeridth @tico24 @yu-croco
 /charts/argo-rollouts/         @jmeridth @yu-croco @tico24

--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -12,3 +12,4 @@ We thank them for their service to the project.
 | Yann Soubeyrand | [yann-soubeyrand](https://github.com/yann-soubeyrand) |
 | David J. M. Karlsen | [davidkarlsen](https://github.com/davidkarlsen) |
 | John Behling | [jbehling](https://github.com/jbehling) |
+| Petr Drastil | [pdrastil](https://github.com/pdrastil) |


### PR DESCRIPTION
## What/Why

Moves Petr Drastil ([pdrastil](https://github.com/pdrastil)) to EMERITUS.md and removes him from the argo-cd and argo-events CODEOWNERS entries, so review requests stop routing to an inactive approver. Petr's fingerprints are all over this chart's history — the redis-secret-init design, years of argo-cd/argo-events stewardship, and review standards this repo still runs on. Thank you @pdrastil for everything. ❤️

## Proof it works

Zero `pdrastil` references remain in CODEOWNERS; one row added to EMERITUS.md matching the existing table format.

## Risk + AI role

Low: governance files only. AI-assisted, maintainer-directed.

## Review focus

Fellow maintainers (@mkilchhofer @tico24 @yu-croco @mbevc1 @vladlosev): confirmation this transition is agreed. Org-level permissions (GitHub team membership) need a separate settings change once this merges.
