### PR TITLE
fix(argo-cd): disable gRPC DNS TXT lookups for localhost and IP literals

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v3.5.2
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 10.8.4
+version: 10.8.5
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Bump redis_exporter to v1.91.1
+    - kind: added
+      description: Add reposerver.grpc.enable.txt.service.config to disable gRPC DNS TXT lookups by default

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1104,6 +1104,7 @@ NAME: my-release
 | controller.envFrom | list | `[]` (See [values.yaml]) | envFrom to pass to application controller |
 | controller.extraArgs | list | `[]` | Additional command line arguments to pass to application controller |
 | controller.extraContainers | list | `[]` | Additional containers to be added to the application controller pod |
+| controller.grpc | object | `false` | GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991) |
 | controller.heartbeatTime | int | `10` | Application controller heartbeat time Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/dynamic-cluster-distribution/#working-of-dynamic-distribution |
 | controller.hostNetwork | bool | `false` | Host Network for application controller pods |
 | controller.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the application controller |
@@ -1231,6 +1232,7 @@ NAME: my-release
 | repoServer.existingVolumes | object | `{}` | Volumes to be used in replacement of emptydir on default volumes |
 | repoServer.extraArgs | list | `[]` | Additional command line arguments to pass to repo server |
 | repoServer.extraContainers | list | `[]` | Additional containers to be added to the repo server pod |
+| repoServer.grpc | object | `false` | GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991) |
 | repoServer.hostNetwork | bool | `false` | Host Network for Repo server pods |
 | repoServer.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the repo server |
 | repoServer.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the repo server |
@@ -1889,6 +1891,7 @@ If you use an External Redis (See Option 3 above), this Job is not deployed.
 | applicationSet.extraEnvFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the ApplicationSet controller |
 | applicationSet.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | applicationSet.extraVolumes | list | `[]` | List of extra volumes to add |
+| applicationSet.grpc | object | `false` | GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991) |
 | applicationSet.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
 | applicationSet.httproute.enabled | bool | `false` | Enable HTTPRoute resource for Argo CD Applicationset Webhook (Gateway API) |
 | applicationSet.httproute.hostnames | list | `[]` (See [values.yaml]) | List of hostnames for the HTTPRoute |
@@ -2121,6 +2124,7 @@ To read more about this component, please read [Argo CD Manifest Hydrator] and [
 | commitServer.extraEnvFrom | list | `[]` (See [values.yaml]) | envFrom to pass to the commit server |
 | commitServer.extraVolumeMounts | list | `[]` | List of extra mounts to add (normally used with extraVolumes) |
 | commitServer.extraVolumes | list | `[]` | List of extra volumes to add |
+| commitServer.grpc | object | `false` | GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991) |
 | commitServer.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Image pull policy for the commit server |
 | commitServer.image.repository | string | `""` (defaults to global.image.repository) | Repository to use for the commit server |
 | commitServer.image.tag | string | `""` (defaults to global.image.tag) | Tag to use for the commit server |

--- a/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-application-controller/deployment.yaml
@@ -106,6 +106,12 @@ spec:
                 key: timeout.reconciliation.jitter
                 name: argocd-cm
                 optional: true
+          - name: GRPC_ENABLE_TXT_SERVICE_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: controller.grpc.enable.txt.service.config
+                optional: true
           - name: ARGOCD_REPO_ERROR_GRACE_PERIOD_SECONDS
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -94,6 +94,12 @@ spec:
                   key: applicationsetcontroller.global.preserved.labels
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: GRPC_ENABLE_TXT_SERVICE_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: argocd-cmd-params-cm
+                  key: applicationsetcontroller.grpc.enable.txt.service.config
+                  optional: true
             - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_LEADER_ELECTION
               valueFrom:
                 configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-commit-server/deployment.yaml
@@ -86,6 +86,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: commitserver.metrics.listen.address
                 optional: true
+          - name: GRPC_ENABLE_TXT_SERVICE_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: commitserver.grpc.enable.txt.service.config
+                optional: true
           - name: ARGOCD_COMMIT_SERVER_LOGFORMAT
             valueFrom:
               configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-configs/argocd-cmd-params-cm.yaml
+++ b/charts/argo-cd/templates/argocd-configs/argocd-cmd-params-cm.yaml
@@ -14,4 +14,8 @@ metadata:
   {{- end }}
 data:
   {{- include "argo-cd.config.params" . | trim | nindent 2 }}
