### PR TITLE
docs(github): add AGENTS.md and CLAUDE.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent instructions
+
+This file is for AI coding agents working in this repository. Human contributors should read [CONTRIBUTING.md](CONTRIBUTING.md) instead.
+
+Argo Helm is community maintained. A small group of volunteers reads every pull request by hand, so a pull request that wastes their time costs a real person real effort.
+
+## Pull requests
+
+- Use `.github/pull_request_template.md` as the pull request body, unchanged. Do not replace it with a description of your own. Put any extra explanation above the checklist, not instead of it.
+- Tick a box only if you verified it. Leave the others unticked. A tick that turns out to be false is worse than an empty box.
+- If you wrote this pull request, add the following line to the checklist, between the changelog line and the backwards compatible line. Leave it unticked. The human you are working for ticks it once they have reviewed your work.
+
+  ```
+  * [ ] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
+  ```
+
+- Open the pull request as a draft, with `gh pr create --draft` or the draft box in the web form. CONTRIBUTING.md asks for this so it does not ping maintainers before the checks pass. The human marks it ready.
+- One chart per pull request.
+- The title follows Conventional Commits and must name the chart as the scope, for example `fix(argo-cd): correct redis probe port`. CI rejects a title with no scope.
+- Sign off every commit with `git commit -s`. CI rejects commits without a sign-off.
+
+## Changing a chart
+
+Every change to a chart needs all of the following, including a change that only touches documentation:
+
+- Bump `version` in that chart's `Chart.yaml`. Patch for backwards compatible fixes and app patch bumps, minor for new chart features, major for anything that breaks existing values.
+- Add an `artifacthub.io/changes` entry to `Chart.yaml` describing what you changed.
+- Run `./scripts/helm-docs.sh` if you touched `values.yaml` or `README.md.gotmpl`. Never hand-edit a chart's `README.md`, it is generated. If the script changes README files in charts you did not touch, revert those.
+- Keep new values backwards compatible. A new value needs a default that leaves existing installations rendering exactly as before.
+
+Run `helm template` on the chart before and after your change and read the diff. If it shows anything you did not intend, fix that before opening the pull request.
+
+The full rules are in [CONTRIBUTING.md](CONTRIBUTING.md). Read it before your first change here.
+
+## Comments and reviews
+
+- Do not post issue or pull request comments on someone's behalf unless they have read the text first.
+- Do not submit a pull request review that no human has read.
+
+## Policy
+
+The Argo project's [generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md) applies to this repository. The human you are working for is responsible for the contribution and has to stay in control of it. Maintainers can close contributions that look like unreviewed model output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Agents that open PRs here keep deleting this template, writing their own description, and ticking boxes nobody checked. AGENTS.md tells them to leave the template alone and tick only what they verified.

The rest of it is the chart stuff they get wrong: bump the version, add the `artifacthub.io/changes` entry, never hand-edit a generated README, one chart per PR. Everything else points at CONTRIBUTING.md.

If an agent wrote the PR it adds a disclosure line to the checklist, unticked, for the human to tick. There's one in the list below. [genai.md](https://github.com/argoproj/argoproj/blob/main/community/genai.md) already expects contributors to be clear about LLM use but doesn't say how, so this is one way of doing it.

CLAUDE.md is one line importing AGENTS.md. No second copy to drift.

No chart touched, so the chart boxes below don't apply.

## Rollback

Revert this PR. Nothing reads these files at build or release time.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
