### PR TITLE
feat(argo-cd): support unhealthyPodEvictionPolicy on PDBs

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.8.4
+version: 10.9.0
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -26,5 +26,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump redis_exporter to v1.91.1
+    - kind: added
+      description: Support setting unhealthyPodEvictionPolicy on all PodDisruptionBudgets

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1153,6 +1153,7 @@ NAME: my-release
 | controller.pdb.labels | object | `{}` | Labels to be added to application controller pdb |
 | controller.pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). |
 | controller.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| controller.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | controller.podAnnotations | object | `{}` | Annotations to be added to application controller pods |
 | controller.podLabels | object | `{}` | Labels to be added to application controller pods |
 | controller.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the application controller pods |
@@ -1272,6 +1273,7 @@ NAME: my-release
 | repoServer.pdb.labels | object | `{}` | Labels to be added to repo server pdb |
 | repoServer.pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). |
 | repoServer.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| repoServer.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | repoServer.podAnnotations | object | `{}` | Annotations to be added to repo server pods |
 | repoServer.podLabels | object | `{}` | Labels to be added to repo server pods |
 | repoServer.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the repo server pods |
@@ -1476,6 +1478,7 @@ NAME: my-release
 | server.pdb.labels | object | `{}` | Labels to be added to Argo CD server pdb |
 | server.pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). |
 | server.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| server.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | server.podAnnotations | object | `{}` | Annotations to be added to server pods |
 | server.podLabels | object | `{}` | Labels to be added to server pods |
 | server.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the Argo CD server pods |
@@ -1607,6 +1610,7 @@ NAME: my-release
 | dex.pdb.labels | object | `{}` | Labels to be added to Dex server pdb |
 | dex.pdb.maxUnavailable | string | `""` | Number of pods that are unavailble after eviction as number or percentage (eg.: 50%). |
 | dex.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| dex.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | dex.podAnnotations | object | `{}` | Annotations to be added to the Dex server pods |
 | dex.podLabels | object | `{}` | Labels to be added to the Dex server pods |
 | dex.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the dex pods |
@@ -1729,6 +1733,7 @@ NAME: my-release
 | redis.pdb.labels | object | `{}` | Labels to be added to Redis pdb |
 | redis.pdb.maxUnavailable | string | `""` | Number of pods that are unavailble after eviction as number or percentage (eg.: 50%). |
 | redis.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| redis.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | redis.podAnnotations | object | `{}` | Annotations to be added to the Redis server pods |
 | redis.podLabels | object | `{}` | Labels to be added to the Redis server pods |
 | redis.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for redis pods |
@@ -1959,6 +1964,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.pdb.labels | object | `{}` | Labels to be added to ApplicationSet controller pdb |
 | applicationSet.pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). |
 | applicationSet.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| applicationSet.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | applicationSet.podAnnotations | object | `{}` | Annotations for the ApplicationSet controller pods |
 | applicationSet.podLabels | object | `{}` | Labels for the ApplicationSet controller pods |
 | applicationSet.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the ApplicationSet controller pods |
@@ -2058,6 +2064,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | notifications.pdb.labels | object | `{}` | Labels to be added to notifications controller pdb |
 | notifications.pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). |
 | notifications.pdb.minAvailable | string | `""` (defaults to 0 if not specified) | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
+| notifications.pdb.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow` |
 | notifications.podAnnotations | object | `{}` | Annotations to be applied to the notifications controller Pods |
 | notifications.podLabels | object | `{}` | Labels to be applied to the notifications controller Pods |
 | notifications.priorityClassName | string | `""` (defaults to global.priorityClassName) | Priority class for the notifications controller pods |

--- a/charts/argo-cd/templates/argocd-application-controller/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/pdb.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.controller.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.controller.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.controller.name) | nindent 6 }}

--- a/charts/argo-cd/templates/argocd-applicationset/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/pdb.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.applicationSet.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.applicationSet.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.applicationSet.name) | nindent 6 }}

--- a/charts/argo-cd/templates/argocd-notifications/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-notifications/pdb.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.notifications.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.notifications.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.notifications.name) | nindent 6 }}

--- a/charts/argo-cd/templates/argocd-repo-server/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/pdb.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.repoServer.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.repoServer.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.repoServer.name) | nindent 6 }}

--- a/charts/argo-cd/templates/argocd-server/pdb.yaml
+++ b/charts/argo-cd/templates/argocd-server/pdb.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.server.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.server.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.server.name) | nindent 6 }}

--- a/charts/argo-cd/templates/dex/pdb.yaml
+++ b/charts/argo-cd/templates/dex/pdb.yaml
@@ -21,6 +21,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.dex.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.dex.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "argo-cd.selectorLabels" (dict "context" . "name" .Values.dex.name) | nindent 6 }}

--- a/charts/argo-cd/templates/redis/pdb.yaml
+++ b/charts/argo-cd/templates/redis/pdb.yaml
@@ -22,6 +22,9 @@ spec:
   {{- else }}
   minAvailable: {{ .Values.redis.pdb.minAvailable | default 0 }}
   {{- end }}
+  {{- with .Values.redis.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "argo-cd.name" . }}-{{ .Values.redis.name }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -809,6 +809,9 @@ controller:
     # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `controller.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## Application controller Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/
@@ -1239,6 +1242,9 @@ dex:
     # -- Number of pods that are unavailble after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `dex.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## Dex Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/
@@ -1571,6 +1577,9 @@ redis:
     # -- Number of pods that are unavailble after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `redis.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## Redis Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/
@@ -2179,6 +2188,9 @@ server:
     # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `server.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## Argo CD server Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/
@@ -3098,6 +3110,9 @@ repoServer:
     # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `repoServer.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## Repo server Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/
@@ -3547,6 +3562,9 @@ applicationSet:
     # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `applicationSet.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## ApplicationSet controller Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/
@@ -4076,6 +4094,9 @@ notifications:
     # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%).
     ## Has higher precedence over `notifications.pdb.minAvailable`
     maxUnavailable: ""
+    # -- Policy for evicting unhealthy (not ready) pods, either `IfHealthyBudget` or `AlwaysAllow`
+    ## Defaults to `IfHealthyBudget` if not set
+    unhealthyPodEvictionPolicy: ""
 
   ## Notifications controller Vertical Pod Autoscaler
   ## Ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/#scaling-workloads-vertically/


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Adds `pdb.unhealthyPodEvictionPolicy` to all seven PodDisruptionBudgets in the argo-cd chart (application controller, server, repo server, applicationset, notifications, dex, redis), passed through to the rendered PDB. Unset by default, so existing installations render exactly as before — verified that `helm template` output with default values differs from `main` only by the chart version label.

Setting it to `AlwaysAllow` lets a not-Ready replica be evicted during a node drain instead of blocking it, per the [Kubernetes drain recommendation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#pdb-unhealthy-pod-eviction-policy). Without it, a single crash-looping replica takes `disruptionsAllowed` to 0 and wedges a node drain indefinitely, even though the pod is Not Ready and serving nothing.

Companion to #4073, which does the same for the argo-workflows chart (kept separate per the one-chart-per-PR rule).

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] I wrote this PR with the help of a LLM but I fully vetted the work before raising this PR for review
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
