### PR TITLE
fix(argo-cd): set EXTENSIONS_DIR so extensions install to the served path

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.8.2
+version: 10.8.3
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis_exporter to v1.91.0
+    - kind: fixed
+      description: Set EXTENSIONS_DIR on the extension installer so server.extensions install to the path argocd-server serves them from

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -489,10 +489,6 @@ spec:
           - name: tmp
             mountPath: /tmp
         env:
-          {{- /* The shared extensions volume is mounted at /tmp/extensions and argocd-server
-          discovers extensions directly under it, while the installer image's built-in default
-          target is /tmp/extensions/resources. Entries in .env render after this and take
-          precedence if an extension sets its own EXTENSIONS_DIR. */}}
           - name: EXTENSIONS_DIR
             value: /tmp/extensions
           {{- with .env }}

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -489,7 +489,15 @@ spec:
           - name: tmp
             mountPath: /tmp
         env:
-          {{- toYaml .env | nindent 10 }}
+          {{- /* The shared extensions volume is mounted at /tmp/extensions and argocd-server
+          discovers extensions directly under it, while the installer image's built-in default
+          target is /tmp/extensions/resources. Entries in .env render after this and take
+          precedence if an extension sets its own EXTENSIONS_DIR. */}}
+          - name: EXTENSIONS_DIR
+            value: /tmp/extensions
+          {{- with .env }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- end }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
Closes #3320

## What/Why

`server.extensions` mounted the shared volume at `/tmp/extensions` (where argocd-server discovers extensions) while the installer image copies into `/tmp/extensions/resources` by default, so installed extensions never loaded in the UI. Upstream made the target configurable via `EXTENSIONS_DIR` (argoproj-labs/argocd-extension-installer#14, thanks @Sturgelose, shipped in the v1.1.0 image the chart pins since #4064), and its documentation prescribes `/tmp/extensions` for this chart's wiring. This sets that env on every extension init container. Entries from each extension's `.env` render after it and take precedence, and the `.env` block is now `with`-guarded so env-less extensions render validly.

## Proof it works

`helm template` with an `extensionList` entry renders `EXTENSIONS_DIR` before the extension's own env, nothing leaks into output from the template comment, and `./scripts/lint.sh` passes. Older pinned installer images ignore the unknown variable, so pinning `v1.0.1` keeps exactly today's behavior.

## Risk + AI role

Low: only the opt-in extensions init container's rendered env changes. AI-assisted, maintainer-directed.

## Review focus

@Sturgelose confirmation welcome that `/tmp/extensions` is the served path per your upstream docs table, since you authored both the report and the fix.

---

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation) (n/a: no values changes)
* [x] I have updated the chart changelog according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog)
* [x] Any new values are backwards compatible and/or have sensible default. (n/a: no new values)
* [x] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).
