### PR TITLE
fix(argo-rollouts): hash only config data in checksum/cm annotation

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.10.0
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.43.1
+version: 2.43.2
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -18,5 +18,5 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: security
-      description: Harden the dashboard container security context by default
+    - kind: fixed
+      description: Hash only the ConfigMap data in the checksum/cm annotation so a chart version bump does not restart the controller

--- a/charts/argo-rollouts/templates/_helpers.tpl
+++ b/charts/argo-rollouts/templates/_helpers.tpl
@@ -67,6 +67,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Return a sha256sum of only the `data` and `stringData` sections of a rendered
+ConfigMap/Secret template, for use in `checksum/*` pod annotations.
+
+Only the config payload is hashed - not the full manifest. The manifest's
+`metadata.labels` includes `helm.sh/chart`, which changes on every chart
+version bump, so hashing the whole manifest would roll the pods on every
+release even when the configuration is unchanged.
+
+Usage:
+  checksum/cm: {{ include "argo-rollouts.config.checksum" (dict "context" $ "path" "/controller/configmap.yaml") }}
+*/}}
+{{- define "argo-rollouts.config.checksum" -}}
+{{- $rendered := include (print .context.Template.BasePath .path) .context | fromYaml -}}
+{{- $data := merge (dict) (dig "data" dict $rendered) (dig "stringData" dict $rendered) -}}
+{{- $data | toYaml | sha256sum -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "argo-rollouts.serviceAccountName" -}}

--- a/charts/argo-rollouts/templates/controller/deployment.yaml
+++ b/charts/argo-rollouts/templates/controller/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        checksum/cm: {{ include (print $.Template.BasePath "/controller/configmap.yaml") . | sha256sum }}
+        checksum/cm: {{ include "argo-rollouts.config.checksum" (dict "context" $ "path" "/controller/configmap.yaml") }}
       labels:
         {{- include "argo-rollouts.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Values.controller.component }}


### PR DESCRIPTION
Ports the argo-cd fix from #4044 to argo-rollouts.

`checksum/cm` hashed the entire rendered ConfigMap, whose `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so the controller was rolled on every upgrade even when no configuration had changed. The `argo-rollouts.config.checksum` helper hashes only the `data`/`stringData` sections instead.

Rendered `2.43.1` against a bumped version with the same values: the checksum is unchanged after this PR and differs before it. Changing `controller.trafficRouterPlugins` still changes it. Upgrading to this version rolls the controller once as the annotation value changes.

`argo-workflows`, `argo-events` and `argocd-image-updater` have the same pattern — happy to follow up with separate PRs.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [x] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [x] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [x] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).