### PR TITLE
feat(argo-workflows): render controller.metricsConfig.temporality in ConfigMap

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.1.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 2.0.3
+version: 2.1.0
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -16,5 +16,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Honor crds.annotations when rendering minified CRDs
+    - kind: added
+      description: Add controller.metricsConfig.temporality for OTLP metric temporality

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -345,6 +345,7 @@ Fields to note:
 | controller.metricsConfig.servicePort | int | `8080` | Service metrics port |
 | controller.metricsConfig.servicePortName | string | `"metrics"` | Service metrics port name |
 | controller.metricsConfig.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
+| controller.metricsConfig.temporality | string | `""` | Temporality of the metrics, e.g. "Delta" or "Cumulative". Only used for OTLP push-based metrics. |
 | controller.name | string | `"workflow-controller"` | Workflow controller name string |
 | controller.namespaceParallelism | string | `nil` | Limits the maximum number of incomplete workflows in a namespace |
 | controller.navColor | string | `""` | Set ui navigation bar background color |

--- a/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-config-map.yaml
@@ -135,6 +135,9 @@ data:
       modifiers:
         {{- toYaml . | nindent 8 }} 
       {{- end }}  
+      {{- with .Values.controller.metricsConfig.temporality }}
+      temporality: {{ . }}
+      {{- end }}
     {{- end }}
     {{- if .Values.controller.telemetryConfig.enabled }}
     telemetryConfig:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -211,6 +211,9 @@ controller:
     # -- Manipulate the metrics created by the workflow controller
     ## Ref: https://argo-workflows.readthedocs.io/en/latest/metrics/#modifiers
     modifiers: {}
+    # -- Temporality of the metrics, e.g. "Delta" or "Cumulative". Only used for OTLP push-based metrics.
+    ## Ref: https://argo-workflows.readthedocs.io/en/latest/metrics/
+    temporality: ""
 
   # -- the controller container's securityContext
   securityContext:


### PR DESCRIPTION
## Summary

Adds support for `controller.metricsConfig.temporality` so it is rendered into `templates/controller/workflow-controller-config-map.yaml`. Previously this value was silently ignored, preventing users from configuring OTLP metric temporality (for example, `Delta` vs `Cumulative`) via chart values.

## Changes
- `values.yaml`: added `controller.metricsConfig.temporality` with an unset default
- `workflow-controller-config-map.yaml`: render `temporality` under `metricsConfig` only when set
- `README.md`: added the corresponding documentation row
- `Chart.yaml`: bumped chart version from 2.0.3 to 2.1.0 and added the Artifact Hub changelog entry

## Validation
- `helm lint charts/argo-workflows`
- `helm template` verified `temporality` is omitted by default and rendered correctly when set

## Checklist

- [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
- [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
- [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
- [x] Any new values are backwards compatible and/or have sensible default.
- [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
- [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Fixes #4059