### PR TITLE
feat(argo-events): add initContainers and extraContainers to webhook

### DIFF
--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.9.11
 description: A Helm chart for Argo Events, the event-driven workflow automation framework
 name: argo-events
-version: 2.4.26
+version: 2.4.27
 home: https://github.com/argoproj/argo-helm
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: added
-      description: Document EventBus creation via extraObjects in the chart README
+      description: Add initContainers and extraContainers to the admission webhook

--- a/charts/argo-events/README.md
+++ b/charts/argo-events/README.md
@@ -240,9 +240,11 @@ done
 | webhook.enabled | bool | `false` | Enable admission webhook. Applies only for cluster-wide installation |
 | webhook.env | list | `[]` (See [values.yaml]) | Environment variables to pass to event controller |
 | webhook.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to event controller |
+| webhook.extraContainers | list | `[]` | Additional containers to be added to the admission webhook pods |
 | webhook.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the event controller |
 | webhook.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the event controller |
 | webhook.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the event controller |
+| webhook.initContainers | list | `[]` | Init containers to add to the admission webhook pods |
 | webhook.livenessProbe.failureThreshold | int | `3` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | webhook.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds after the container has started before [probe] is initiated |
 | webhook.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the [probe] |

--- a/charts/argo-events/templates/argo-events-webhook/deployment.yaml
+++ b/charts/argo-events/templates/argo-events-webhook/deployment.yaml
@@ -95,6 +95,13 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with .Values.webhook.extraContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end -}}
+      {{- with .Values.webhook.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/argo-events/values.yaml
+++ b/charts/argo-events/values.yaml
@@ -483,6 +483,12 @@ webhook:
   #    cpu: 250m
   #    memory: 256Mi
 
+  # -- Additional containers to be added to the admission webhook pods
+  extraContainers: []
+
+  # -- Init containers to add to the admission webhook pods
+  initContainers: []
+
   serviceAccount:
     # -- Create a service account for the admission webhook
     create: true


### PR DESCRIPTION
The events controller accepts `controller.initContainers` and `controller.extraContainers`, but the admission webhook deployment has no equivalent, so `webhook.initContainers` / `webhook.extraContainers` were silently ignored. This adds both values to the webhook deployment using the same blocks the controller template uses.

Closes #4066

Both values default to `[]`. `helm template` output with default values and with `webhook.enabled=true` is byte for byte identical before and after this change.

Tested on a kind cluster with an init container and a sidecar set on the webhook: the pod comes up `2/2 Running`, the init container reports `Completed`.

<img width="1882" height="960" alt="image" src="https://github.com/user-attachments/assets/5f4832b9-8f87-4927-8d5c-cc0786715810" />


<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->

