### PR TITLE
chore(github): let renovate bump Redis 8.x images again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -105,8 +105,8 @@
       "matchDatasources": [
         "docker"
       ],
-      "allowedVersions": "< 7.4",
-      "description": ["With version 7.4, Redis is moving away from the BSD 3-Clause License"],
+      "allowedVersions": "<7.4.0 || >=8.0.0",
+      "description": ["Redis 7.4.x is not open source (RSAL/SSPL); Redis 8.0+ restored an OSI-approved option (AGPLv3), so only the 7.4-7.x line is excluded"],
       "commitMessagePrefix": "chore({{parentDir}}):",
       "postUpgradeTasks": {
         "commands": [


### PR DESCRIPTION
Relates to #4057

## What/Why

The redis image rule in `renovate.json` still pinned `allowedVersions: "< 7.4"` from the 2024 license change, even though the chart has shipped Redis 8.x for some time (Redis 8.0+ restored an OSI-approved AGPLv3 option). The stale constraint silently blocked Renovate from proposing 8.x security rebuilds, which is how the redis-ha image sat on an OpenSSL-vulnerable `8.2.3-alpine` until draft advisory GHSA-5p3w-hgjv-f6q3 flagged it (fixed manually in #4057). This admits `<7.4.0 || >=8.0.0`, excluding only the non-open-source 7.4-7.x line, and corrects the rule description.

## Proof it works

`renovate.json` parses as valid JSON; the range excludes exactly 7.4.0-7.x and admits the 8.x line the chart already ships. Future OpenSSL-class rebuilds arrive as normal Renovate PRs instead of requiring a security report to notice.

## Risk + AI role

Low: tooling config only; Renovate proposals remain reviewable PRs. AI-assisted, maintainer-directed.

## Review focus

Renovate `allowedVersions` semantics for docker versioning: confirm the `||` range form is honored (vs needing the regex `/.../ ` form).
