### PR TITLE
fix(argo-cd): bump redis-ha Redis image to patched OpenSSL base

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.7.0
+version: 10.7.1
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: added
-      description: Support specifying a VPA startup boost via <component>.vpa.startupBoost for all components
+    - kind: security
+      description: Bump the redis-ha Redis image to 8.6.4-alpine so it no longer ships an OpenSSL version affected by the RSASVE uninitialized-memory issue (reported by m98anu)

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1782,7 +1782,7 @@ The main options are listed here:
 | redis-ha.haproxy.tolerations | list | `[]` | [Tolerations] for use with node taints for haproxy pods. |
 | redis-ha.hardAntiAffinity | bool | `true` | Whether the Redis server pods should be forced to run on separate nodes. |
 | redis-ha.image.repository | string | `"ecr-public.aws.com/docker/library/redis"` | Redis repository |
-| redis-ha.image.tag | string | `"8.2.3-alpine"` | Redis tag |
+| redis-ha.image.tag | string | `"8.6.4-alpine"` | Redis tag |
 | redis-ha.persistentVolume.enabled | bool | `false` | Configures persistence on Redis nodes |
 | redis-ha.redis.config | object | See [values.yaml] | Any valid redis config options in this section will be applied to each server (see `redis-ha` chart) |
 | redis-ha.redis.config.save | string | `'""'` | Will save the DB if both the given number of seconds and the given number of write operations against the DB occurred. `""`  is disabled |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1889,8 +1889,10 @@ redis-ha:
     # -- Redis repository
     repository: ecr-public.aws.com/docker/library/redis
     # -- Redis tag
-    ## Do not upgrade to >= 7.4.0, otherwise you are no longer using an open source version of Redis
-    tag: 8.2.3-alpine
+    ## Do not use 7.4.0 <= v < 8.0.0, otherwise you are no longer using an open source version of Redis
+    ## Runs ahead of the upstream HA manifests' pin: the redis 8.2.x line is only built on Alpine 3.22,
+    ## whose OpenSSL carries known vulnerabilities (GHSA-5p3w-hgjv-f6q3 report); 8.6.x is the patched base.
+    tag: 8.6.4-alpine
   ## Prometheus redis-exporter sidecar
   exporter:
     # -- Enable Prometheus redis-exporter sidecar


### PR DESCRIPTION
## What/Why

Fixes the draft advisory GHSA-5p3w-hgjv-f6q3 (thanks @m98anu): the redis-ha pods shipped `redis:8.2.3-alpine`, whose OpenSSL 3.5.5-r0 is affected by the RSASVE/`EVP_PKEY_encapsulate` uninitialized-memory issue. The 8.2.x image line is only built on Alpine 3.22 with no patched variant (`8.2.4-alpine3.23` does not exist), so staying on upstream's HA pin cannot be patched; this bumps redis-ha to `8.6.4-alpine` (Alpine 3.23, patched OpenSSL), aligning it with the standalone Redis image the chart already ships. The values comment documents the deliberate divergence from upstream's pin, and the stale pre-Redis-8 license warning on that value is corrected.

## Proof it works

`./scripts/lint.sh` passes and `helm template` with `redis-ha.enabled=true` renders `8.6.4-alpine` for the HA server and sentinel containers. Reachability note: redis's OpenSSL use is TLS and does not exercise RSASVE KEM encapsulation, so this is scanner-severity rather than deployment-reachable, but the vulnerable package is removed regardless.

## Risk + AI role

Medium: runs HA Redis four minors past what upstream argo-cd pins and tests. The redis-ha chart supports 8.x and CI installs the HA path. AI-assisted, maintainer-directed.

## Review focus

@mkilchhofer per the Slack thread: comfort with redis-ha running ahead of upstream's 8.2 pin (there is no patched 8.2 alternative), and whether to also fold in a renovate.json fix for the stale `allowedVersions: "< 7.4"` redis constraint that has been silently blocking these security rebumps (I have it as a separate follow-up PR otherwise).

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog)
* [x] Any new values are backwards compatible and/or have sensible default. (n/a: no new values)
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
