### PR TITLE
docs(github): tell agents to lint locally before opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Every change to a chart needs all of the following, including a change that only
 
 Run `helm template` on the chart before and after your change and read the diff. If it shows anything you did not intend, fix that before opening the pull request.
 
+Run `./scripts/lint.sh` before you open the pull request. It takes no arguments and runs chart-testing in Docker over the charts you changed, the same lint CI runs, so it is what catches a missing version bump. Run `./scripts/lint-changelog.sh` too. That one needs only bash and checks that `artifacthub.io/changes` holds exactly one entry. Both are quicker than waiting for CI to fail.
+
 The full rules are in [CONTRIBUTING.md](CONTRIBUTING.md). Read it before your first change here.
 
 ## Comments and reviews


### PR DESCRIPTION
Follow-up to #4062, for the addition @jmeridth asked for in his review: tell agents to run the lint scripts locally before opening the PR.

Two things I changed from the suggested wording:

- `./scripts/lint.sh` takes no chart argument. It runs `ct lint`, which diffs against `origin/main` and works out the changed charts itself, and an extra argument is silently ignored. The line says so, otherwise an agent passes a chart name and believes it linted only that chart.
- `lint.sh` does not look at the changelog. That is `scripts/lint-changelog.sh` locally and `ah lint` in CI, so the line names the changelog script too. It needs only bash, no Docker, which makes it the cheap half of the pair.

Ran both on this branch. `lint-changelog.sh` passes, and `lint.sh` prints "No chart changes detected", which is right for a docs-only change.

No chart touched, so the chart boxes below don't apply.

## Rollback

Revert this PR. Nothing reads this file at build or release time.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
* [ ] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
