### PR TITLE
fix(argo-workflows): derive ServiceMonitor scheme from metricsConfig.secure

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v4.1.2
 name: argo-workflows
 description: A Helm chart for Argo Workflows
 type: application
-version: 2.0.4
+version: 2.0.5
 icon: https://argo-workflows.readthedocs.io/en/stable/assets/logo.png
 home: https://github.com/argoproj/argo-helm
 sources:
@@ -17,4 +17,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Install notes no longer instruct submitting workflows without executor RBAC; they now explain the workflow ServiceAccount requirement and the values that create it
+      description: ServiceMonitor scheme is derived from metricsConfig.secure / telemetryConfig.secure when not set explicitly, adding tlsConfig.insecureSkipVerify for HTTPS metrics

--- a/charts/argo-workflows/README.md
+++ b/charts/argo-workflows/README.md
@@ -347,7 +347,7 @@ Fields to note:
 | controller.metricsConfig.port | int | `9090` | Port is the port where metrics are emitted |
 | controller.metricsConfig.portName | string | `"metrics"` | Container metrics port name |
 | controller.metricsConfig.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping |
-| controller.metricsConfig.scheme | string | `"http"` | serviceMonitor scheme |
+| controller.metricsConfig.scheme | string | `""` | ServiceMonitor scheme. Leave empty to derive from `secure` flag. |
 | controller.metricsConfig.secure | bool | `false` | Flag that use a self-signed cert for TLS |
 | controller.metricsConfig.servicePort | int | `8080` | Service metrics port |
 | controller.metricsConfig.servicePortName | string | `"metrics"` | Service metrics port name |
@@ -394,7 +394,7 @@ Fields to note:
 | controller.telemetryConfig.metricsTTL | string | `""` | How often custom metrics are cleared from memory |
 | controller.telemetryConfig.path | string | `"/telemetry"` | telemetry path |
 | controller.telemetryConfig.port | int | `8081` | telemetry container port |
-| controller.telemetryConfig.scheme | string | `"http"` | telemetry serviceMonitor scheme to use |
+| controller.telemetryConfig.scheme | string | `""` | telemetry serviceMonitor scheme to use. Leave empty to derive from `secure` flag. |
 | controller.telemetryConfig.secure | bool | `false` | Flag that use a self-signed cert for TLS |
 | controller.telemetryConfig.servicePort | int | `8081` | telemetry service port |
 | controller.telemetryConfig.servicePortName | string | `"telemetry"` | telemetry service port name |

--- a/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
+++ b/charts/argo-workflows/templates/controller/workflow-controller-servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- $apiVersion := include "argo-workflows.apiVersions.monitoring" . }}
+{{- $metricsScheme := .Values.controller.metricsConfig.scheme | default (ternary "https" "http" .Values.controller.metricsConfig.secure) }}
 {{- if and (.Capabilities.APIVersions.Has $apiVersion) (or .Values.controller.metricsConfig.enabled .Values.controller.telemetryConfig.enabled) .Values.controller.serviceMonitor.enabled }}
 apiVersion: {{ $apiVersion }}
 kind: ServiceMonitor
@@ -25,7 +26,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       honorLabels: {{ .Values.controller.metricsConfig.honorLabels }}
-      scheme: {{ .Values.controller.metricsConfig.scheme}}
+      scheme: {{ $metricsScheme }}
+      {{- if and (eq $metricsScheme "https") (not .Values.controller.metricsConfig.tlsConfig) }}
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- end }}
   {{- end }}
   {{- if .Values.controller.telemetryConfig.enabled }}
     - port: telemetry
@@ -40,7 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       honorLabels: {{ .Values.controller.metricsConfig.honorLabels }}
-      scheme: {{ .Values.controller.telemetryConfig.scheme }}
+      scheme: {{ .Values.controller.telemetryConfig.scheme | default (ternary "https" "http" .Values.controller.telemetryConfig.secure) }}
   {{- end }}
   {{- with .Values.controller.metricsConfig.targetLabels }}
   targetLabels:

--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -192,8 +192,8 @@ controller:
     servicePort: 8080
     # -- Service metrics port name
     servicePortName: metrics
-    # -- serviceMonitor scheme
-    scheme: http
+    # -- ServiceMonitor scheme. Leave empty to derive from `secure` flag.
+    scheme: ""
     # -- Flag to enable headless service
     headlessService: false
     # -- When true, honorLabels preserves the metric’s labels when they collide with the target’s labels.
@@ -315,8 +315,8 @@ controller:
     servicePort: 8081
     # -- telemetry service port name
     servicePortName: telemetry
-    # -- telemetry serviceMonitor scheme to use
-    scheme: http
+    # -- telemetry serviceMonitor scheme to use. Leave empty to derive from `secure` flag.
+    scheme: ""
   serviceMonitor:
     # -- Enable a prometheus ServiceMonitor
     enabled: false


### PR DESCRIPTION
With `controller.metricsConfig.secure: true` the workflow-controller serves `/metrics` over HTTPS with a self-signed certificate, but the ServiceMonitor still renders `scheme: http` (the values default), so Prometheus fails the TLS handshake and never scrapes the controller.

Fix: `controller.metricsConfig.scheme` and `controller.telemetryConfig.scheme` now default to `""` and the template derives `https`/`http` from the matching `secure` flag; an explicit `scheme` value still wins. When the derived metrics scheme is `https` and no `metricsConfig.tlsConfig` is set, the endpoint gets `tlsConfig.insecureSkipVerify: true` for the self-signed certificate. Default values render exactly as before (`helm template` output is byte-identical to `main`).

<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