+  reposerver.grpc.enable.txt.service.config: {{ .Values.repoServer.grpc.enableTxtServiceConfig | quote }}
+  controller.grpc.enable.txt.service.config: {{ .Values.controller.grpc.enableTxtServiceConfig | quote }}
+  commitserver.grpc.enable.txt.service.config: {{ .Values.commitServer.grpc.enableTxtServiceConfig | quote }}
+  applicationsetcontroller.grpc.enable.txt.service.config: {{ .Values.applicationSet.grpc.enableTxtServiceConfig | quote }}
 {{- end }}

--- a/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-repo-server/deployment.yaml
@@ -228,6 +228,12 @@ spec:
                 name: argocd-cmd-params-cm
                 key: otlp.headers
                 optional: true
+          - name: GRPC_ENABLE_TXT_SERVICE_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-cmd-params-cm
+                key: reposerver.grpc.enable.txt.service.config
+                optional: true
           - name: ARGOCD_REPO_SERVER_OTLP_ATTRS
             valueFrom:
                 configMapKeyRef:

--- a/charts/argo-cd/templates/argocd-server/deployment.yaml
+++ b/charts/argo-cd/templates/argocd-server/deployment.yaml
@@ -491,6 +491,8 @@ spec:
         env:
           - name: EXTENSIONS_DIR
             value: /tmp/extensions
+          - name: GRPC_ENABLE_TXT_SERVICE_CONFIG
+            value: "false"
           {{- with .env }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -867,6 +867,11 @@ controller:
   # -- Environment variables to pass to application controller
   env: []
 
+  # -- GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991)
+  # @default -- `false`
+  grpc:
+    enableTxtServiceConfig: false
+
   # -- envFrom to pass to application controller
   # @default -- `[]` (See [values.yaml])
   envFrom: []
@@ -3156,6 +3161,11 @@ repoServer:
   # -- Environment variables to pass to repo server
   env: []
 
+  # -- GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991)
+  # @default -- `false`
+  grpc:
+    enableTxtServiceConfig: false
+
   # -- envFrom to pass to repo server
   # @default -- `[]` (See [values.yaml])
   envFrom: []
@@ -3606,6 +3616,11 @@ applicationSet:
   extraEnv: []
     # - name: "MY_VAR"
     #   value: "value"
+
+  # -- GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991)
+  # @default -- `false`
+  grpc:
+    enableTxtServiceConfig: false
 
   # -- envFrom to pass to the ApplicationSet controller
   # @default -- `[]` (See [values.yaml])
@@ -4701,6 +4716,11 @@ commitServer:
   extraEnv: []
     # - name: "MY_VAR"
     #   value: "value"
+
+  # -- GRPC service config DNS TXT lookups, set to false to disable DNS SRV/TXT lookups for localhost and IP literals (Argo CD issue #24991)
+  # @default -- `false`
+  grpc:
+    enableTxtServiceConfig: false
 
   # -- envFrom to pass to the commit server
   # @default -- `[]` (See [values.yaml])


### PR DESCRIPTION
Problem
- repo-server health checks query `_grpc_config.localhost` DNS every ~30 seconds
- According to gRPC Proposal A10, clients should skip DNS SRV/TXT lookups for "localhost" and IP literals
- Setting `GRPC_ENABLE_TXT_SERVICE_CONFIG=false` disables this DNS TXT lookup behavior

Root cause
- Setting this environment variable in the Dockerfile fixes the issue
- The argo-helm chart did not expose this configuration option
- Therefore, Helm deployments inherit the default behavior from the container image

Fix
- Added `GRPC_ENABLE_TXT_SERVICE_CONFIG=false` as an environment variable to all relevant Argo CD components:
  - argocd-repo-server (uses ConfigMap reference to allow override)
  - argocd-application-controller (uses ConfigMap reference to allow override)
  - argocd-server (hardcoded false value for sidecar container)
  - argocd-commit-server (uses ConfigMap reference to allow override)
  - argocd-applicationset-controller (uses ConfigMap reference to allow override)
- Added new configuration section `grpc.enableTxtServiceConfig` (default: false) to each component's values.yaml
- Created ConfigMap entries in argocd-cmd-params-cm.yaml for the env var values

How tested
- Ran `./scripts/helm-docs.sh` - generated documentation successfully
- Ran `./scripts/lint.sh` - all lint checks passed for all charts
- Ran `helm template` - template renders correctly with the new env vars present
- Verified backwards compatibility - existing deployments will use default false value unless explicitly changed

Links
- gRPC Proposal A10: https://github.com/grpc/proposal/blob/master/A10-skip-dns-srv-txt-for-localhost-and-literals.md
- Argoproj argo-helm issue #3743: https://github.com/argoproj/argo-helm/issues/3743
- This change was prepared with an AI agent operated by KR-Ravindra
